### PR TITLE
Push to `cloudposse` Registry

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -58,6 +58,7 @@ steps:
     title: Push image with tag based semver tags
     type: push
     registry: dockerhub
+    image_name: cloudposse/terraform-root-modules
     candidate: ${{build_image}}
     tag: "${{SEMVERSION_TAG}}"
     when:
@@ -81,6 +82,7 @@ steps:
     title: Push image with latest tag
     type: push
     registry: dockerhub
+    image_name: cloudposse/terraform-root-modules
     candidate: ${{build_image}}
     tag: latest
     when:


### PR DESCRIPTION
## what
* Push to `cloudposse/terraform-root-modules`

## why
* Without specifying `image_name` it defaults to `library` which is owned by docker.