### PR TITLE
[aws/accounts] do not use ssm module

### DIFF
--- a/aws/accounts/audit.tf
+++ b/aws/accounts/audit.tf
@@ -1,53 +1,21 @@
-resource "aws_organizations_account" "audit" {
-  count                      = "${local.audit_count}"
-  name                       = "audit"
-  email                      = "${format(var.account_email, "audit")}"
-  iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
-  role_name                  = "${var.account_role_name}"
-}
-
-locals {
-  audit_count                            = "${contains(var.accounts_enabled, "audit") == true ? 1 : 0}"
-  audit_account_arn                      = "${join("", aws_organizations_account.audit.*.arn)}"
-  audit_account_id                       = "${join("", aws_organizations_account.audit.*.id)}"
-  audit_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.audit.*.id)}:role/OrganizationAccountAccessRole"
-}
-
-resource "aws_ssm_parameter" "audit_account_id" {
-  count       = "${local.audit_count}"
-  name        = "/${var.namespace}/audit/account_id"
-  description = "AWS Account ID"
-  type        = "String"
-  value       = "${local.audit_account_id}"
-  overwrite   = "true"
-}
-
-resource "aws_ssm_parameter" "audit_account_arn" {
-  count       = "${local.audit_count}"
-  name        = "/${var.namespace}/audit/account_arn"
-  description = "AWS Account ARN"
-  type        = "String"
-  value       = "${local.audit_account_arn}"
-  overwrite   = "true"
-}
-
-resource "aws_ssm_parameter" "audit_organization_account_access_role" {
-  count       = "${local.audit_count}"
-  name        = "/${var.namespace}/audit/organization_account_access_role"
-  description = "AWS Organization Account Access Role"
-  type        = "String"
-  value       = "${local.audit_account_id}"
-  overwrite   = "true"
+module "audit" {
+  source                             = "stage"
+  namespace                          = "${var.namespace}"
+  stage                              = "audit"
+  accounts_enabled                   = "${var.accounts_enabled}"
+  account_email                      = "${var.account_email}"
+  account_iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
+  account_role_name                  = "${var.account_role_name}"
 }
 
 output "audit_account_arn" {
-  value = "${local.audit_account_arn}"
+  value = "${module.audit.account_arn}"
 }
 
 output "audit_account_id" {
-  value = "${local.audit_account_id}"
+  value = "${module.audit.account_id}"
 }
 
 output "audit_organization_account_access_role" {
-  value = "${local.audit_organization_account_access_role}"
+  value = "${module.audit.organization_account_access_role}"
 }

--- a/aws/accounts/corp.tf
+++ b/aws/accounts/corp.tf
@@ -1,53 +1,21 @@
-resource "aws_organizations_account" "corp" {
-  count                      = "${local.corp_count}"
-  name                       = "corp"
-  email                      = "${format(var.account_email, "corp")}"
-  iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
-  role_name                  = "${var.account_role_name}"
-}
-
-locals {
-  corp_count                            = "${contains(var.accounts_enabled, "corp") == true ? 1 : 0}"
-  corp_account_arn                      = "${join("", aws_organizations_account.corp.*.arn)}"
-  corp_account_id                       = "${join("", aws_organizations_account.corp.*.id)}"
-  corp_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.corp.*.id)}:role/OrganizationAccountAccessRole"
-}
-
-resource "aws_ssm_parameter" "corp_account_id" {
-  count       = "${local.corp_count}"
-  name        = "/${var.namespace}/corp/account_id"
-  description = "AWS Account ID"
-  type        = "String"
-  value       = "${local.corp_account_id}"
-  overwrite   = "true"
-}
-
-resource "aws_ssm_parameter" "corp_account_arn" {
-  count       = "${local.corp_count}"
-  name        = "/${var.namespace}/corp/account_arn"
-  description = "AWS Account ARN"
-  type        = "String"
-  value       = "${local.corp_account_arn}"
-  overwrite   = "true"
-}
-
-resource "aws_ssm_parameter" "corp_organization_account_access_role" {
-  count       = "${local.corp_count}"
-  name        = "/${var.namespace}/corp/organization_account_access_role"
-  description = "AWS Organization Account Access Role"
-  type        = "String"
-  value       = "${local.corp_account_id}"
-  overwrite   = "true"
+module "corp" {
+  source                             = "stage"
+  namespace                          = "${var.namespace}"
+  stage                              = "corp"
+  accounts_enabled                   = "${var.accounts_enabled}"
+  account_email                      = "${var.account_email}"
+  account_iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
+  account_role_name                  = "${var.account_role_name}"
 }
 
 output "corp_account_arn" {
-  value = "${local.corp_account_arn}"
+  value = "${module.corp.account_arn}"
 }
 
 output "corp_account_id" {
-  value = "${local.corp_account_id}"
+  value = "${module.corp.account_id}"
 }
 
 output "corp_organization_account_access_role" {
-  value = "${local.corp_organization_account_access_role}"
+  value = "${module.corp.organization_account_access_role}"
 }

--- a/aws/accounts/corp.tf
+++ b/aws/accounts/corp.tf
@@ -1,5 +1,5 @@
 resource "aws_organizations_account" "corp" {
-  count                      = "${contains(var.accounts_enabled, "corp") == true ? 1 : 0}"
+  count                      = "${local.corp_count}"
   name                       = "corp"
   email                      = "${format(var.account_email, "corp")}"
   iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
@@ -7,38 +7,37 @@ resource "aws_organizations_account" "corp" {
 }
 
 locals {
+  corp_count                            = "${contains(var.accounts_enabled, "corp") == true ? 1 : 0}"
   corp_account_arn                      = "${join("", aws_organizations_account.corp.*.arn)}"
   corp_account_id                       = "${join("", aws_organizations_account.corp.*.id)}"
   corp_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.corp.*.id)}:role/OrganizationAccountAccessRole"
 }
 
