### PR TITLE
[aws/accounts] Publish account details to SSM

### DIFF
--- a/aws/accounts/Makefile
+++ b/aws/accounts/Makefile
@@ -1,11 +1,8 @@
 init:
 	init-terraform
 
-plan:
-	terraform $@
-
-apply:
-	terraform $@
-
 clean:
 	rm -rf .terraform
+
+%:
+	terraform $@

--- a/aws/accounts/audit.tf
+++ b/aws/accounts/audit.tf
@@ -36,7 +36,7 @@ module "audit_parameters" {
       value       = "${local.audit_organization_account_access_role}"
       type        = "String"
       overwrite   = "true"
-      description = "AWS Organizational Account Access Role"
+      description = "AWS Organization Account Access Role"
     },
   ]
 }

--- a/aws/accounts/audit.tf
+++ b/aws/accounts/audit.tf
@@ -6,14 +6,49 @@ resource "aws_organizations_account" "audit" {
   role_name                  = "${var.account_role_name}"
 }
 
+locals {
+  audit_account_arn                      = "${join("", aws_organizations_account.audit.*.arn)}"
+  audit_account_id                       = "${join("", aws_organizations_account.audit.*.id)}"
+  audit_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.audit.*.id)}:role/OrganizationAccountAccessRole"
+}
+
+module "audit_parameters" {
+  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
+  enabled = "${contains(var.accounts_enabled, "audit") == true ? "true" : "false"}"
+
+  parameter_write = [
+    {
+      name        = "/${var.namespace}/audit/account_id"
+      value       = "${local.audit_account_id}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Account ID"
+    },
+    {
+      name        = "/${var.namespace}/audit/account_arn"
+      value       = "${local.audit_account_arn}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Account ARN"
+    },
+    {
+      name        = "/${var.namespace}/audit/organization_account_access_role"
+      value       = "${local.audit_organization_account_access_role}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Organizational Account Access Role"
+    },
+  ]
+}
+
 output "audit_account_arn" {
-  value = "${join("", aws_organizations_account.audit.*.arn)}"
+  value = "${local.audit_account_arn}"
 }
 
 output "audit_account_id" {
-  value = "${join("", aws_organizations_account.audit.*.id)}"
+  value = "${local.audit_account_id}"
 }
 
 output "audit_organization_account_access_role" {
-  value = "arn:aws:iam::${join("", aws_organizations_account.audit.*.id)}:role/OrganizationAccountAccessRole"
+  value = "${local.audit_organization_account_access_role}"
 }

--- a/aws/accounts/corp.tf
+++ b/aws/accounts/corp.tf
@@ -36,7 +36,7 @@ module "corp_parameters" {
       value       = "${local.corp_organization_account_access_role}"
       type        = "String"
       overwrite   = "true"
-      description = "AWS Organizational Account Access Role"
+      description = "AWS Organization Account Access Role"
     },
   ]
 }

--- a/aws/accounts/corp.tf
+++ b/aws/accounts/corp.tf
@@ -6,14 +6,49 @@ resource "aws_organizations_account" "corp" {
   role_name                  = "${var.account_role_name}"
 }
 
+locals {
+  corp_account_arn                      = "${join("", aws_organizations_account.corp.*.arn)}"
+  corp_account_id                       = "${join("", aws_organizations_account.corp.*.id)}"
+  corp_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.corp.*.id)}:role/OrganizationAccountAccessRole"
+}
+
+module "corp_parameters" {
+  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
+  enabled = "${contains(var.accounts_enabled, "corp") == true ? "true" : "false"}"
+
+  parameter_write = [
+    {
+      name        = "/${var.namespace}/corp/account_id"
+      value       = "${local.corp_account_id}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Account ID"
+    },
+    {
+      name        = "/${var.namespace}/corp/account_arn"
+      value       = "${local.corp_account_arn}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Account ARN"
+    },
+    {
+      name        = "/${var.namespace}/corp/organization_account_access_role"
+      value       = "${local.corp_organization_account_access_role}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Organizational Account Access Role"
+    },
+  ]
+}
+
 output "corp_account_arn" {
-  value = "${join("", aws_organizations_account.corp.*.arn)}"
+  value = "${local.corp_account_arn}"
 }
 
 output "corp_account_id" {
-  value = "${join("", aws_organizations_account.corp.*.id)}"
+  value = "${local.corp_account_id}"
 }
 
 output "corp_organization_account_access_role" {
-  value = "arn:aws:iam::${join("", aws_organizations_account.corp.*.id)}:role/OrganizationAccountAccessRole"
+  value = "${local.corp_organization_account_access_role}"
 }

