### PR TITLE
Push stable images to dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM alpine:3.7
+FROM scratch
 COPY aws/ /aws
 WORKDIR /aws

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -43,9 +43,10 @@ steps:
         all:
           executeForBranch: "'${{SEMVERSION_BRANCH}}' != ''"
 
-  push_image_tag:
+  push_image_tag_to_cfcr:
     title: Push image with tag based semver tags
     type: push
+    registry: cfcr
     candidate: ${{build_image}}
     tag: "${{SEMVERSION_TAG}}"
     when:
@@ -53,9 +54,33 @@ steps:
         all:
           executeForTag: "'${{SEMVERSION_TAG}}' != ''"
 
-  push_image_latest:
+  push_image_tag_to_dockerhub:
+    title: Push image with tag based semver tags
+    type: push
+    registry: dockerhub
+    candidate: ${{build_image}}
+    tag: "${{SEMVERSION_TAG}}"
+    when:
+      condition:
+        all:
+          executeForTag: "'${{SEMVERSION_TAG}}' != ''"
+
+
+  push_image_latest_to_cfcf:
     title: Push image with latest tag
     type: push
+    registry: cfcr
+    candidate: ${{build_image}}
+    tag: latest
+    when:
+      condition:
+        all:
+          executeForMasterBranch: "'${{CF_BRANCH}}' == 'master'"
+
+  push_image_latest_to_dockerhub:
+    title: Push image with latest tag
+    type: push
+    registry: dockerhub
     candidate: ${{build_image}}
     tag: latest
     when:


### PR DESCRIPTION
## what
* Publish images to Docker Hub
* Use scratch image

## why
* simplify documentation to allow others to include our public root modules in their geodesic modules

