### PR TITLE
Fixes for reference-architectures

### DIFF
--- a/aws/organization/Makefile
+++ b/aws/organization/Makefile
@@ -1,0 +1,8 @@
+init:
+	init-terraform
+
+%:
+	terraform $@
+
+clean:
+	rm -rf .terraform

--- a/aws/tfstate-backend/Makefile
+++ b/aws/tfstate-backend/Makefile
@@ -1,6 +1,6 @@
 ## Initialize the terraform state backend
 init:
-	@aws s3 ls s3://${TF_BUCKET}/tfstate-backend/terraform.tfstates > /dev/null || \
+	@aws s3 ls s3://${TF_BUCKET}/tfstate-backend/terraform.tfstate > /dev/null || \
 		scripts/$@.sh
 	@[ -d .terraform ] || init-terraform
 

--- a/aws/tfstate-backend/Makefile
+++ b/aws/tfstate-backend/Makefile
@@ -1,6 +1,8 @@
-## Initialize the configuration (should only be run once)
+## Initialize the terraform state backend
 init:
-	@scripts/$@.sh
+	@aws s3 ls s3://${TF_BUCKET}/tfstate-backend/terraform.tfstates > /dev/null || \
+		scripts/$@.sh
+	@[ -d .terraform ] || init-terraform
 
 ## Destroy the configuration (only works if `force_destroy=true`)
 destroy:
@@ -9,3 +11,7 @@ destroy:
 ## Force destroy the bucket (not recommended!)
 force-destroy:
 	@scripts/$@.sh
+
+## Pass target through to terraform
+%:
+	terraform $@

--- a/aws/users/Makefile
+++ b/aws/users/Makefile
@@ -1,10 +1,7 @@
 init:
 	init-terraform
 
-plan:
-	terraform $@
-
-apply:
+%:
 	terraform $@
 
 clean:

--- a/aws/users/variables.tf
+++ b/aws/users/variables.tf
@@ -19,16 +19,19 @@ variable "name" {
 variable "smtp_username" {
   description = "Username to authenticate with the SMTP server"
   type        = "string"
+  default     = ""
 }
 
 variable "smtp_password" {
   description = "Password to authenticate with the SMTP server"
   type        = "string"
+  default     = ""
 }
 
 variable "smtp_host" {
   description = "SMTP Host"
   default     = "smtp.mailgun.org"
+  default     = ""
 }
 
 variable "smtp_port" {


### PR DESCRIPTION
## what
* Add `Makefile` to `aws/organizations`
* Support `make init` in `tfstate-backend` when backend already provisioned
* Make `SMTP_*` vars optional (only needed if sending mail and we're not always going to be doing that)

## why
* Use `Makefile` as the standard interface for all root modules => consistency & documentation

## references
* https://github.com/cloudposse/reference-architectures/pull/1
