### PR TITLE
[aws/users] Add signin url output

### DIFF
--- a/aws/users/main.tf
+++ b/aws/users/main.tf
@@ -36,5 +36,11 @@ locals {
 }
 
 output "account_alias" {
-  value = "${local.account_alias}"
+  description = "AWS IAM Account Alias"
+  value       = "${local.account_alias}"
+}
+
+output "signin_url" {
+  description = "AWS Signin URL"
+  value       = "${local.signin_url}"
 }


### PR DESCRIPTION
## what
* Add `signin_url` output

## why
* Make it easier to "copy and paste" login information =)