### PR TITLE
Feature fix chart repo

### DIFF
--- a/aws/kops-aws-platform/chart-repo.tf
+++ b/aws/kops-aws-platform/chart-repo.tf
@@ -1,9 +1,10 @@
 module "kops_chart_repo" {
-  source       = "git::https://github.com/cloudposse/terraform-aws-kops-chart-repo.git?ref=tags/0.1.1"
-  namespace    = "${var.namespace}"
-  stage        = "${var.stage}"
-  name         = "chart-repo"
-  cluster_name = "${var.region}.${var.zone_name}"
+  source          = "git::https://github.com/cloudposse/terraform-aws-kops-chart-repo.git?ref=tags/0.2.2"
+  namespace       = "${var.namespace}"
+  stage           = "${var.stage}"
+  name            = "chart-repo"
+  cluster_name    = "${var.region}.${var.zone_name}"
+  permitted_nodes = "${var.permitted_nodes}"
 
   tags = {
     Cluster = "${var.region}.${var.zone_name}"

--- a/aws/kops-aws-platform/main.tf
+++ b/aws/kops-aws-platform/main.tf
@@ -28,6 +28,12 @@ variable "zone_name" {
   description = "DNS zone name"
 }
 
+variable "permitted_nodes" {
+  type        = "string"
+  description = "Kops kubernetes nodes that are permitted to assume the role (e.g. 'nodes', 'masters', or 'both')"
+  default     = "masters"
+}
+
 provider "aws" {
   assume_role {
     role_arn = "${var.aws_assume_role_arn}"

--- a/aws/kops-aws-platform/main.tf
+++ b/aws/kops-aws-platform/main.tf
@@ -31,7 +31,7 @@ variable "zone_name" {
 variable "permitted_nodes" {
   type        = "string"
   description = "Kops kubernetes nodes that are permitted to assume the role (e.g. 'nodes', 'masters', or 'both')"
-  default     = "masters"
+  default     = "both"
 }
 
 provider "aws" {


### PR DESCRIPTION
## What
* Make configurable what servers can assume role `masters`, `nodes` or `both`

## Why
* For `kiam` we need just `masters`, for `kube2iam` just `nodes`