-module "corp_parameters" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
-  enabled = "${contains(var.accounts_enabled, "corp") == true ? "true" : "false"}"
+resource "aws_ssm_parameter" "corp_account_id" {
+  count       = "${local.corp_count}"
+  name        = "/${var.namespace}/corp/account_id"
+  description = "AWS Account ID"
+  type        = "String"
+  value       = "${local.corp_account_id}"
+  overwrite   = "true"
+}
 
-  parameter_write = [
-    {
-      name        = "/${var.namespace}/corp/account_id"
-      value       = "${local.corp_account_id}"
-      type        = "String"
-      overwrite   = "true"
-      description = "AWS Account ID"
-    },
-    {
-      name        = "/${var.namespace}/corp/account_arn"
-      value       = "${local.corp_account_arn}"
-      type        = "String"
-      overwrite   = "true"
-      description = "AWS Account ARN"
-    },
-    {
-      name        = "/${var.namespace}/corp/organization_account_access_role"
-      value       = "${local.corp_organization_account_access_role}"
-      type        = "String"
-      overwrite   = "true"
-      description = "AWS Organization Account Access Role"
-    },
-  ]
+resource "aws_ssm_parameter" "corp_account_arn" {
+  count       = "${local.corp_count}"
+  name        = "/${var.namespace}/corp/account_arn"
+  description = "AWS Account ARN"
+  type        = "String"
+  value       = "${local.corp_account_arn}"
+  overwrite   = "true"
+}
+
+resource "aws_ssm_parameter" "corp_organization_account_access_role" {
+  count       = "${local.corp_count}"
+  name        = "/${var.namespace}/corp/organization_account_access_role"
+  description = "AWS Organization Account Access Role"
+  type        = "String"
+  value       = "${local.corp_account_id}"
+  overwrite   = "true"
 }
 
 output "corp_account_arn" {

--- a/aws/accounts/data.tf
+++ b/aws/accounts/data.tf
@@ -1,53 +1,21 @@
-resource "aws_organizations_account" "data" {
-  count                      = "${local.data_count}"
-  name                       = "data"
-  email                      = "${format(var.account_email, "data")}"
-  iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
-  role_name                  = "${var.account_role_name}"
-}
-
-locals {
-  data_count                            = "${contains(var.accounts_enabled, "data") == true ? 1 : 0}"
-  data_account_arn                      = "${join("", aws_organizations_account.data.*.arn)}"
-  data_account_id                       = "${join("", aws_organizations_account.data.*.id)}"
-  data_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.data.*.id)}:role/OrganizationAccountAccessRole"
-}
-
-resource "aws_ssm_parameter" "data_account_id" {
-  count       = "${local.data_count}"
-  name        = "/${var.namespace}/data/account_id"
-  description = "AWS Account ID"
-  type        = "String"
-  value       = "${local.data_account_id}"
-  overwrite   = "true"
-}
-
-resource "aws_ssm_parameter" "data_account_arn" {
-  count       = "${local.data_count}"
-  name        = "/${var.namespace}/data/account_arn"
-  description = "AWS Account ARN"
-  type        = "String"
-  value       = "${local.data_account_arn}"
-  overwrite   = "true"
-}
-
-resource "aws_ssm_parameter" "data_organization_account_access_role" {
-  count       = "${local.data_count}"
-  name        = "/${var.namespace}/data/organization_account_access_role"
-  description = "AWS Organization Account Access Role"
-  type        = "String"
-  value       = "${local.data_account_id}"
-  overwrite   = "true"
+module "data" {
+  source                             = "stage"
+  namespace                          = "${var.namespace}"
+  stage                              = "data"
+  accounts_enabled                   = "${var.accounts_enabled}"
+  account_email                      = "${var.account_email}"
+  account_iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
+  account_role_name                  = "${var.account_role_name}"
 }
 
 output "data_account_arn" {
-  value = "${local.data_account_arn}"
+  value = "${module.data.account_arn}"
 }
 
 output "data_account_id" {
-  value = "${local.data_account_id}"
+  value = "${module.data.account_id}"
 }
 
 output "data_organization_account_access_role" {
-  value = "${local.data_organization_account_access_role}"
+  value = "${module.data.organization_account_access_role}"
 }

--- a/aws/accounts/dev.tf
+++ b/aws/accounts/dev.tf
@@ -1,53 +1,21 @@
-resource "aws_organizations_account" "dev" {
-  count                      = "${local.dev_count}"
-  name                       = "dev"
-  email                      = "${format(var.account_email, "dev")}"
-  iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
-  role_name                  = "${var.account_role_name}"
-}
-
-locals {
-  dev_count                            = "${contains(var.accounts_enabled, "dev") == true ? 1 : 0}"
-  dev_account_arn                      = "${join("", aws_organizations_account.dev.*.arn)}"
-  dev_account_id                       = "${join("", aws_organizations_account.dev.*.id)}"
-  dev_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.dev.*.id)}:role/OrganizationAccountAccessRole"
-}
-
-resource "aws_ssm_parameter" "dev_account_id" {
-  count       = "${local.dev_count}"
-  name        = "/${var.namespace}/dev/account_id"
-  description = "AWS Account ID"
-  type        = "String"
-  value       = "${local.dev_account_id}"
-  overwrite   = "true"
-}
-
-resource "aws_ssm_parameter" "dev_account_arn" {
-  count       = "${local.dev_count}"
-  name        = "/${var.namespace}/dev/account_arn"
-  description = "AWS Account ARN"
-  type        = "String"
-  value       = "${local.dev_account_arn}"
-  overwrite   = "true"
-}
-
-resource "aws_ssm_parameter" "dev_organization_account_access_role" {
-  count       = "${local.dev_count}"
-  name        = "/${var.namespace}/dev/organization_account_access_role"
-  description = "AWS Organization Account Access Role"
-  type        = "String"
-  value       = "${local.dev_account_id}"
-  overwrite   = "true"
+module "dev" {
+  source                             = "stage"
+  namespace                          = "${var.namespace}"
+  stage                              = "dev"
+  accounts_enabled                   = "${var.accounts_enabled}"
+  account_email                      = "${var.account_email}"
+  account_iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
+  account_role_name                  = "${var.account_role_name}"
 }
 
 output "dev_account_arn" {
-  value = "${local.dev_account_arn}"
+  value = "${module.dev.account_arn}"
 }
 
 output "dev_account_id" {
-  value = "${local.dev_account_id}"
+  value = "${module.dev.account_id}"
 }
 
 output "dev_organization_account_access_role" {
-  value = "${local.dev_organization_account_access_role}"
+  value = "${module.dev.organization_account_access_role}"
 }

--- a/aws/accounts/dev.tf
+++ b/aws/accounts/dev.tf
@@ -1,5 +1,5 @@
 resource "aws_organizations_account" "dev" {
-  count                      = "${contains(var.accounts_enabled, "dev") == true ? 1 : 0}"
+  count                      = "${local.dev_count}"
   name                       = "dev"
   email                      = "${format(var.account_email, "dev")}"
   iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
@@ -7,38 +7,37 @@ resource "aws_organizations_account" "dev" {
 }
 
 locals {
+  dev_count                            = "${contains(var.accounts_enabled, "dev") == true ? 1 : 0}"
   dev_account_arn                      = "${join("", aws_organizations_account.dev.*.arn)}"
   dev_account_id                       = "${join("", aws_organizations_account.dev.*.id)}"
   dev_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.dev.*.id)}:role/OrganizationAccountAccessRole"
 }
 
