### PR TITLE
Add `allowed_cidr_blocks` to `aurora-mysql` to make it publicly accessible

### DIFF
--- a/aws/backing-services/aurora-mysql.tf
+++ b/aws/backing-services/aurora-mysql.tf
@@ -45,6 +45,12 @@ variable "MYSQL_CLUSTER_PUBLICLY_ACCESSIBLE" {
   description = "Specifies the accessibility options for the DB instance. A value of true specifies an Internet-facing instance with a publicly resolvable DNS name, which resolves to a public IP address. A value of false specifies an internal instance with a DNS name that resolves to a private IP address"
 }
 
+variable "MYSQL_CLUSTER_ALLOWED_CIDR_BLOCKS" {
+  type        = "list"
+  default     = ["0.0.0.0/0"]
+  description = "List of CIDR blocks allowed to access the cluster"
+}
+
 module "aurora_mysql" {
   source              = "git::https://github.com/cloudposse/terraform-aws-rds-cluster.git?ref=tags/0.7.0"
   namespace           = "${var.namespace}"
@@ -63,6 +69,7 @@ module "aurora_mysql" {
   zone_id             = "${var.zone_id}"
   enabled             = "${var.MYSQL_CLUSTER_ENABLED}"
   publicly_accessible = "${var.MYSQL_CLUSTER_PUBLICLY_ACCESSIBLE}"
+  allowed_cidr_blocks = "${var.MYSQL_CLUSTER_ALLOWED_CIDR_BLOCKS}"
 }
 
 output "aurora_mysql_database_name" {


### PR DESCRIPTION
## what
* Add `allowed_cidr_blocks` to `aurora-mysql`

## why
* To make it publicly accessible

## notes
For an Aurora cluster to be publicly accessible, the following three conditions must be met:

1. `publicly_accessible` flag must be set to `true`, in which case the RDS instances will be assigned a public IP address and the internal DNS will be pointed to it (otherwise it will be assigned a private IP address)

2. The instances must be placed into public subnets (with an Internet Gateway), so they could be reached from the Internet

3. The Security Group must have ingress rules to allow connection from an external IP address, CIDR blocks, or other security groups. To allow public access from any IP, use `"0.0.0.0/0"` as allowed CIDR blocks
 