### PR TITLE
[accounts] Enforce consistent email convention and add new accounts

### DIFF
--- a/aws/accounts/audit.auto.tfvars.example
+++ b/aws/accounts/audit.auto.tfvars.example
@@ -1,2 +1,0 @@
-audit_account_name="audit"
-audit_account_email="info+audit@cloudposse.co"

--- a/aws/accounts/audit.tf
+++ b/aws/accounts/audit.tf
@@ -1,29 +1,19 @@
-variable "audit_account_name" {
-  type        = "string"
-  description = "Audit account name"
-  default     = "audit"
-}
-
-variable "audit_account_email" {
-  type        = "string"
-  description = "Audit account email"
-}
-
 resource "aws_organizations_account" "audit" {
-  name                       = "${var.audit_account_name}"
-  email                      = "${var.audit_account_email}"
+  count                      = "${contains(var.accounts_enabled, "audit") == true ? 1 : 0}"
+  name                       = "audit"
+  email                      = "${format(var.account_email, "audit")}"
   iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
   role_name                  = "${var.account_role_name}"
 }
 
 output "audit_account_arn" {
-  value = "${aws_organizations_account.audit.arn}"
+  value = "${join("", aws_organizations_account.audit.*.arn)}"
 }
 
 output "audit_account_id" {
-  value = "${aws_organizations_account.audit.id}"
+  value = "${join("", aws_organizations_account.audit.*.id)}"
 }
 
 output "audit_organization_account_access_role" {
-  value = "arn:aws:iam::${aws_organizations_account.audit.id}:role/OrganizationAccountAccessRole"
+  value = "arn:aws:iam::${join("", aws_organizations_account.audit.id)}:role/OrganizationAccountAccessRole"
 }

--- a/aws/accounts/audit.tf
+++ b/aws/accounts/audit.tf
@@ -15,5 +15,5 @@ output "audit_account_id" {
 }
 
 output "audit_organization_account_access_role" {
-  value = "arn:aws:iam::${join("", aws_organizations_account.audit.id)}:role/OrganizationAccountAccessRole"
+  value = "arn:aws:iam::${join("", aws_organizations_account.audit.*.id)}:role/OrganizationAccountAccessRole"
 }

--- a/aws/accounts/corp.tf
+++ b/aws/accounts/corp.tf
@@ -1,0 +1,19 @@
+resource "aws_organizations_account" "corp" {
+  count                      = "${contains(var.accounts_enabled, "corp") == true ? 1 : 0}"
+  name                       = "corp"
+  email                      = "${format(var.account_email, "corp")}"
+  iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
+  role_name                  = "${var.account_role_name}"
+}
+
+output "corp_account_arn" {
+  value = "${join("", aws_organizations_account.corp.*.arn)}"
+}
+
+output "corp_account_id" {
+  value = "${join("", aws_organizations_account.corp.*.id)}"
+}
+
+output "corp_organization_account_access_role" {
+  value = "arn:aws:iam::${join("", aws_organizations_account.corp.*.id)}:role/OrganizationAccountAccessRole"
+}

--- a/aws/accounts/data.tf
+++ b/aws/accounts/data.tf
@@ -1,0 +1,19 @@
+resource "aws_organizations_account" "data" {
+  count                      = "${contains(var.accounts_enabled, "data") == true ? 1 : 0}"
+  name                       = "data"
+  email                      = "${format(var.account_email, "data")}"
+  iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
+  role_name                  = "${var.account_role_name}"
+}
+
+output "data_account_arn" {
+  value = "${join("", aws_organizations_account.data.*.arn)}"
+}
+
+output "data_account_id" {
+  value = "${join("", aws_organizations_account.data.*.id)}"
+}
+
+output "data_organization_account_access_role" {
+  value = "arn:aws:iam::${join("", aws_organizations_account.data.*.id)}:role/OrganizationAccountAccessRole"
+}

--- a/aws/accounts/dev.auto.tfvars.example
+++ b/aws/accounts/dev.auto.tfvars.example
@@ -1,2 +1,0 @@
-dev_account_name="dev"
-dev_account_email="info+dev@cloudposse.co"

--- a/aws/accounts/dev.tf
+++ b/aws/accounts/dev.tf
@@ -1,29 +1,19 @@
-variable "dev_account_name" {
-  type        = "string"
-  description = "Dev account name"
-  default     = "dev"
-}
-
-variable "dev_account_email" {
-  type        = "string"
-  description = "Dev account email"
-}
-
 resource "aws_organizations_account" "dev" {
-  name                       = "${var.dev_account_name}"
-  email                      = "${var.dev_account_email}"
+  count                      = "${contains(var.accounts_enabled, "dev") == true ? 1 : 0}"
+  name                       = "dev"
+  email                      = "${format(var.account_email, "dev")}"
   iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
   role_name                  = "${var.account_role_name}"
 }
 
 output "dev_account_arn" {
-  value = "${aws_organizations_account.dev.arn}"
+  value = "${join("", aws_organizations_account.dev.*.arn)}"
 }
 
 output "dev_account_id" {
-  value = "${aws_organizations_account.dev.id}"
+  value = "${join("", aws_organizations_account.dev.*.id)}"
 }
 
 output "dev_organization_account_access_role" {
-  value = "arn:aws:iam::${aws_organizations_account.dev.id}:role/OrganizationAccountAccessRole"
+  value = "arn:aws:iam::${join("", aws_organizations_account.dev.id)}:role/OrganizationAccountAccessRole"
 }