-module "dev_parameters" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
-  enabled = "${contains(var.accounts_enabled, "dev") == true ? "true" : "false"}"
+resource "aws_ssm_parameter" "dev_account_id" {
+  count       = "${local.dev_count}"
+  name        = "/${var.namespace}/dev/account_id"
+  description = "AWS Account ID"
+  type        = "String"
+  value       = "${local.dev_account_id}"
+  overwrite   = "true"
+}
 
-  parameter_write = [
-    {
-      name        = "/${var.namespace}/dev/account_id"
-      value       = "${local.dev_account_id}"
-      type        = "String"
-      overwrite   = "true"
-      description = "AWS Account ID"
-    },
-    {
-      name        = "/${var.namespace}/dev/account_arn"
-      value       = "${local.dev_account_arn}"
-      type        = "String"
-      overwrite   = "true"
-      description = "AWS Account ARN"
-    },
-    {
-      name        = "/${var.namespace}/dev/organization_account_access_role"
-      value       = "${local.dev_organization_account_access_role}"
-      type        = "String"
-      overwrite   = "true"
-      description = "AWS Organization Account Access Role"
-    },
-  ]
+resource "aws_ssm_parameter" "dev_account_arn" {
+  count       = "${local.dev_count}"
+  name        = "/${var.namespace}/dev/account_arn"
+  description = "AWS Account ARN"
+  type        = "String"
+  value       = "${local.dev_account_arn}"
+  overwrite   = "true"
+}
+
+resource "aws_ssm_parameter" "dev_organization_account_access_role" {
+  count       = "${local.dev_count}"
+  name        = "/${var.namespace}/dev/organization_account_access_role"
+  description = "AWS Organization Account Access Role"
+  type        = "String"
+  value       = "${local.dev_account_id}"
+  overwrite   = "true"
 }
 
 output "dev_account_arn" {

--- a/aws/accounts/identity.tf
+++ b/aws/accounts/identity.tf
@@ -1,53 +1,21 @@
-resource "aws_organizations_account" "identity" {
-  count                      = "${local.identity_count}"
-  name                       = "identity"
-  email                      = "${format(var.account_email, "identity")}"
-  iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
-  role_name                  = "${var.account_role_name}"
-}
-
-locals {
-  identity_count                            = "${contains(var.accounts_enabled, "identity") == true ? 1 : 0}"
-  identity_account_arn                      = "${join("", aws_organizations_account.identity.*.arn)}"
-  identity_account_id                       = "${join("", aws_organizations_account.identity.*.id)}"
-  identity_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.identity.*.id)}:role/OrganizationAccountAccessRole"
-}
-
-resource "aws_ssm_parameter" "identity_account_id" {
-  count       = "${local.identity_count}"
-  name        = "/${var.namespace}/identity/account_id"
-  description = "AWS Account ID"
-  type        = "String"
-  value       = "${local.identity_account_id}"
-  overwrite   = "true"
-}
-
-resource "aws_ssm_parameter" "identity_account_arn" {
-  count       = "${local.identity_count}"
-  name        = "/${var.namespace}/identity/account_arn"
-  description = "AWS Account ARN"
-  type        = "String"
-  value       = "${local.identity_account_arn}"
-  overwrite   = "true"
-}
-
-resource "aws_ssm_parameter" "identity_organization_account_access_role" {
-  count       = "${local.identity_count}"
-  name        = "/${var.namespace}/identity/organization_account_access_role"
-  description = "AWS Organization Account Access Role"
-  type        = "String"
-  value       = "${local.identity_account_id}"
-  overwrite   = "true"
+module "identity" {
+  source                             = "stage"
+  namespace                          = "${var.namespace}"
+  stage                              = "identity"
+  accounts_enabled                   = "${var.accounts_enabled}"
+  account_email                      = "${var.account_email}"
+  account_iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
+  account_role_name                  = "${var.account_role_name}"
 }
 
 output "identity_account_arn" {
-  value = "${local.identity_account_arn}"
+  value = "${module.identity.account_arn}"
 }
 
 output "identity_account_id" {
-  value = "${local.identity_account_id}"
+  value = "${module.identity.account_id}"
 }
 
 output "identity_organization_account_access_role" {
-  value = "${local.identity_organization_account_access_role}"
+  value = "${module.identity.organization_account_access_role}"
 }

--- a/aws/accounts/identity.tf
+++ b/aws/accounts/identity.tf
@@ -1,5 +1,5 @@
 resource "aws_organizations_account" "identity" {
-  count                      = "${contains(var.accounts_enabled, "identity") == true ? 1 : 0}"
+  count                      = "${local.identity_count}"
   name                       = "identity"
   email                      = "${format(var.account_email, "identity")}"
   iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
@@ -7,38 +7,37 @@ resource "aws_organizations_account" "identity" {
 }
 
 locals {
+  identity_count                            = "${contains(var.accounts_enabled, "identity") == true ? 1 : 0}"
   identity_account_arn                      = "${join("", aws_organizations_account.identity.*.arn)}"
   identity_account_id                       = "${join("", aws_organizations_account.identity.*.id)}"
   identity_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.identity.*.id)}:role/OrganizationAccountAccessRole"
 }
 
