### PR TITLE
[iam] Use account remote state to fetch sub account IDs

### DIFF
--- a/aws/iam/audit.auto.tfvars.example
+++ b/aws/iam/audit.auto.tfvars.example
@@ -1,2 +1,0 @@
-audit_account_id=""
-audit_account_user_names=["", "",]

--- a/aws/iam/audit.tf
+++ b/aws/iam/audit.tf
@@ -1,6 +1,6 @@
 variable "audit_account_user_names" {
   type        = "list"
-  description = "IAM user names to grant access to Audit account"
+  description = "IAM user names to grant access to the `audit` account"
   default     = []
 }
 

--- a/aws/iam/audit.tf
+++ b/aws/iam/audit.tf
@@ -7,6 +7,7 @@ variable "audit_account_user_names" {
 # Provision group access to audit account. Careful! Very few people, if any should have access to this account.
 module "organization_access_group_audit" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.2.1"
+  enabled           = "${contains(var.accounts_enabled, "audit") == true ? "true" : "false"}"
   namespace         = "${var.namespace}"
   stage             = "audit"
   name              = "admin"

--- a/aws/iam/audit.tf
+++ b/aws/iam/audit.tf
@@ -15,6 +15,6 @@ module "organization_access_group_audit" {
   stage             = "audit"
   name              = "admin"
   user_names        = ["${var.audit_account_user_names}"]
-  member_account_id = "${var.audit_account_id}"
+  member_account_id = "${local.audit_account_id}"
   require_mfa       = "true"
 }

--- a/aws/iam/audit.tf
+++ b/aws/iam/audit.tf
@@ -1,20 +1,16 @@
-variable "audit_account_id" {
-  type        = "string"
-  description = "Audit account ID"
-}
-
 variable "audit_account_user_names" {
   type        = "list"
   description = "IAM user names to grant access to Audit account"
+  default     = []
 }
 
 # Provision group access to audit account. Careful! Very few people, if any should have access to this account.
 module "organization_access_group_audit" {
-  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.1.3"
+  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.2.1"
   namespace         = "${var.namespace}"
   stage             = "audit"
   name              = "admin"
-  user_names        = ["${var.audit_account_user_names}"]
-  member_account_id = "${local.audit_account_id}"
+  user_names        = "${var.audit_account_user_names}"
+  member_account_id = "${data.terraform_remote_state.accounts.audit_account_id}"
   require_mfa       = "true"
 }

--- a/aws/iam/corp.tf
+++ b/aws/iam/corp.tf
@@ -1,7 +1,7 @@
 variable "corp_account_user_names" {
   type        = "list"
   description = "IAM user names to grant access to Dev account"
-  defaulti    = []
+  default     = []
 }
 
 # Provision group access to corp account

--- a/aws/iam/corp.tf
+++ b/aws/iam/corp.tf
@@ -1,0 +1,17 @@
+variable "corp_account_user_names" {
+  type        = "list"
+  description = "IAM user names to grant access to Dev account"
+  defaulti    = []
+}
+
+# Provision group access to corp account
+module "organization_access_group_corp" {
+  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.2.1"
+  enabled           = "${contains(var.accounts_enabled, "corp") == true ? "true" : "false"}"
+  namespace         = "${var.namespace}"
+  stage             = "corp"
+  name              = "admin"
+  user_names        = "${var.corp_account_user_names}"
+  member_account_id = "${data.terraform_remote_state.accounts.corp_account_id}"
+  require_mfa       = "true"
+}

--- a/aws/iam/corp.tf
+++ b/aws/iam/corp.tf
@@ -1,6 +1,6 @@
 variable "corp_account_user_names" {
   type        = "list"
-  description = "IAM user names to grant access to Dev account"
+  description = "IAM user names to grant access to the `corp` account"
   default     = []
 }
 

--- a/aws/iam/data.tf
+++ b/aws/iam/data.tf
@@ -1,0 +1,17 @@
+variable "data_account_user_names" {
+  type        = "list"
+  description = "IAM user names to grant access to Dev account"
+  defaulti    = []
+}
+
+# Provision group access to data account
+module "organization_access_group_data" {
+  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.2.1"
+  enabled           = "${contains(var.accounts_enabled, "data") == true ? "true" : "false"}"
+  namespace         = "${var.namespace}"
+  stage             = "data"
+  name              = "admin"
+  user_names        = "${var.data_account_user_names}"
+  member_account_id = "${data.terraform_remote_state.accounts.data_account_id}"
+  require_mfa       = "true"
+}

--- a/aws/iam/data.tf
+++ b/aws/iam/data.tf
@@ -1,7 +1,7 @@
 variable "data_account_user_names" {
   type        = "list"
   description = "IAM user names to grant access to Dev account"
-  defaulti    = []
+  default     = []
 }
 
 # Provision group access to data account

--- a/aws/iam/data.tf
+++ b/aws/iam/data.tf
@@ -1,6 +1,6 @@
 variable "data_account_user_names" {
   type        = "list"
-  description = "IAM user names to grant access to Dev account"
+  description = "IAM user names to grant access to the `data` account"
   default     = []
 }
 

--- a/aws/iam/dev.auto.tfvars.example
+++ b/aws/iam/dev.auto.tfvars.example
@@ -1,2 +1,0 @@
-dev_account_id=""
-dev_account_user_names=["", "",]

--- a/aws/iam/dev.tf
+++ b/aws/iam/dev.tf
@@ -1,6 +1,6 @@
 variable "dev_account_user_names" {
   type        = "list"
-  description = "IAM user names to grant access to Dev account"
+  description = "IAM user names to grant access to the `dev` account"
   default     = []
 }
 

--- a/aws/iam/dev.tf
+++ b/aws/iam/dev.tf
@@ -1,7 +1,7 @@
 variable "dev_account_user_names" {
   type        = "list"
   description = "IAM user names to grant access to Dev account"
-  defaulti    = []
+  default     = []
 }
 
 # Provision group access to dev account

--- a/aws/iam/dev.tf
+++ b/aws/iam/dev.tf
@@ -15,6 +15,6 @@ module "organization_access_group_dev" {
   stage             = "dev"
   name              = "admin"
   user_names        = ["${var.dev_account_user_names}"]
-  member_account_id = "${var.dev_account_id}"
+  member_account_id = "${local.dev_account_id}"
   require_mfa       = "true"
 }

--- a/aws/iam/dev.tf
+++ b/aws/iam/dev.tf
@@ -1,20 +1,16 @@
-variable "dev_account_id" {
-  type        = "string"
-  description = "Dev account ID"
-}
-
 variable "dev_account_user_names" {
   type        = "list"
   description = "IAM user names to grant access to Dev account"
+  defaulti    = []
 }
 
 # Provision group access to dev account
 module "organization_access_group_dev" {
-  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.1.3"
+  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.2.1"
   namespace         = "${var.namespace}"
   stage             = "dev"
   name              = "admin"
-  user_names        = ["${var.dev_account_user_names}"]
-  member_account_id = "${local.dev_account_id}"
+  user_names        = "${var.dev_account_user_names}"
+  member_account_id = "${data.terraform_remote_state.accounts.dev_account_id}"
   require_mfa       = "true"
 }

--- a/aws/iam/dev.tf
+++ b/aws/iam/dev.tf
@@ -7,6 +7,7 @@ variable "dev_account_user_names" {
 # Provision group access to dev account
 module "organization_access_group_dev" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.2.1"
+  enabled           = "${contains(var.accounts_enabled, "dev") == true ? "true" : "false"}"
   namespace         = "${var.namespace}"
   stage             = "dev"
   name              = "admin"

--- a/aws/iam/identity.tf
+++ b/aws/iam/identity.tf
@@ -1,6 +1,6 @@
 variable "identity_account_user_names" {
   type        = "list"
-  description = "IAM user names to grant access to Dev account"
+  description = "IAM user names to grant access to the `identity` account"
   default     = []
 }
 

--- a/aws/iam/identity.tf
+++ b/aws/iam/identity.tf
@@ -1,7 +1,7 @@
 variable "identity_account_user_names" {
   type        = "list"
   description = "IAM user names to grant access to Dev account"
-  defaulti    = []
+  default     = []
 }
 
 # Provision group access to identity account

--- a/aws/iam/identity.tf
+++ b/aws/iam/identity.tf
@@ -1,0 +1,17 @@
+variable "identity_account_user_names" {
+  type        = "list"
+  description = "IAM user names to grant access to Dev account"
+  defaulti    = []
+}
+
+# Provision group access to identity account
+module "organization_access_group_identity" {
+  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.2.1"
+  enabled           = "${contains(var.accounts_enabled, "identity") == true ? "true" : "false"}"
+  namespace         = "${var.namespace}"
+  stage             = "identity"
+  name              = "admin"
+  user_names        = "${var.identity_account_user_names}"
+  member_account_id = "${data.terraform_remote_state.accounts.identity_account_id}"
+  require_mfa       = "true"
+}

--- a/aws/iam/main.tf
+++ b/aws/iam/main.tf
@@ -13,8 +13,30 @@ variable "namespace" {
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
+variable "stage" {
+  type        = "string"
+  description = "Stage, e.g. 'prod', 'staging', 'dev', or 'test'"
+}
+
 provider "aws" {
   assume_role {
     role_arn = "${var.aws_assume_role_arn}"
   }
+}
+
+data "terraform_remote_state" "accounts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.namespace}-${var.stage}-terraform-state"
+    key    = "accounts/terraform.tfstate"
+  }
+}
+
+locals {
+  audit_account_id   = "${data.terraform_remote_state.accounts.audit_account_id}"
+  dev_account_id     = "${data.terraform_remote_state.accounts.dev_account_id}"
+  prod_account_id    = "${data.terraform_remote_state.accounts.prod_account_id}"
+  staging_account_id = "${data.terraform_remote_state.accounts.staging_account_id}"
+  testing_account_id = "${data.terraform_remote_state.accounts.testing_account_id}"
 }

--- a/aws/iam/main.tf
+++ b/aws/iam/main.tf
@@ -33,10 +33,4 @@ data "terraform_remote_state" "accounts" {
   }
 }
 
