### PR TITLE
Add `parent-testing-ns`

### DIFF
--- a/aws/root-dns/parent-testing-ns.tf
+++ b/aws/root-dns/parent-testing-ns.tf
@@ -1,0 +1,11 @@
+variable "testing_name_servers" {
+  type = "list"
+}
+
+resource "aws_route53_record" "testing_dns_zone_ns" {
+  zone_id = "${aws_route53_zone.parent_dns_zone.zone_id}"
+  name    = "testing"
+  type    = "NS"
+  ttl     = "30"
+  records = ["${var.testing_name_servers}"]
+}

--- a/aws/root-dns/terraform.tfvars.example
+++ b/aws/root-dns/terraform.tfvars.example
@@ -1,7 +1,8 @@
 parent_domain_name="cloudposse.co"
 domain_name="root.cloudposse.co"
-prod_name_servers = ["", "", "", "",]
-staging_name_servers = ["", "", "", "",]
-audit_name_servers = ["", "", "", "",]
-dev_name_servers = ["", "", "", "",]
-local_name_servers = ["", "", "", "",]
+prod_name_servers = ["", "", "", ""]
+staging_name_servers = ["", "", "", ""]
+audit_name_servers = ["", "", "", ""]
+dev_name_servers = ["", "", "", ""]
+local_name_servers = ["", "", "", ""]
+testing_name_servers = ["", "", "", ""]


### PR DESCRIPTION
## what
* Add `parent-testing-ns`

## why
* To provision Name Servers in the parent DNS zone for the testing DNZ zone (zone delegation)