-module "identity_parameters" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
-  enabled = "${contains(var.accounts_enabled, "identity") == true ? "true" : "false"}"
+resource "aws_ssm_parameter" "identity_account_id" {
+  count       = "${local.identity_count}"
+  name        = "/${var.namespace}/identity/account_id"
+  description = "AWS Account ID"
+  type        = "String"
+  value       = "${local.identity_account_id}"
+  overwrite   = "true"
+}
 
-  parameter_write = [
-    {
-      name        = "/${var.namespace}/identity/account_id"
-      value       = "${local.identity_account_id}"
-      type        = "String"
-      overwrite   = "true"
-      description = "AWS Account ID"
-    },
-    {
-      name        = "/${var.namespace}/identity/account_arn"
-      value       = "${local.identity_account_arn}"
-      type        = "String"
-      overwrite   = "true"
-      description = "AWS Account ARN"
-    },
-    {
-      name        = "/${var.namespace}/identity/organization_account_access_role"
-      value       = "${local.identity_organization_account_access_role}"
-      type        = "String"
-      overwrite   = "true"
-      description = "AWS Organization Account Access Role"
-    },
-  ]
+resource "aws_ssm_parameter" "identity_account_arn" {
+  count       = "${local.identity_count}"
+  name        = "/${var.namespace}/identity/account_arn"
+  description = "AWS Account ARN"
+  type        = "String"
+  value       = "${local.identity_account_arn}"
+  overwrite   = "true"
+}
+
+resource "aws_ssm_parameter" "identity_organization_account_access_role" {
+  count       = "${local.identity_count}"
+  name        = "/${var.namespace}/identity/organization_account_access_role"
+  description = "AWS Organization Account Access Role"
+  type        = "String"
+  value       = "${local.identity_account_id}"
+  overwrite   = "true"
 }
 
 output "identity_account_arn" {

--- a/aws/accounts/prod.tf
+++ b/aws/accounts/prod.tf
@@ -1,53 +1,21 @@
-resource "aws_organizations_account" "prod" {
-  count                      = "${local.prod_count}"
-  name                       = "prod"
-  email                      = "${format(var.account_email, "prod")}"
-  iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
-  role_name                  = "${var.account_role_name}"
-}
-
-locals {
-  prod_count                            = "${contains(var.accounts_enabled, "prod") == true ? 1 : 0}"
-  prod_account_arn                      = "${join("", aws_organizations_account.prod.*.arn)}"
-  prod_account_id                       = "${join("", aws_organizations_account.prod.*.id)}"
-  prod_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.prod.*.id)}:role/OrganizationAccountAccessRole"
-}
-
-resource "aws_ssm_parameter" "prod_account_id" {
-  count       = "${local.prod_count}"
-  name        = "/${var.namespace}/prod/account_id"
-  description = "AWS Account ID"
-  type        = "String"
-  value       = "${local.prod_account_id}"
-  overwrite   = "true"
-}
-
-resource "aws_ssm_parameter" "prod_account_arn" {
-  count       = "${local.prod_count}"
-  name        = "/${var.namespace}/prod/account_arn"
-  description = "AWS Account ARN"
-  type        = "String"
-  value       = "${local.prod_account_arn}"
-  overwrite   = "true"
-}
-
-resource "aws_ssm_parameter" "prod_organization_account_access_role" {
-  count       = "${local.prod_count}"
-  name        = "/${var.namespace}/prod/organization_account_access_role"
-  description = "AWS Organization Account Access Role"
-  type        = "String"
-  value       = "${local.prod_account_id}"
-  overwrite   = "true"
+module "prod" {
+  source                             = "stage"
+  namespace                          = "${var.namespace}"
+  stage                              = "prod"
+  accounts_enabled                   = "${var.accounts_enabled}"
+  account_email                      = "${var.account_email}"
+  account_iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
+  account_role_name                  = "${var.account_role_name}"
 }
 
 output "prod_account_arn" {
-  value = "${local.prod_account_arn}"
+  value = "${module.prod.account_arn}"
 }
 
 output "prod_account_id" {
-  value = "${local.prod_account_id}"
+  value = "${module.prod.account_id}"
 }
 
 output "prod_organization_account_access_role" {
-  value = "${local.prod_organization_account_access_role}"
+  value = "${module.prod.organization_account_access_role}"
 }

--- a/aws/accounts/prod.tf
+++ b/aws/accounts/prod.tf
@@ -1,5 +1,5 @@
 resource "aws_organizations_account" "prod" {
-  count                      = "${contains(var.accounts_enabled, "prod") == true ? 1 : 0}"
+  count                      = "${local.prod_count}"
   name                       = "prod"
   email                      = "${format(var.account_email, "prod")}"
   iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
@@ -7,38 +7,37 @@ resource "aws_organizations_account" "prod" {
 }
 
 locals {
+  prod_count                            = "${contains(var.accounts_enabled, "prod") == true ? 1 : 0}"
   prod_account_arn                      = "${join("", aws_organizations_account.prod.*.arn)}"
   prod_account_id                       = "${join("", aws_organizations_account.prod.*.id)}"
   prod_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.prod.*.id)}:role/OrganizationAccountAccessRole"
 }
 