-locals {
-  audit_account_id   = "${data.terraform_remote_state.accounts.audit_account_id}"
-  dev_account_id     = "${data.terraform_remote_state.accounts.dev_account_id}"
-  prod_account_id    = "${data.terraform_remote_state.accounts.prod_account_id}"
-  staging_account_id = "${data.terraform_remote_state.accounts.staging_account_id}"
-  testing_account_id = "${data.terraform_remote_state.accounts.testing_account_id}"
-}
+locals {}

--- a/aws/iam/main.tf
+++ b/aws/iam/main.tf
@@ -4,20 +4,6 @@ terraform {
   backend "s3" {}
 }
 
-variable "aws_assume_role_arn" {
-  type = "string"
-}
-
-variable "namespace" {
-  type        = "string"
-  description = "Namespace (e.g. `cp` or `cloudposse`)"
-}
-
-variable "stage" {
-  type        = "string"
-  description = "Stage, e.g. 'prod', 'staging', 'dev', or 'test'"
-}
-
 provider "aws" {
   assume_role {
     role_arn = "${var.aws_assume_role_arn}"

--- a/aws/iam/prod.auto.tfvars.example
+++ b/aws/iam/prod.auto.tfvars.example
@@ -1,2 +1,0 @@
-prod_account_id=""
-prod_account_user_names=["", "",]

--- a/aws/iam/prod.tf
+++ b/aws/iam/prod.tf
@@ -7,6 +7,7 @@ variable "prod_account_user_names" {
 # Provision group access to production account
 module "organization_access_group_prod" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.2.1"
+  enabled           = "${contains(var.accounts_enabled, "prod") == true ? "true" : "false"}"
   namespace         = "${var.namespace}"
   stage             = "prod"
   name              = "admin"

--- a/aws/iam/prod.tf
+++ b/aws/iam/prod.tf
@@ -15,6 +15,6 @@ module "organization_access_group_prod" {
   stage             = "prod"
   name              = "admin"
   user_names        = ["${var.prod_account_user_names}"]
-  member_account_id = "${var.prod_account_id}"
+  member_account_id = "${local.prod_account_id}"
   require_mfa       = "true"
 }

--- a/aws/iam/prod.tf
+++ b/aws/iam/prod.tf
@@ -1,20 +1,16 @@
-variable "prod_account_id" {
-  type        = "string"
-  description = "Production account ID"
-}
-
 variable "prod_account_user_names" {
   type        = "list"
   description = "IAM user names to grant access to Production account"
+  default     = []
 }
 
 # Provision group access to production account
 module "organization_access_group_prod" {
-  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.1.3"
+  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.2.1"
   namespace         = "${var.namespace}"
   stage             = "prod"
   name              = "admin"
-  user_names        = ["${var.prod_account_user_names}"]
-  member_account_id = "${local.prod_account_id}"
+  user_names        = "${var.prod_account_user_names}"
+  member_account_id = "${data.terraform_remote_state.accounts.prod_account_id}"
   require_mfa       = "true"
 }

--- a/aws/iam/prod.tf
+++ b/aws/iam/prod.tf
@@ -1,6 +1,6 @@
 variable "prod_account_user_names" {
   type        = "list"
-  description = "IAM user names to grant access to Production account"
+  description = "IAM user names to grant access to the `prod` account"
   default     = []
 }
 

--- a/aws/iam/security.tf
+++ b/aws/iam/security.tf
@@ -1,0 +1,17 @@
+variable "security_account_user_names" {
+  type        = "list"
+  description = "IAM user names to grant access to Dev account"
+  defaulti    = []
+}
+
+# Provision group access to security account
+module "organization_access_group_security" {
+  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.2.1"
+  enabled           = "${contains(var.accounts_enabled, "security") == true ? "true" : "false"}"
+  namespace         = "${var.namespace}"
+  stage             = "security"
+  name              = "admin"
+  user_names        = "${var.security_account_user_names}"
+  member_account_id = "${data.terraform_remote_state.accounts.security_account_id}"
+  require_mfa       = "true"
+}

--- a/aws/iam/security.tf
+++ b/aws/iam/security.tf
@@ -1,6 +1,6 @@
 variable "security_account_user_names" {
   type        = "list"
-  description = "IAM user names to grant access to Dev account"
+  description = "IAM user names to grant access to the `security` account"
   default     = []
 }
 

--- a/aws/iam/security.tf
+++ b/aws/iam/security.tf
@@ -1,7 +1,7 @@
 variable "security_account_user_names" {
   type        = "list"
   description = "IAM user names to grant access to Dev account"
-  defaulti    = []
+  default     = []
 }
 
 # Provision group access to security account

--- a/aws/iam/staging.auto.tfvars.example
+++ b/aws/iam/staging.auto.tfvars.example
@@ -1,2 +1,0 @@
-staging_account_id=""
-staging_account_user_names=["", "",]

--- a/aws/iam/staging.tf
+++ b/aws/iam/staging.tf
@@ -7,6 +7,7 @@ variable "staging_account_user_names" {
 # Provision group access to staging account
 module "organization_access_group_staging" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.2.1"
+  enabled           = "${contains(var.accounts_enabled, "staging") == true ? "true" : "false"}"
   namespace         = "${var.namespace}"
   stage             = "staging"
   name              = "admin"

--- a/aws/iam/staging.tf
+++ b/aws/iam/staging.tf
@@ -1,6 +1,6 @@
 variable "staging_account_user_names" {
   type        = "list"
-  description = "IAM user names to grant access to Staging account"
+  description = "IAM user names to grant access to the `staging` account"
   default     = []
 }
 

--- a/aws/iam/staging.tf
+++ b/aws/iam/staging.tf
@@ -15,6 +15,6 @@ module "organization_access_group_staging" {
   stage             = "staging"
   name              = "admin"
   user_names        = ["${var.staging_account_user_names}"]
-  member_account_id = "${var.staging_account_id}"
+  member_account_id = "${local.staging_account_id}"
   require_mfa       = "true"
 }

--- a/aws/iam/staging.tf
+++ b/aws/iam/staging.tf
@@ -1,20 +1,16 @@
-variable "staging_account_id" {
-  type        = "string"
-  description = "Staging account ID"
-}
-
 variable "staging_account_user_names" {
   type        = "list"
   description = "IAM user names to grant access to Staging account"
+  default     = []
 }
 
 # Provision group access to staging account
 module "organization_access_group_staging" {
-  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.1.3"
+  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.2.1"
   namespace         = "${var.namespace}"
   stage             = "staging"
   name              = "admin"
-  user_names        = ["${var.staging_account_user_names}"]
-  member_account_id = "${local.staging_account_id}"
+  user_names        = "${var.staging_account_user_names}"
+  member_account_id = "${data.terraform_remote_state.accounts.staging_account_id}"
   require_mfa       = "true"
 }

--- a/aws/iam/testing.auto.tfvars.example
+++ b/aws/iam/testing.auto.tfvars.example
@@ -1,2 +1,0 @@
-testing_account_id=""
-testing_account_user_names=["", "",]

--- a/aws/iam/testing.tf
+++ b/aws/iam/testing.tf
@@ -7,6 +7,7 @@ variable "testing_account_user_names" {
 # Provision group access to testing account
 module "organization_access_group_testing" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.2.1"
+  enabled           = "${contains(var.accounts_enabled, "testing") == true ? "true" : "false"}"
   namespace         = "${var.namespace}"
   stage             = "testing"
   name              = "admin"

--- a/aws/iam/testing.tf
+++ b/aws/iam/testing.tf
@@ -1,20 +1,16 @@
-variable "testing_account_id" {
-  type        = "string"
-  description = "Testing account ID"
-}
-
 variable "testing_account_user_names" {
   type        = "list"
   description = "IAM user names to grant access to Testing account"
+  default     = []
 }
 
 # Provision group access to testing account
 module "organization_access_group_testing" {
-  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.1.3"
+  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.2.1"
   namespace         = "${var.namespace}"
   stage             = "testing"
   name              = "admin"
-  user_names        = ["${var.testing_account_user_names}"]
-  member_account_id = "${local.testing_account_id}"
+  user_names        = "${var.testing_account_user_names}"
+  member_account_id = "${data.terraform_remote_state.accounts.testing_account_id}"
   require_mfa       = "true"
 }

--- a/aws/iam/testing.tf
+++ b/aws/iam/testing.tf
@@ -1,6 +1,6 @@
 variable "testing_account_user_names" {
   type        = "list"
-  description = "IAM user names to grant access to Testing account"
+  description = "IAM user names to grant access to the `testing` account"
   default     = []
 }
 

--- a/aws/iam/testing.tf
+++ b/aws/iam/testing.tf
@@ -15,6 +15,6 @@ module "organization_access_group_testing" {
   stage             = "testing"
   name              = "admin"
   user_names        = ["${var.testing_account_user_names}"]
-  member_account_id = "${var.testing_account_id}"
+  member_account_id = "${local.testing_account_id}"
   require_mfa       = "true"
 }

--- a/aws/iam/variables.tf
+++ b/aws/iam/variables.tf
@@ -1,0 +1,19 @@
+variable "accounts_enabled" {
+  type        = "list"
+  description = "Accounts to enable"
+  default     = ["dev", "staging", "prod", "testing", "audit"]
+}
+
+variable "aws_assume_role_arn" {
+  type = "string"
+}
+
+variable "namespace" {
+  type        = "string"
+  description = "Namespace (e.g. `cp` or `cloudposse`)"
+}
+
+variable "stage" {
+  type        = "string"
+  description = "Stage, e.g. 'prod', 'staging', 'dev', or 'test'"
+}


### PR DESCRIPTION
## what

Use account remote state to fetch sub account IDs. This should resolve https://github.com/cloudposse/terraform-root-modules/issues/62

## why

So that we don’t need to hardcode these as vars e.g. in the top root [Dockerfile](https://github.com/cloudposse/root.cloudposse.co/blob/master/Dockerfile#L25)

## testing

I have tested this locally by rebuilding `terraform-root-modules`, pulling that into `root.cloudposse.co` Geodesic and running an IAM plan, which was a no-op:

```
✓   (cpco-root-admin) iam ⨠  terraform plan
Acquiring state lock. This may take a few moments...
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

data.terraform_remote_state.accounts: Refreshing state...
null_resource.default: Refreshing state... (ID: 7186560472194827449)
null_resource.default: Refreshing state... (ID: 6969270438690546927)
null_resource.default: Refreshing state... (ID: 5537321665039813386)
null_resource.default: Refreshing state... (ID: 6352812055576901350)
null_resource.default: Refreshing state... (ID: 4482607511053085631)
aws_iam_group.default: Refreshing state... (ID: cpco-testing-admin)
aws_iam_group.default: Refreshing state... (ID: cpco-prod-admin)
aws_iam_group.default: Refreshing state... (ID: cpco-dev-admin)
aws_iam_group.default: Refreshing state... (ID: cpco-staging-admin)
aws_iam_group.default: Refreshing state... (ID: cpco-audit-admin)
aws_iam_group_membership.default: Refreshing state... (ID: cpco-audit-admin)
aws_iam_group_membership.default: Refreshing state... (ID: cpco-prod-admin)
aws_iam_group_membership.default: Refreshing state... (ID: cpco-dev-admin)
aws_iam_group_membership.default: Refreshing state... (ID: cpco-testing-admin)
aws_iam_group_membership.default: Refreshing state... (ID: cpco-staging-admin)
data.aws_iam_policy_document.with_mfa: Refreshing state...
data.aws_iam_policy_document.with_mfa: Refreshing state...
aws_iam_group_policy.with_mfa: Refreshing state... (ID: cpco-testing-admin:cpco-testing-admin)
data.aws_iam_policy_document.with_mfa: Refreshing state...
data.aws_iam_policy_document.with_mfa: Refreshing state...
aws_iam_group_policy.with_mfa: Refreshing state... (ID: cpco-audit-admin:cpco-audit-admin)
aws_iam_group_policy.with_mfa: Refreshing state... (ID: cpco-dev-admin:cpco-dev-admin)
aws_iam_group_policy.with_mfa: Refreshing state... (ID: cpco-staging-admin:cpco-staging-admin)
data.aws_iam_policy_document.with_mfa: Refreshing state...
aws_iam_group_policy.with_mfa: Refreshing state... (ID: cpco-prod-admin:cpco-prod-admin)

------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.
```
