### PR TITLE
Update external-dns.tf

### DIFF
--- a/aws/kops-aws-platform/external-dns.tf
+++ b/aws/kops-aws-platform/external-dns.tf
@@ -1,5 +1,5 @@
 module "kops_external_dns" {
-  source       = "git::https://github.com/cloudposse/terraform-aws-kops-external-dns.git?ref=tags/0.1.1"
+  source       = "git::https://github.com/cloudposse/terraform-aws-kops-external-dns.git?ref=tags/0.1.2"
   namespace    = "${module.identity.namespace}"
   stage        = "${module.identity.stage}"
   name         = "external-dns"


### PR DESCRIPTION
## What
* Bump use new version of https://github.com/cloudposse/terraform-aws-kops-external-dns/pull/3

## Why
* To assume roles on nodes 