--- a/aws/accounts/data.tf
+++ b/aws/accounts/data.tf
@@ -36,7 +36,7 @@ module "data_parameters" {
       value       = "${local.data_organization_account_access_role}"
       type        = "String"
       overwrite   = "true"
-      description = "AWS Organizational Account Access Role"
+      description = "AWS Organization Account Access Role"
     },
   ]
 }

--- a/aws/accounts/data.tf
+++ b/aws/accounts/data.tf
@@ -6,14 +6,49 @@ resource "aws_organizations_account" "data" {
   role_name                  = "${var.account_role_name}"
 }
 
+locals {
+  data_account_arn                      = "${join("", aws_organizations_account.data.*.arn)}"
+  data_account_id                       = "${join("", aws_organizations_account.data.*.id)}"
+  data_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.data.*.id)}:role/OrganizationAccountAccessRole"
+}
+
+module "data_parameters" {
+  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
+  enabled = "${contains(var.accounts_enabled, "data") == true ? "true" : "false"}"
+
+  parameter_write = [
+    {
+      name        = "/${var.namespace}/data/account_id"
+      value       = "${local.data_account_id}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Account ID"
+    },
+    {
+      name        = "/${var.namespace}/data/account_arn"
+      value       = "${local.data_account_arn}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Account ARN"
+    },
+    {
+      name        = "/${var.namespace}/data/organization_account_access_role"
+      value       = "${local.data_organization_account_access_role}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Organizational Account Access Role"
+    },
+  ]
+}
+
 output "data_account_arn" {
-  value = "${join("", aws_organizations_account.data.*.arn)}"
+  value = "${local.data_account_arn}"
 }
 
 output "data_account_id" {
-  value = "${join("", aws_organizations_account.data.*.id)}"
+  value = "${local.data_account_id}"
 }
 
 output "data_organization_account_access_role" {
-  value = "arn:aws:iam::${join("", aws_organizations_account.data.*.id)}:role/OrganizationAccountAccessRole"
+  value = "${local.data_organization_account_access_role}"
 }

--- a/aws/accounts/dev.tf
+++ b/aws/accounts/dev.tf
@@ -6,14 +6,49 @@ resource "aws_organizations_account" "dev" {
   role_name                  = "${var.account_role_name}"
 }
 
+locals {
+  dev_account_arn                      = "${join("", aws_organizations_account.dev.*.arn)}"
+  dev_account_id                       = "${join("", aws_organizations_account.dev.*.id)}"
+  dev_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.dev.*.id)}:role/OrganizationAccountAccessRole"
+}
+
+module "dev_parameters" {
+  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
+  enabled = "${contains(var.accounts_enabled, "dev") == true ? "true" : "false"}"
+
+  parameter_write = [
+    {
+      name        = "/${var.namespace}/dev/account_id"
+      value       = "${local.dev_account_id}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Account ID"
+    },
+    {
+      name        = "/${var.namespace}/dev/account_arn"
+      value       = "${local.dev_account_arn}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Account ARN"
+    },
+    {
+      name        = "/${var.namespace}/dev/organization_account_access_role"
+      value       = "${local.dev_organization_account_access_role}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Organizational Account Access Role"
+    },
+  ]
+}
+
 output "dev_account_arn" {
-  value = "${join("", aws_organizations_account.dev.*.arn)}"
+  value = "${local.dev_account_arn}"
 }
 
 output "dev_account_id" {
-  value = "${join("", aws_organizations_account.dev.*.id)}"
+  value = "${local.dev_account_id}"
 }
 
 output "dev_organization_account_access_role" {
-  value = "arn:aws:iam::${join("", aws_organizations_account.dev.*.id)}:role/OrganizationAccountAccessRole"
+  value = "${local.dev_organization_account_access_role}"
 }