-module "prod_parameters" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
-  enabled = "${contains(var.accounts_enabled, "prod") == true ? "true" : "false"}"
+resource "aws_ssm_parameter" "prod_account_id" {
+  count       = "${local.prod_count}"
+  name        = "/${var.namespace}/prod/account_id"
+  description = "AWS Account ID"
+  type        = "String"
+  value       = "${local.prod_account_id}"
+  overwrite   = "true"
+}
 
-  parameter_write = [
-    {
-      name        = "/${var.namespace}/prod/account_id"
-      value       = "${local.prod_account_id}"
-      type        = "String"
-      overwrite   = "true"
-      description = "AWS Account ID"
-    },
-    {
-      name        = "/${var.namespace}/prod/account_arn"
-      value       = "${local.prod_account_arn}"
-      type        = "String"
-      overwrite   = "true"
-      description = "AWS Account ARN"
-    },
-    {
-      name        = "/${var.namespace}/prod/organization_account_access_role"
-      value       = "${local.prod_organization_account_access_role}"
-      type        = "String"
-      overwrite   = "true"
-      description = "AWS Organization Account Access Role"
-    },
-  ]
+resource "aws_ssm_parameter" "prod_account_arn" {
+  count       = "${local.prod_count}"
+  name        = "/${var.namespace}/prod/account_arn"
+  description = "AWS Account ARN"
+  type        = "String"
+  value       = "${local.prod_account_arn}"
+  overwrite   = "true"
+}
+
+resource "aws_ssm_parameter" "prod_organization_account_access_role" {
+  count       = "${local.prod_count}"
+  name        = "/${var.namespace}/prod/organization_account_access_role"
+  description = "AWS Organization Account Access Role"
+  type        = "String"
+  value       = "${local.prod_account_id}"
+  overwrite   = "true"
 }
 
 output "prod_account_arn" {

--- a/aws/accounts/security.tf
+++ b/aws/accounts/security.tf
@@ -1,53 +1,21 @@
-resource "aws_organizations_account" "security" {
-  count                      = "${local.security_count}"
-  name                       = "security"
-  email                      = "${format(var.account_email, "security")}"
-  iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
-  role_name                  = "${var.account_role_name}"
-}
-
-locals {
-  security_count                            = "${contains(var.accounts_enabled, "security") == true ? 1 : 0}"
-  security_account_arn                      = "${join("", aws_organizations_account.security.*.arn)}"
-  security_account_id                       = "${join("", aws_organizations_account.security.*.id)}"
-  security_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.security.*.id)}:role/OrganizationAccountAccessRole"
-}
-
-resource "aws_ssm_parameter" "security_account_id" {
-  count       = "${local.security_count}"
-  name        = "/${var.namespace}/security/account_id"
-  description = "AWS Account ID"
-  type        = "String"
-  value       = "${local.security_account_id}"
-  overwrite   = "true"
-}
-
-resource "aws_ssm_parameter" "security_account_arn" {
-  count       = "${local.security_count}"
-  name        = "/${var.namespace}/security/account_arn"
-  description = "AWS Account ARN"
-  type        = "String"
-  value       = "${local.security_account_arn}"
-  overwrite   = "true"
-}
-
-resource "aws_ssm_parameter" "security_organization_account_access_role" {
-  count       = "${local.security_count}"
-  name        = "/${var.namespace}/security/organization_account_access_role"
-  description = "AWS Organization Account Access Role"
-  type        = "String"
-  value       = "${local.security_account_id}"
-  overwrite   = "true"
+module "security" {
+  source                             = "stage"
+  namespace                          = "${var.namespace}"
+  stage                              = "security"
+  accounts_enabled                   = "${var.accounts_enabled}"
+  account_email                      = "${var.account_email}"
+  account_iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
+  account_role_name                  = "${var.account_role_name}"
 }
 
 output "security_account_arn" {
-  value = "${local.security_account_arn}"
+  value = "${module.security.account_arn}"
 }
 
 output "security_account_id" {
-  value = "${local.security_account_id}"
+  value = "${module.security.account_id}"
 }
 
 output "security_organization_account_access_role" {
-  value = "${local.security_organization_account_access_role}"
+  value = "${module.security.organization_account_access_role}"
 }

--- a/aws/accounts/security.tf
+++ b/aws/accounts/security.tf
@@ -1,5 +1,5 @@
 resource "aws_organizations_account" "security" {
-  count                      = "${contains(var.accounts_enabled, "security") == true ? 1 : 0}"
+  count                      = "${local.security_count}"
   name                       = "security"
   email                      = "${format(var.account_email, "security")}"
   iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
@@ -7,38 +7,37 @@ resource "aws_organizations_account" "security" {
 }
 
 locals {
+  security_count                            = "${contains(var.accounts_enabled, "security") == true ? 1 : 0}"
   security_account_arn                      = "${join("", aws_organizations_account.security.*.arn)}"
   security_account_id                       = "${join("", aws_organizations_account.security.*.id)}"
   security_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.security.*.id)}:role/OrganizationAccountAccessRole"
 }
 
