### PR TITLE
Grant premissions for app secrets group

### DIFF
--- a/aws/chamber/main.tf
+++ b/aws/chamber/main.tf
@@ -30,7 +30,7 @@ variable "account_id" {
 
 variable "parameter_groups" {
   type        = "list"
-  description = "Paramter groups names"
+  description = "Parameter group names"
   default     = ["kops", "app"]
 }
 

--- a/aws/chamber/main.tf
+++ b/aws/chamber/main.tf
@@ -28,6 +28,12 @@ variable "account_id" {
   description = "AWS account ID"
 }
 
+variable "parameter_groups" {
+  type        = "string"
+  description = "Comma separated name of paramter groups"
+  default     = "kops, app"
+}
+
 provider "aws" {
   assume_role {
     role_arn = "${var.aws_assume_role_arn}"

--- a/aws/chamber/main.tf
+++ b/aws/chamber/main.tf
@@ -29,9 +29,9 @@ variable "account_id" {
 }
 
 variable "parameter_groups" {
-  type        = "string"
-  description = "Comma separated name of paramter groups"
-  default     = "kops, app"
+  type        = "list"
+  description = "Paramter groups names"
+  default     = ["kops", "app"]
 }
 
 provider "aws" {

--- a/aws/chamber/user.tf
+++ b/aws/chamber/user.tf
@@ -1,15 +1,15 @@
 # Chamber user for CI/CD systems that cannot leverage IAM instance profiles
 # https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-access.html
 module "chamber_user" {
-  source        = "git::https://github.com/cloudposse/terraform-aws-iam-chamber-user.git?ref=tags/0.1.4"
-  namespace     = "${var.namespace}"
-  stage         = "${var.stage}"
-  name          = "chamber"
-  attributes    = ["codefresh"]
-  kms_key_arn   = "${module.chamber_kms_key.key_arn}"
+  source      = "git::https://github.com/cloudposse/terraform-aws-iam-chamber-user.git?ref=tags/0.1.4"
+  namespace   = "${var.namespace}"
+  stage       = "${var.stage}"
+  name        = "chamber"
+  attributes  = ["codefresh"]
+  kms_key_arn = "${module.chamber_kms_key.key_arn}"
+
   ssm_resources = [
-    "${format("arn:aws:ssm:%s:%s:parameter/kops/*", var.region, var.account_id)}",
-    "${format("arn:aws:ssm:%s:%s:parameter/app/*", var.region, var.account_id)}"
+    "${formatlist("arn:aws:ssm:%s:%s:parameter/%s/*", var.region, var.account_id, split(",", replace(var.parameter_groups, " ", "")))}",
   ]
 }
 

--- a/aws/chamber/user.tf
+++ b/aws/chamber/user.tf
@@ -7,7 +7,10 @@ module "chamber_user" {
   name          = "chamber"
   attributes    = ["codefresh"]
   kms_key_arn   = "${module.chamber_kms_key.key_arn}"
-  ssm_resources = ["${format("arn:aws:ssm:%s:%s:parameter/kops/*", var.region, var.account_id)}"]
+  ssm_resources = [
+    "${format("arn:aws:ssm:%s:%s:parameter/kops/*", var.region, var.account_id)}",
+    "${format("arn:aws:ssm:%s:%s:parameter/app/*", var.region, var.account_id)}"
+  ]
 }
 
 output "chamber_user_name" {

--- a/aws/chamber/user.tf
+++ b/aws/chamber/user.tf
@@ -1,7 +1,7 @@
 # Chamber user for CI/CD systems that cannot leverage IAM instance profiles
 # https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-access.html
 module "chamber_user" {
-  source      = "git::https://github.com/cloudposse/terraform-aws-iam-chamber-user.git?ref=tags/0.1.4"
+  source      = "git::https://github.com/cloudposse/terraform-aws-iam-chamber-user.git?ref=tags/0.1.5"
   namespace   = "${var.namespace}"
   stage       = "${var.stage}"
   name        = "chamber"

--- a/aws/chamber/user.tf
+++ b/aws/chamber/user.tf
@@ -9,7 +9,7 @@ module "chamber_user" {
   kms_key_arn = "${module.chamber_kms_key.key_arn}"
 
   ssm_resources = [
-    "${formatlist("arn:aws:ssm:%s:%s:parameter/%s/*", var.region, var.account_id, split(",", replace(var.parameter_groups, " ", "")))}",
+    "${formatlist("arn:aws:ssm:%s:%s:parameter/%s/*", var.region, var.account_id, var.parameter_groups)}",
   ]
 }
 


### PR DESCRIPTION
## What
* Grant chamber permissions for `app` secrets group

## Why
* We use pattern `chamber exec kops app` so need access to both