--- a/aws/accounts/dev.tf
+++ b/aws/accounts/dev.tf
@@ -36,7 +36,7 @@ module "dev_parameters" {
       value       = "${local.dev_organization_account_access_role}"
       type        = "String"
       overwrite   = "true"
-      description = "AWS Organizational Account Access Role"
+      description = "AWS Organization Account Access Role"
     },
   ]
 }

--- a/aws/accounts/identity.tf
+++ b/aws/accounts/identity.tf
@@ -36,7 +36,7 @@ module "identity_parameters" {
       value       = "${local.identity_organization_account_access_role}"
       type        = "String"
       overwrite   = "true"
-      description = "AWS Organizational Account Access Role"
+      description = "AWS Organization Account Access Role"
     },
   ]
 }

--- a/aws/accounts/identity.tf
+++ b/aws/accounts/identity.tf
@@ -6,14 +6,49 @@ resource "aws_organizations_account" "identity" {
   role_name                  = "${var.account_role_name}"
 }
 
+locals {
+  identity_account_arn                      = "${join("", aws_organizations_account.identity.*.arn)}"
+  identity_account_id                       = "${join("", aws_organizations_account.identity.*.id)}"
+  identity_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.identity.*.id)}:role/OrganizationAccountAccessRole"
+}
+
+module "identity_parameters" {
+  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
+  enabled = "${contains(var.accounts_enabled, "identity") == true ? "true" : "false"}"
+
+  parameter_write = [
+    {
+      name        = "/${var.namespace}/identity/account_id"
+      value       = "${local.identity_account_id}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Account ID"
+    },
+    {
+      name        = "/${var.namespace}/identity/account_arn"
+      value       = "${local.identity_account_arn}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Account ARN"
+    },
+    {
+      name        = "/${var.namespace}/identity/organization_account_access_role"
+      value       = "${local.identity_organization_account_access_role}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Organizational Account Access Role"
+    },
+  ]
+}
+
 output "identity_account_arn" {
-  value = "${join("", aws_organizations_account.identity.*.arn)}"
+  value = "${local.identity_account_arn}"
 }
 
 output "identity_account_id" {
-  value = "${join("", aws_organizations_account.identity.*.id)}"
+  value = "${local.identity_account_id}"
 }
 
 output "identity_organization_account_access_role" {
-  value = "arn:aws:iam::${join("", aws_organizations_account.identity.*.id)}:role/OrganizationAccountAccessRole"
+  value = "${local.identity_organization_account_access_role}"
 }

--- a/aws/accounts/main.tf
+++ b/aws/accounts/main.tf
@@ -8,6 +8,11 @@ variable "aws_assume_role_arn" {
   type = "string"
 }
 
+variable "namespace" {
+  type        = "string"
+  description = "Namespace (e.g. `cp` or `cloudposse`)"
+}
+
 variable "account_role_name" {
   type        = "string"
   description = "IAM role that Organization automatically preconfigures in the new member account"

--- a/aws/accounts/prod.tf
+++ b/aws/accounts/prod.tf
@@ -36,7 +36,7 @@ module "prod_parameters" {
       value       = "${local.prod_organization_account_access_role}"
       type        = "String"
       overwrite   = "true"
-      description = "AWS Organizational Account Access Role"
+      description = "AWS Organization Account Access Role"
     },
   ]
 }

--- a/aws/accounts/prod.tf
+++ b/aws/accounts/prod.tf
@@ -6,14 +6,49 @@ resource "aws_organizations_account" "prod" {
   role_name                  = "${var.account_role_name}"
 }
 