--- a/aws/accounts/dev.tf
+++ b/aws/accounts/dev.tf
@@ -15,5 +15,5 @@ output "dev_account_id" {
 }
 
 output "dev_organization_account_access_role" {
-  value = "arn:aws:iam::${join("", aws_organizations_account.dev.id)}:role/OrganizationAccountAccessRole"
+  value = "arn:aws:iam::${join("", aws_organizations_account.dev.*.id)}:role/OrganizationAccountAccessRole"
 }

--- a/aws/accounts/identity.tf
+++ b/aws/accounts/identity.tf
@@ -1,0 +1,19 @@
+resource "aws_organizations_account" "identity" {
+  count                      = "${contains(var.accounts_enabled, "identity") == true ? 1 : 0}"
+  name                       = "identity"
+  email                      = "${format(var.account_email, "identity")}"
+  iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
+  role_name                  = "${var.account_role_name}"
+}
+
+output "identity_account_arn" {
+  value = "${join("", aws_organizations_account.identity.*.arn)}"
+}
+
+output "identity_account_id" {
+  value = "${join("", aws_organizations_account.identity.*.id)}"
+}
+
+output "identity_organization_account_access_role" {
+  value = "arn:aws:iam::${join("", aws_organizations_account.identity.*.id)}:role/OrganizationAccountAccessRole"
+}

--- a/aws/accounts/main.tf
+++ b/aws/accounts/main.tf
@@ -14,10 +14,21 @@ variable "account_role_name" {
   default     = "OrganizationAccountAccessRole"
 }
 
