### PR TITLE
Use remote state for nameservers

### DIFF
--- a/aws/accounts/audit.tf
+++ b/aws/accounts/audit.tf
@@ -19,3 +19,11 @@ resource "aws_organizations_account" "audit" {
 output "audit_account_arn" {
   value = "${aws_organizations_account.audit.arn}"
 }
+
+output "audit_account_id" {
+  value = "${aws_organizations_account.audit.id}"
+}
+
+output "audit_organization_account_access_role" {
+  value = "arn:aws:iam::${aws_organizations_account.audit.id}:role/OrganizationAccountAccessRole"
+}

--- a/aws/accounts/dev.tf
+++ b/aws/accounts/dev.tf
@@ -19,3 +19,11 @@ resource "aws_organizations_account" "dev" {
 output "dev_account_arn" {
   value = "${aws_organizations_account.dev.arn}"
 }
+
+output "dev_account_id" {
+  value = "${aws_organizations_account.dev.id}"
+}
+
+output "dev_organization_account_access_role" {
+  value = "arn:aws:iam::${aws_organizations_account.dev.id}:role/OrganizationAccountAccessRole"
+}

--- a/aws/accounts/prod.tf
+++ b/aws/accounts/prod.tf
@@ -19,3 +19,11 @@ resource "aws_organizations_account" "prod" {
 output "prod_account_arn" {
   value = "${aws_organizations_account.prod.arn}"
 }
+
+output "prod_account_id" {
+  value = "${aws_organizations_account.prod.id}"
+}
+
+output "prod_organization_account_access_role" {
+  value = "arn:aws:iam::${aws_organizations_account.prod.id}:role/OrganizationAccountAccessRole"
+}

--- a/aws/accounts/staging.tf
+++ b/aws/accounts/staging.tf
@@ -19,3 +19,11 @@ resource "aws_organizations_account" "staging" {
 output "staging_account_arn" {
   value = "${aws_organizations_account.staging.arn}"
 }
+
+output "staging_account_id" {
+  value = "${aws_organizations_account.staging.id}"
+}
+
+output "staging_organization_account_access_role" {
+  value = "arn:aws:iam::${aws_organizations_account.staging.id}:role/OrganizationAccountAccessRole"
+}

--- a/aws/accounts/testing.tf
+++ b/aws/accounts/testing.tf
@@ -19,3 +19,11 @@ resource "aws_organizations_account" "testing" {
 output "testing_account_arn" {
   value = "${aws_organizations_account.testing.arn}"
 }
+
+output "testing_account_id" {
+  value = "${aws_organizations_account.testing.id}"
+}
+
+output "testing_organization_account_access_role" {
+  value = "arn:aws:iam::${aws_organizations_account.testing.id}:role/OrganizationAccountAccessRole"
+}

--- a/aws/root-dns/main.tf
+++ b/aws/root-dns/main.tf
@@ -8,8 +8,21 @@ variable "aws_assume_role_arn" {
   type = "string"
 }
 
+variable "namespace" {
+}
+
 provider "aws" {
   assume_role {
     role_arn = "${var.aws_assume_role_arn}"
   }
 }
+
+data "terraform_remote_state" "root" {
+  backend = "s3"
+  config {
+    bucket = "${var.namespace}-root-terraform-state"
+    key    = "accounts/terraform.tfstate"
+  }
+}
+
+

--- a/aws/root-dns/ns/main.tf
+++ b/aws/root-dns/ns/main.tf
@@ -1,0 +1,34 @@
+module "label" {
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  delimiter  = "${var.delimiter}"
+  attributes = "${var.attributes}"
+  tags       = "${var.tags}"
+}
+
+data "terraform_remote_state" "stage" {
+  backend = "s3"
+
+  # This assumes stage is using a `terraform-aws-tfstate-backend`
+  #   https://github.com/cloudposse/terraform-aws-tfstate-backend
+  config {
+    role_arn = "${var.role_arn}"
+    bucket   = "${module.label.id}"
+    key      = "${var.key}"
+  }
+}
+
+locals {
+  name_servers = "${data.terraform_remote_state.stage.name_servers}"
+}
+
+resource "aws_route53_record" "dns_zone_ns" {
+  count   = "${signum(length(local.name_servers))}"
+  zone_id = "${var.zone_id}"
+  name    = "${var.stage}"
+  type    = "NS"
+  ttl     = "${var.ttl}"
+  records = ["${local.name_servers}"]
+}

--- a/aws/root-dns/ns/outputs.tf
+++ b/aws/root-dns/ns/outputs.tf
@@ -1,0 +1,9 @@
+output "stage" {
+  description = "Name of the subaccount corresponding to the name servers"
+  value       = "${var.stage}"
+}
+
+output "name_servers" {
+  description = "Name servers for the account's delegated DNS zone"
+  value       = "${local.name_servers}"
+}

--- a/aws/root-dns/ns/variables.tf
+++ b/aws/root-dns/ns/variables.tf
@@ -1,0 +1,50 @@
+variable "namespace" {
+  type        = "string"
+  description = "Namespace (e.g. `eg` or `example`)"
+}
+
+variable "stage" {
+  type        = "string"
+  description = "Stage (e.g. `prod`, `dev`, `staging`)"
+}
+
+variable "name" {
+  type        = "string"
+  default     = "terraform"
+  description = "Name  (e.g. `app` or `cluster`)"
+}
+
+variable "delimiter" {
+  type        = "string"
+  default     = "-"
+  description = "Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`"
+}
+
+variable "attributes" {
+  type        = "list"
+  default     = ["state"]
+  description = "Additional attributes (e.g. `state`)"
+}
+
+variable "tags" {
+  type        = "map"
+  default     = {}
+  description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
+}
+
+variable "role_arn" {
+  description = "The role to be assumed in the subaccount"
+}
+
+variable "zone_id" {
+  description = "DNS zone to update"
+}
+
+variable "ttl" {
+  description = "Default TTL for the NS records"
+  default     = "30"
+}
+
+variable "key" {
+  default = "account-dns/terraform.tfstate"
+}

--- a/aws/root-dns/parent-audit-ns.tf
+++ b/aws/root-dns/parent-audit-ns.tf
@@ -1,12 +1,11 @@
-variable "audit_name_servers" {
-  type = "list"
+module "audit" {
+  source = "ns"
+  role_arn = "${data.terraform_remote_state.root.audit_organization_account_access_role}"
+  namespace = "${var.namespace}"
+  stage = "audit"
+  zone_id = "${aws_route53_zone.parent_dns_zone.zone_id}"
 }
 
-resource "aws_route53_record" "audit_dns_zone_ns" {
-  count   = "${signum(length(var.audit_name_servers))}"
-  zone_id = "${aws_route53_zone.parent_dns_zone.zone_id}"
-  name    = "audit"
-  type    = "NS"
-  ttl     = "30"
-  records = ["${var.audit_name_servers}"]
+output "audit_name_servers" {
+  value = "${module.audit.name_servers}"
 }

--- a/aws/root-dns/parent-dev-ns.tf
+++ b/aws/root-dns/parent-dev-ns.tf
@@ -1,12 +1,11 @@
-variable "dev_name_servers" {
-  type = "list"
+module "dev" {
+  source = "ns"
+  role_arn = "${data.terraform_remote_state.root.dev_organization_account_access_role}"
+  namespace = "${var.namespace}"
+  stage = "dev"
+  zone_id = "${aws_route53_zone.parent_dns_zone.zone_id}"
 }
 
-resource "aws_route53_record" "dev_dns_zone_ns" {
-  count   = "${signum(length(var.dev_name_servers))}"
-  zone_id = "${aws_route53_zone.parent_dns_zone.zone_id}"
-  name    = "dev"
-  type    = "NS"
-  ttl     = "30"
-  records = ["${var.dev_name_servers}"]
+output "dev_name_servers" {
+  value = "${module.dev.name_servers}"
 }

--- a/aws/root-dns/parent-local-ns.tf
+++ b/aws/root-dns/parent-local-ns.tf
@@ -1,12 +1,15 @@
-variable "local_name_servers" {
-  type = "list"
-}
-
-resource "aws_route53_record" "local_dns_zone_ns" {
-  count   = "${signum(length(var.local_name_servers))}"
+resource "aws_route53_record" "local_dns_name" {
   zone_id = "${aws_route53_zone.parent_dns_zone.zone_id}"
   name    = "local"
-  type    = "NS"
+  type    = "A"
   ttl     = "30"
-  records = ["${var.local_name_servers}"]
+  records = ["127.0.0.1"]
+}
+
+resource "aws_route53_record" "local_dns_wildcard" {
+  zone_id = "${aws_route53_zone.parent_dns_zone.zone_id}"
+  name    = "*.local"
+  type    = "A"
+  ttl     = "30"
+  records = ["127.0.0.1"]
 }

--- a/aws/root-dns/parent-prod-ns.tf
+++ b/aws/root-dns/parent-prod-ns.tf
@@ -1,12 +1,11 @@
-variable "prod_name_servers" {
-  type = "list"
+module "prod" {
+  source = "ns"
+  role_arn = "${data.terraform_remote_state.root.prod_organization_account_access_role}"
+  namespace = "${var.namespace}"
+  stage = "prod"
+  zone_id = "${aws_route53_zone.parent_dns_zone.zone_id}"
 }
 
-resource "aws_route53_record" "prod_dns_zone_ns" {
-  count   = "${signum(length(var.prod_name_servers))}"
-  zone_id = "${aws_route53_zone.parent_dns_zone.zone_id}"
-  name    = "prod"
-  type    = "NS"
-  ttl     = "30"
-  records = ["${var.prod_name_servers}"]
+output "prod_name_servers" {
+  value = "${module.prod.name_servers}"
 }

--- a/aws/root-dns/parent-staging-ns.tf
+++ b/aws/root-dns/parent-staging-ns.tf
@@ -1,12 +1,11 @@
-variable "staging_name_servers" {
-  type = "list"
+module "staging" {
+  source = "ns"
+  role_arn = "${data.terraform_remote_state.root.staging_organization_account_access_role}"
+  namespace = "${var.namespace}"
+  stage = "staging"
+  zone_id = "${aws_route53_zone.parent_dns_zone.zone_id}"
 }
 
-resource "aws_route53_record" "staging_dns_zone_ns" {
-  count   = "${signum(length(var.staging_name_servers))}"
-  zone_id = "${aws_route53_zone.parent_dns_zone.zone_id}"
-  name    = "staging"
-  type    = "NS"
-  ttl     = "30"
-  records = ["${var.staging_name_servers}"]
+output "staging_name_servers" {
+  value = "${module.staging.name_servers}"
 }

--- a/aws/root-dns/parent-testing-ns.tf
+++ b/aws/root-dns/parent-testing-ns.tf
@@ -1,12 +1,11 @@
-variable "testing_name_servers" {
-  type = "list"
+module "testing" {
+  source = "ns"
+  role_arn = "${data.terraform_remote_state.root.testing_organization_account_access_role}"
+  namespace = "${var.namespace}"
+  stage = "testing"
+  zone_id = "${aws_route53_zone.parent_dns_zone.zone_id}"
 }
 
-resource "aws_route53_record" "testing_dns_zone_ns" {
-  count   = "${signum(length(var.testing_name_servers))}"
-  zone_id = "${aws_route53_zone.parent_dns_zone.zone_id}"
-  name    = "testing"
-  type    = "NS"
-  ttl     = "30"
-  records = ["${var.testing_name_servers}"]
+output "testing_name_servers" {
+  value = "${module.testing.name_servers}"
 }


### PR DESCRIPTION
## what
* Use remote state and organizational account roles to obtain name servers for subaccount
* Define a local module to reduce repetition

## why
* *Radically* simplify the cold-start problem as it relates to DNS by eliminating the need to set environment variables for subaccounts
* Setting these environment variables in the `Dockerfile` was like playing the [Towers of Hanoi](https://en.wikipedia.org/wiki/Tower_of_Hanoi)