+locals {
+  prod_account_arn                      = "${join("", aws_organizations_account.prod.*.arn)}"
+  prod_account_id                       = "${join("", aws_organizations_account.prod.*.id)}"
+  prod_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.prod.*.id)}:role/OrganizationAccountAccessRole"
+}
+
+module "prod_parameters" {
+  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
+  enabled = "${contains(var.accounts_enabled, "prod") == true ? "true" : "false"}"
+
+  parameter_write = [
+    {
+      name        = "/${var.namespace}/prod/account_id"
+      value       = "${local.prod_account_id}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Account ID"
+    },
+    {
+      name        = "/${var.namespace}/prod/account_arn"
+      value       = "${local.prod_account_arn}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Account ARN"
+    },
+    {
+      name        = "/${var.namespace}/prod/organization_account_access_role"
+      value       = "${local.prod_organization_account_access_role}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Organizational Account Access Role"
+    },
+  ]
+}
+
 output "prod_account_arn" {
-  value = "${join("", aws_organizations_account.prod.*.arn)}"
+  value = "${local.prod_account_arn}"
 }
 
 output "prod_account_id" {
-  value = "${join("", aws_organizations_account.prod.*.id)}"
+  value = "${local.prod_account_id}"
 }
 
 output "prod_organization_account_access_role" {
-  value = "arn:aws:iam::${join("", aws_organizations_account.prod.*.id)}:role/OrganizationAccountAccessRole"
+  value = "${local.prod_organization_account_access_role}"
 }

--- a/aws/accounts/security.tf
+++ b/aws/accounts/security.tf
@@ -6,14 +6,49 @@ resource "aws_organizations_account" "security" {
   role_name                  = "${var.account_role_name}"
 }
 
+locals {
+  security_account_arn                      = "${join("", aws_organizations_account.security.*.arn)}"
+  security_account_id                       = "${join("", aws_organizations_account.security.*.id)}"
+  security_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.security.*.id)}:role/OrganizationAccountAccessRole"
+}
+
+module "security_parameters" {
+  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
+  enabled = "${contains(var.accounts_enabled, "security") == true ? "true" : "false"}"
+
+  parameter_write = [
+    {
+      name        = "/${var.namespace}/security/account_id"
+      value       = "${local.security_account_id}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Account ID"
+    },
+    {
+      name        = "/${var.namespace}/security/account_arn"
+      value       = "${local.security_account_arn}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Account ARN"
+    },
+    {
+      name        = "/${var.namespace}/security/organization_account_access_role"
+      value       = "${local.security_organization_account_access_role}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Organizational Account Access Role"
+    },
+  ]
+}
+
 output "security_account_arn" {
-  value = "${join("", aws_organizations_account.security.*.arn)}"
+  value = "${local.security_account_arn}"
 }
 
 output "security_account_id" {
-  value = "${join("", aws_organizations_account.security.*.id)}"
+  value = "${local.security_account_id}"
 }
 
 output "security_organization_account_access_role" {
-  value = "arn:aws:iam::${join("", aws_organizations_account.security.*.id)}:role/OrganizationAccountAccessRole"
+  value = "${local.security_organization_account_access_role}"
 }

--- a/aws/accounts/security.tf
+++ b/aws/accounts/security.tf
@@ -36,7 +36,7 @@ module "security_parameters" {
       value       = "${local.security_organization_account_access_role}"
       type        = "String"
       overwrite   = "true"
-      description = "AWS Organizational Account Access Role"
+      description = "AWS Organization Account Access Role"
     },
   ]
 }

--- a/aws/accounts/staging.tf
+++ b/aws/accounts/staging.tf
@@ -6,14 +6,49 @@ resource "aws_organizations_account" "staging" {
   role_name                  = "${var.account_role_name}"
 }
 