-module "security_parameters" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
-  enabled = "${contains(var.accounts_enabled, "security") == true ? "true" : "false"}"
+resource "aws_ssm_parameter" "security_account_id" {
+  count       = "${local.security_count}"
+  name        = "/${var.namespace}/security/account_id"
+  description = "AWS Account ID"
+  type        = "String"
+  value       = "${local.security_account_id}"
+  overwrite   = "true"
+}
 
-  parameter_write = [
-    {
-      name        = "/${var.namespace}/security/account_id"
-      value       = "${local.security_account_id}"
-      type        = "String"
-      overwrite   = "true"
-      description = "AWS Account ID"
-    },
-    {
-      name        = "/${var.namespace}/security/account_arn"
-      value       = "${local.security_account_arn}"
-      type        = "String"
-      overwrite   = "true"
-      description = "AWS Account ARN"
-    },
-    {
-      name        = "/${var.namespace}/security/organization_account_access_role"
-      value       = "${local.security_organization_account_access_role}"
-      type        = "String"
-      overwrite   = "true"
-      description = "AWS Organization Account Access Role"
-    },
-  ]
+resource "aws_ssm_parameter" "security_account_arn" {
+  count       = "${local.security_count}"
+  name        = "/${var.namespace}/security/account_arn"
+  description = "AWS Account ARN"
+  type        = "String"
+  value       = "${local.security_account_arn}"
+  overwrite   = "true"
+}
+
+resource "aws_ssm_parameter" "security_organization_account_access_role" {
+  count       = "${local.security_count}"
+  name        = "/${var.namespace}/security/organization_account_access_role"
+  description = "AWS Organization Account Access Role"
+  type        = "String"
+  value       = "${local.security_account_id}"
+  overwrite   = "true"
 }
 
 output "security_account_arn" {

--- a/aws/accounts/stage/main.tf
+++ b/aws/accounts/stage/main.tf
@@ -1,0 +1,41 @@
+resource "aws_organizations_account" "default" {
+  count                      = "${local.count}"
+  name                       = "${var.stage}"
+  email                      = "${format(var.account_email, var.stage)}"
+  iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
+  role_name                  = "${var.account_role_name}"
+}
+
+locals {
+  count                            = "${contains(var.accounts_enabled, var.stage) == true ? 1 : 0}"
+  account_arn                      = "${join("", aws_organizations_account.default.*.arn)}"
+  account_id                       = "${join("", aws_organizations_account.default.*.id)}"
+  organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.default.*.id)}:role/OrganizationAccountAccessRole"
+}
+
+resource "aws_ssm_parameter" "account_id" {
+  count       = "${local.count}"
+  name        = "/${var.namespace}/${var.stage}/account_id"
+  description = "AWS Account ID"
+  type        = "String"
+  value       = "${local.account_id}"
+  overwrite   = "true"
+}
+
+resource "aws_ssm_parameter" "account_arn" {
+  count       = "${local.count}"
+  name        = "/${var.namespace}/${var.stage}/account_arn"
+  description = "AWS Account ARN"
+  type        = "String"
+  value       = "${local.account_arn}"
+  overwrite   = "true"
+}
+
+resource "aws_ssm_parameter" "organization_account_access_role" {
+  count       = "${local.count}"
+  name        = "/${var.namespace}/${var.stage}/organization_account_access_role"
+  description = "AWS Organization Account Access Role"
+  type        = "String"
+  value       = "${local.organization_account_access_role}"
+  overwrite   = "true"
+}