+variable "account_email" {
+  type        = "string"
+  description = "Email address format for accounts (e.g. `%s@cloudposse.co`)"
+}
+
 variable "account_iam_user_access_to_billing" {
   type        = "string"
   description = "If set to `ALLOW`, the new account enables IAM users to access account billing information if they have the required permissions. If set to `DENY`, then only the root user of the new account can access account billing information"
   default     = "DENY"
+}
+
+variable "accounts_enabled" {
+  type        = "list"
+  description = "Accounts to enable"
+  default     = ["dev", "staging", "prod", "testing", "audit"]
 }
 
 provider "aws" {

--- a/aws/accounts/prod.auto.tfvars.example
+++ b/aws/accounts/prod.auto.tfvars.example
@@ -1,2 +1,0 @@
-prod_account_name="prod"
-prod_account_email="info+prod@cloudposse.co"

--- a/aws/accounts/prod.tf
+++ b/aws/accounts/prod.tf
@@ -15,5 +15,5 @@ output "prod_account_id" {
 }
 
 output "prod_organization_account_access_role" {
-  value = "arn:aws:iam::${join("", aws_organizations_account.prod.id)}:role/OrganizationAccountAccessRole"
+  value = "arn:aws:iam::${join("", aws_organizations_account.prod.*.id)}:role/OrganizationAccountAccessRole"
 }

--- a/aws/accounts/prod.tf
+++ b/aws/accounts/prod.tf
@@ -1,29 +1,19 @@
-variable "prod_account_name" {
-  type        = "string"
-  description = "Production account name"
-  default     = "prod"
-}
-
-variable "prod_account_email" {
-  type        = "string"
-  description = "Production account email"
-}
-
 resource "aws_organizations_account" "prod" {
-  name                       = "${var.prod_account_name}"
-  email                      = "${var.prod_account_email}"
+  count                      = "${contains(var.accounts_enabled, "prod") == true ? 1 : 0}"
+  name                       = "prod"
+  email                      = "${format(var.account_email, "prod")}"
   iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
   role_name                  = "${var.account_role_name}"
 }
 
 output "prod_account_arn" {
-  value = "${aws_organizations_account.prod.arn}"
+  value = "${join("", aws_organizations_account.prod.*.arn)}"
 }
 
 output "prod_account_id" {
-  value = "${aws_organizations_account.prod.id}"
+  value = "${join("", aws_organizations_account.prod.*.id)}"
 }
 
 output "prod_organization_account_access_role" {
-  value = "arn:aws:iam::${aws_organizations_account.prod.id}:role/OrganizationAccountAccessRole"
+  value = "arn:aws:iam::${join("", aws_organizations_account.prod.id)}:role/OrganizationAccountAccessRole"
 }

--- a/aws/accounts/security.tf
+++ b/aws/accounts/security.tf
@@ -1,0 +1,19 @@
+resource "aws_organizations_account" "security" {
+  count                      = "${contains(var.accounts_enabled, "security") == true ? 1 : 0}"
+  name                       = "security"
+  email                      = "${format(var.account_email, "security")}"
+  iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
+  role_name                  = "${var.account_role_name}"
+}
+
+output "security_account_arn" {
+  value = "${join("", aws_organizations_account.security.*.arn)}"
+}
+
+output "security_account_id" {
+  value = "${join("", aws_organizations_account.security.*.id)}"
+}
+
+output "security_organization_account_access_role" {
+  value = "arn:aws:iam::${join("", aws_organizations_account.security.*.id)}:role/OrganizationAccountAccessRole"
+}

--- a/aws/accounts/staging.auto.tfvars.example
+++ b/aws/accounts/staging.auto.tfvars.example
@@ -1,2 +1,0 @@
-staging_account_name="staging"
-staging_account_email="info+staging@cloudposse.co"

--- a/aws/accounts/staging.tf
+++ b/aws/accounts/staging.tf
@@ -15,5 +15,5 @@ output "staging_account_id" {
 }
 
 output "staging_organization_account_access_role" {
-  value = "arn:aws:iam::${join("", aws_organizations_account.staging.id)}:role/OrganizationAccountAccessRole"
+  value = "arn:aws:iam::${join("", aws_organizations_account.staging.*.id)}:role/OrganizationAccountAccessRole"
 }

--- a/aws/accounts/staging.tf
+++ b/aws/accounts/staging.tf
@@ -1,29 +1,19 @@
-variable "staging_account_name" {
-  type        = "string"
-  description = "Staging account name"
-  default     = "staging"
-}
-
-variable "staging_account_email" {
-  type        = "string"
-  description = "Staging account email"
-}
-
 resource "aws_organizations_account" "staging" {
-  name                       = "${var.staging_account_name}"
-  email                      = "${var.staging_account_email}"
+  count                      = "${contains(var.accounts_enabled, "staging") == true ? 1 : 0}"
+  name                       = "staging"
+  email                      = "${format(var.account_email, "staging")}"
   iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
   role_name                  = "${var.account_role_name}"
 }
 
 output "staging_account_arn" {
-  value = "${aws_organizations_account.staging.arn}"
+  value = "${join("", aws_organizations_account.staging.*.arn)}"
 }
 
 output "staging_account_id" {
-  value = "${aws_organizations_account.staging.id}"
+  value = "${join("", aws_organizations_account.staging.*.id)}"
 }
 
 output "staging_organization_account_access_role" {
-  value = "arn:aws:iam::${aws_organizations_account.staging.id}:role/OrganizationAccountAccessRole"
+  value = "arn:aws:iam::${join("", aws_organizations_account.staging.id)}:role/OrganizationAccountAccessRole"
 }

--- a/aws/accounts/testing.auto.tfvars.example
+++ b/aws/accounts/testing.auto.tfvars.example
@@ -1,2 +1,0 @@
-testing_account_name="testing"
-testing_account_email="info+testing@cloudposse.co"

--- a/aws/accounts/testing.tf
+++ b/aws/accounts/testing.tf
@@ -1,29 +1,19 @@
-variable "testing_account_name" {
-  type        = "string"
-  description = "Testing account name"
-  default     = "testing"
-}
-
-variable "testing_account_email" {
-  type        = "string"
-  description = "Testing account email"
-}
-
 resource "aws_organizations_account" "testing" {
-  name                       = "${var.testing_account_name}"
-  email                      = "${var.testing_account_email}"
+  count                      = "${contains(var.accounts_enabled, "testing") == true ? 1 : 0}"
+  name                       = "testing"
+  email                      = "${format(var.account_email, "testing")}"
   iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
   role_name                  = "${var.account_role_name}"
 }
 
 output "testing_account_arn" {
-  value = "${aws_organizations_account.testing.arn}"
+  value = "${join("", aws_organizations_account.testing.*.arn)}"
 }
 
 output "testing_account_id" {
-  value = "${aws_organizations_account.testing.id}"
+  value = "${join("", aws_organizations_account.testing.*.id)}"
 }
 
 output "testing_organization_account_access_role" {
-  value = "arn:aws:iam::${aws_organizations_account.testing.id}:role/OrganizationAccountAccessRole"
+  value = "arn:aws:iam::${join("", aws_organizations_account.testing.id)}:role/OrganizationAccountAccessRole"
 }

--- a/aws/accounts/testing.tf
+++ b/aws/accounts/testing.tf
@@ -15,5 +15,5 @@ output "testing_account_id" {
 }
 
 output "testing_organization_account_access_role" {
-  value = "arn:aws:iam::${join("", aws_organizations_account.testing.id)}:role/OrganizationAccountAccessRole"
+  value = "arn:aws:iam::${join("", aws_organizations_account.testing.*.id)}:role/OrganizationAccountAccessRole"
 }


### PR DESCRIPTION
## what
* Enforce that a common format is used for all emails (`e.g. ops+%s@example.co`)
* Add some additional accounts for other use-cases
* Provide a stable way to enable/disable accounts
* Eliminate nearly all variables to reduce customization burden

## why
* Simplifying the cold start problem
* Using `counts` is not a "stable" way to allocate stateful resources like accounts

## plan

![image](https://user-images.githubusercontent.com/52489/50271507-c8a48800-03e9-11e9-85c5-f35d4bb50e6b.png)