+locals {
+  staging_account_arn                      = "${join("", aws_organizations_account.staging.*.arn)}"
+  staging_account_id                       = "${join("", aws_organizations_account.staging.*.id)}"
+  staging_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.staging.*.id)}:role/OrganizationAccountAccessRole"
+}
+
+module "staging_parameters" {
+  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
+  enabled = "${contains(var.accounts_enabled, "staging") == true ? "true" : "false"}"
+
+  parameter_write = [
+    {
+      name        = "/${var.namespace}/staging/account_id"
+      value       = "${local.staging_account_id}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Account ID"
+    },
+    {
+      name        = "/${var.namespace}/staging/account_arn"
+      value       = "${local.staging_account_arn}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Account ARN"
+    },
+    {
+      name        = "/${var.namespace}/staging/organization_account_access_role"
+      value       = "${local.staging_organization_account_access_role}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Organizational Account Access Role"
+    },
+  ]
+}
+
 output "staging_account_arn" {
-  value = "${join("", aws_organizations_account.staging.*.arn)}"
+  value = "${local.staging_account_arn}"
 }
 
 output "staging_account_id" {
-  value = "${join("", aws_organizations_account.staging.*.id)}"
+  value = "${local.staging_account_id}"
 }
 
 output "staging_organization_account_access_role" {
-  value = "arn:aws:iam::${join("", aws_organizations_account.staging.*.id)}:role/OrganizationAccountAccessRole"
+  value = "${local.staging_organization_account_access_role}"
 }

--- a/aws/accounts/staging.tf
+++ b/aws/accounts/staging.tf
@@ -36,7 +36,7 @@ module "staging_parameters" {
       value       = "${local.staging_organization_account_access_role}"
       type        = "String"
       overwrite   = "true"
-      description = "AWS Organizational Account Access Role"
+      description = "AWS Organization Account Access Role"
     },
   ]
 }

--- a/aws/accounts/testing.tf
+++ b/aws/accounts/testing.tf
@@ -6,14 +6,49 @@ resource "aws_organizations_account" "testing" {
   role_name                  = "${var.account_role_name}"
 }
 
+locals {
+  testing_account_arn                      = "${join("", aws_organizations_account.testing.*.arn)}"
+  testing_account_id                       = "${join("", aws_organizations_account.testing.*.id)}"
+  testing_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.testing.*.id)}:role/OrganizationAccountAccessRole"
+}
+
+module "testing_parameters" {
+  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
+  enabled = "${contains(var.accounts_enabled, "testing") == true ? "true" : "false"}"
+
+  parameter_write = [
+    {
+      name        = "/${var.namespace}/testing/account_id"
+      value       = "${local.testing_account_id}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Account ID"
+    },
+    {
+      name        = "/${var.namespace}/testing/account_arn"
+      value       = "${local.testing_account_arn}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Account ARN"
+    },
+    {
+      name        = "/${var.namespace}/testing/organization_account_access_role"
+      value       = "${local.testing_organization_account_access_role}"
+      type        = "String"
+      overwrite   = "true"
+      description = "AWS Organizational Account Access Role"
+    },
+  ]
+}
+
 output "testing_account_arn" {
-  value = "${join("", aws_organizations_account.testing.*.arn)}"
+  value = "${local.testing_account_arn}"
 }
 
 output "testing_account_id" {
-  value = "${join("", aws_organizations_account.testing.*.id)}"
+  value = "${local.testing_account_id}"
 }
 
 output "testing_organization_account_access_role" {
-  value = "arn:aws:iam::${join("", aws_organizations_account.testing.*.id)}:role/OrganizationAccountAccessRole"
+  value = "${local.testing_organization_account_access_role}"
 }

--- a/aws/accounts/testing.tf
+++ b/aws/accounts/testing.tf
@@ -36,7 +36,7 @@ module "testing_parameters" {
       value       = "${local.testing_organization_account_access_role}"
       type        = "String"
       overwrite   = "true"
-      description = "AWS Organizational Account Access Role"
+      description = "AWS Organization Account Access Role"
     },
   ]
 }


### PR DESCRIPTION
## what
* Publish AWS Account details to SSM parameter store

## why
* With SSM parameter store, we can reference parameters using the variable names in other modules, which makes it easier to query data programmatically since we don't need to hardcode attributes. 