--- a/aws/accounts/stage/outputs.tf
+++ b/aws/accounts/stage/outputs.tf
@@ -1,0 +1,11 @@
+output "account_arn" {
+  value = "${local.account_arn}"
+}
+
+output "account_id" {
+  value = "${local.account_id}"
+}
+
+output "organization_account_access_role" {
+  value = "${local.organization_account_access_role}"
+}

--- a/aws/accounts/stage/variables.tf
+++ b/aws/accounts/stage/variables.tf
@@ -1,0 +1,30 @@
+variable "namespace" {
+  type        = "string"
+  description = "Namespace (e.g. `cp` or `cloudposse`)"
+}
+
+variable "stage" {
+  type        = "string"
+  description = "Stage (e.g. `audit`)"
+  default     = "audit"
+}
+
+variable "account_role_name" {
+  type        = "string"
+  description = "IAM role that Organization automatically preconfigures in the new member account"
+}
+
+variable "account_email" {
+  type        = "string"
+  description = "Email address format for accounts (e.g. `%s@cloudposse.co`)"
+}
+
+variable "account_iam_user_access_to_billing" {
+  type        = "string"
+  description = "If set to `ALLOW`, the new account enables IAM users to access account billing information if they have the required permissions. If set to `DENY`, then only the root user of the new account can access account billing information"
+}
+
+variable "accounts_enabled" {
+  type        = "list"
+  description = "Accounts to enable"
+}

--- a/aws/accounts/stage/variables.tf
+++ b/aws/accounts/stage/variables.tf
@@ -6,7 +6,6 @@ variable "namespace" {
 variable "stage" {
   type        = "string"
   description = "Stage (e.g. `audit`)"
-  default     = "audit"
 }
 
 variable "account_role_name" {

--- a/aws/accounts/staging.tf
+++ b/aws/accounts/staging.tf
@@ -1,53 +1,21 @@
-resource "aws_organizations_account" "staging" {
-  count                      = "${local.staging_count}"
-  name                       = "staging"
-  email                      = "${format(var.account_email, "staging")}"
-  iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
-  role_name                  = "${var.account_role_name}"
-}
-
-locals {
-  staging_count                            = "${contains(var.accounts_enabled, "staging") == true ? 1 : 0}"
-  staging_account_arn                      = "${join("", aws_organizations_account.staging.*.arn)}"
-  staging_account_id                       = "${join("", aws_organizations_account.staging.*.id)}"
-  staging_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.staging.*.id)}:role/OrganizationAccountAccessRole"
-}
-
-resource "aws_ssm_parameter" "staging_account_id" {
-  count       = "${local.staging_count}"
-  name        = "/${var.namespace}/staging/account_id"
-  description = "AWS Account ID"
-  type        = "String"
-  value       = "${local.staging_account_id}"
-  overwrite   = "true"
-}
-
-resource "aws_ssm_parameter" "staging_account_arn" {
-  count       = "${local.staging_count}"
-  name        = "/${var.namespace}/staging/account_arn"
-  description = "AWS Account ARN"
-  type        = "String"
-  value       = "${local.staging_account_arn}"
-  overwrite   = "true"
-}
-
-resource "aws_ssm_parameter" "staging_organization_account_access_role" {
-  count       = "${local.staging_count}"
-  name        = "/${var.namespace}/staging/organization_account_access_role"
-  description = "AWS Organization Account Access Role"
-  type        = "String"
-  value       = "${local.staging_account_id}"
-  overwrite   = "true"
+module "staging" {
+  source                             = "stage"
+  namespace                          = "${var.namespace}"
+  stage                              = "staging"
+  accounts_enabled                   = "${var.accounts_enabled}"
+  account_email                      = "${var.account_email}"
+  account_iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
+  account_role_name                  = "${var.account_role_name}"
 }
 
 output "staging_account_arn" {
-  value = "${local.staging_account_arn}"
+  value = "${module.staging.account_arn}"
 }
 
 output "staging_account_id" {
-  value = "${local.staging_account_id}"
+  value = "${module.staging.account_id}"
 }
 
 output "staging_organization_account_access_role" {
-  value = "${local.staging_organization_account_access_role}"
+  value = "${module.staging.organization_account_access_role}"
 }

--- a/aws/accounts/testing.tf
+++ b/aws/accounts/testing.tf
@@ -1,53 +1,21 @@
-resource "aws_organizations_account" "testing" {
-  count                      = "${local.testing_count}"
-  name                       = "testing"
-  email                      = "${format(var.account_email, "testing")}"
-  iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
-  role_name                  = "${var.account_role_name}"
-}
-
-locals {
-  testing_count                            = "${contains(var.accounts_enabled, "testing") == true ? 1 : 0}"
-  testing_account_arn                      = "${join("", aws_organizations_account.testing.*.arn)}"
-  testing_account_id                       = "${join("", aws_organizations_account.testing.*.id)}"
-  testing_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.testing.*.id)}:role/OrganizationAccountAccessRole"
-}
-
-resource "aws_ssm_parameter" "testing_account_id" {
-  count       = "${local.testing_count}"
-  name        = "/${var.namespace}/testing/account_id"
-  description = "AWS Account ID"
-  type        = "String"
-  value       = "${local.testing_account_id}"
-  overwrite   = "true"
-}
-
-resource "aws_ssm_parameter" "testing_account_arn" {
-  count       = "${local.testing_count}"
-  name        = "/${var.namespace}/testing/account_arn"
-  description = "AWS Account ARN"
-  type        = "String"
-  value       = "${local.testing_account_arn}"
-  overwrite   = "true"
-}
-
-resource "aws_ssm_parameter" "testing_organization_account_access_role" {
-  count       = "${local.testing_count}"
-  name        = "/${var.namespace}/testing/organization_account_access_role"
-  description = "AWS Organization Account Access Role"
-  type        = "String"
-  value       = "${local.testing_account_id}"
-  overwrite   = "true"
+module "testing" {
+  source                             = "stage"
+  namespace                          = "${var.namespace}"
+  stage                              = "testing"
+  accounts_enabled                   = "${var.accounts_enabled}"
+  account_email                      = "${var.account_email}"
+  account_iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
+  account_role_name                  = "${var.account_role_name}"
 }
 
 output "testing_account_arn" {
-  value = "${local.testing_account_arn}"
+  value = "${module.testing.account_arn}"
 }
 
 output "testing_account_id" {
-  value = "${local.testing_account_id}"
+  value = "${module.testing.account_id}"
 }
 
 output "testing_organization_account_access_role" {
-  value = "${local.testing_organization_account_access_role}"
+  value = "${module.testing.organization_account_access_role}"
 }

--- a/aws/accounts/testing.tf
+++ b/aws/accounts/testing.tf
@@ -1,5 +1,5 @@
 resource "aws_organizations_account" "testing" {
-  count                      = "${contains(var.accounts_enabled, "testing") == true ? 1 : 0}"
+  count                      = "${local.testing_count}"
   name                       = "testing"
   email                      = "${format(var.account_email, "testing")}"
   iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
@@ -7,38 +7,37 @@ resource "aws_organizations_account" "testing" {
 }
 
 locals {
+  testing_count                            = "${contains(var.accounts_enabled, "testing") == true ? 1 : 0}"
   testing_account_arn                      = "${join("", aws_organizations_account.testing.*.arn)}"
   testing_account_id                       = "${join("", aws_organizations_account.testing.*.id)}"
   testing_organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.testing.*.id)}:role/OrganizationAccountAccessRole"
 }
 
-module "testing_parameters" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
-  enabled = "${contains(var.accounts_enabled, "testing") == true ? "true" : "false"}"
+resource "aws_ssm_parameter" "testing_account_id" {
+  count       = "${local.testing_count}"
+  name        = "/${var.namespace}/testing/account_id"
+  description = "AWS Account ID"
+  type        = "String"
+  value       = "${local.testing_account_id}"
+  overwrite   = "true"
+}
 
-  parameter_write = [
-    {
-      name        = "/${var.namespace}/testing/account_id"
-      value       = "${local.testing_account_id}"
-      type        = "String"
-      overwrite   = "true"
-      description = "AWS Account ID"
-    },
-    {
-      name        = "/${var.namespace}/testing/account_arn"
-      value       = "${local.testing_account_arn}"
-      type        = "String"
-      overwrite   = "true"
-      description = "AWS Account ARN"
-    },
-    {
-      name        = "/${var.namespace}/testing/organization_account_access_role"
-      value       = "${local.testing_organization_account_access_role}"
-      type        = "String"
-      overwrite   = "true"
-      description = "AWS Organization Account Access Role"
-    },
-  ]
+resource "aws_ssm_parameter" "testing_account_arn" {
+  count       = "${local.testing_count}"
+  name        = "/${var.namespace}/testing/account_arn"
+  description = "AWS Account ARN"
+  type        = "String"
+  value       = "${local.testing_account_arn}"
+  overwrite   = "true"
+}
+
+resource "aws_ssm_parameter" "testing_organization_account_access_role" {
+  count       = "${local.testing_count}"
+  name        = "/${var.namespace}/testing/organization_account_access_role"
+  description = "AWS Organization Account Access Role"
+  type        = "String"
+  value       = "${local.testing_account_id}"
+  overwrite   = "true"
 }
 
 output "testing_account_arn" {


### PR DESCRIPTION
## what
* Define `aws_ssm_parameter` parameters directly rather than rely on ssm module
* Use a submodule to reduce copy/pasta mistakes

## why
* `value of 'count' cannot be computed` errors
* Do not want to update `terraform-aws-ssm-parameter-store` to pass in count explicitly (no added benefit at this point)

## upgrading
* You'll need to migrate the state for accounts to the submodule

```
terraform state mv aws_organizations_account.audit  module.audit.aws_organizations_account.default
terraform state mv aws_organizations_account.staging  module.staging.aws_organizations_account.default
# ...
```