### PR TITLE
[users] dynamic account groups

### DIFF
--- a/aws/iam/audit.tf
+++ b/aws/iam/audit.tf
@@ -15,3 +15,18 @@ module "organization_access_group_audit" {
   member_account_id = "${data.terraform_remote_state.accounts.audit_account_id}"
   require_mfa       = "true"
 }
+
+module "organization_access_group_ssm_audit" {
+  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
+  enabled = "${contains(var.accounts_enabled, "audit") == true ? "true" : "false"}"
+
+  parameter_write = [
+    {
+      name        = "/${var.namespace}/audit/admin_group"
+      value       = "${module.organization_access_group_audit.group_name}"
+      type        = "String"
+      overwrite   = "true"
+      description = "IAM admin group name for the 'audit' account"
+    },
+  ]
+}

--- a/aws/iam/corp.tf
+++ b/aws/iam/corp.tf
@@ -15,3 +15,18 @@ module "organization_access_group_corp" {
   member_account_id = "${data.terraform_remote_state.accounts.corp_account_id}"
   require_mfa       = "true"
 }
+
+module "organization_access_group_ssm_corp" {
+  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
+  enabled = "${contains(var.accounts_enabled, "corp") == true ? "true" : "false"}"
+
+  parameter_write = [
+    {
+      name        = "/${var.namespace}/corp/admin_group"
+      value       = "${module.organization_access_group_corp.group_name}"
+      type        = "String"
+      overwrite   = "true"
+      description = "IAM admin group name for the 'corp' account"
+    },
+  ]
+}

--- a/aws/iam/data.tf
+++ b/aws/iam/data.tf
@@ -15,3 +15,18 @@ module "organization_access_group_data" {
   member_account_id = "${data.terraform_remote_state.accounts.data_account_id}"
   require_mfa       = "true"
 }
+
+module "organization_access_group_ssm_data" {
+  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
+  enabled = "${contains(var.accounts_enabled, "data") == true ? "true" : "false"}"
+
+  parameter_write = [
+    {
+      name        = "/${var.namespace}/data/admin_group"
+      value       = "${module.organization_access_group_data.group_name}"
+      type        = "String"
+      overwrite   = "true"
+      description = "IAM admin group name for the 'data' account"
+    },
+  ]
+}

--- a/aws/iam/dev.tf
+++ b/aws/iam/dev.tf
@@ -15,3 +15,18 @@ module "organization_access_group_dev" {
   member_account_id = "${data.terraform_remote_state.accounts.dev_account_id}"
   require_mfa       = "true"
 }
+
+module "organization_access_group_ssm_dev" {
+  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
+  enabled = "${contains(var.accounts_enabled, "dev") == true ? "true" : "false"}"
+
+  parameter_write = [
+    {
+      name        = "/${var.namespace}/dev/admin_group"
+      value       = "${module.organization_access_group_dev.group_name}"
+      type        = "String"
+      overwrite   = "true"
+      description = "IAM admin group name for the 'dev' account"
+    },
+  ]
+}

--- a/aws/iam/identity.tf
+++ b/aws/iam/identity.tf
@@ -15,3 +15,18 @@ module "organization_access_group_identity" {
   member_account_id = "${data.terraform_remote_state.accounts.identity_account_id}"
   require_mfa       = "true"
 }
+
+module "organization_access_group_ssm_identity" {
+  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
+  enabled = "${contains(var.accounts_enabled, "identity") == true ? "true" : "false"}"
+
+  parameter_write = [
+    {
+      name        = "/${var.namespace}/identity/admin_group"
+      value       = "${module.organization_access_group_identity.group_name}"
+      type        = "String"
+      overwrite   = "true"
+      description = "IAM admin group name for the 'identity' account"
+    },
+  ]
+}

--- a/aws/iam/prod.tf
+++ b/aws/iam/prod.tf
@@ -15,3 +15,18 @@ module "organization_access_group_prod" {
   member_account_id = "${data.terraform_remote_state.accounts.prod_account_id}"
   require_mfa       = "true"
 }
+
+module "organization_access_group_ssm_prod" {
+  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
+  enabled = "${contains(var.accounts_enabled, "prod") == true ? "true" : "false"}"
+
+  parameter_write = [
+    {
+      name        = "/${var.namespace}/prod/admin_group"
+      value       = "${module.organization_access_group_prod.group_name}"
+      type        = "String"
+      overwrite   = "true"
+      description = "IAM admin group name for the 'prod' account"
+    },
+  ]
+}

--- a/aws/iam/security.tf
+++ b/aws/iam/security.tf
@@ -15,3 +15,18 @@ module "organization_access_group_security" {
   member_account_id = "${data.terraform_remote_state.accounts.security_account_id}"
   require_mfa       = "true"
 }
+
+module "organization_access_group_ssm_security" {
+  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
+  enabled = "${contains(var.accounts_enabled, "security") == true ? "true" : "false"}"
+
+  parameter_write = [
+    {
+      name        = "/${var.namespace}/security/admin_group"
+      value       = "${module.organization_access_group_security.group_name}"
+      type        = "String"
+      overwrite   = "true"
+      description = "IAM admin group name for the 'security' account"
+    },
+  ]
+}

--- a/aws/iam/staging.tf
+++ b/aws/iam/staging.tf
@@ -15,3 +15,18 @@ module "organization_access_group_staging" {
   member_account_id = "${data.terraform_remote_state.accounts.staging_account_id}"
   require_mfa       = "true"
 }
+
+module "organization_access_group_ssm_staging" {
+  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
+  enabled = "${contains(var.accounts_enabled, "staging") == true ? "true" : "false"}"
+
+  parameter_write = [
+    {
+      name        = "/${var.namespace}/staging/admin_group"
+      value       = "${module.organization_access_group_staging.group_name}"
+      type        = "String"
+      overwrite   = "true"
+      description = "IAM admin group name for the 'staging' account"
+    },
+  ]
+}

--- a/aws/iam/testing.tf
+++ b/aws/iam/testing.tf
@@ -15,3 +15,18 @@ module "organization_access_group_testing" {
   member_account_id = "${data.terraform_remote_state.accounts.testing_account_id}"
   require_mfa       = "true"
 }
+
+module "organization_access_group_ssm_testing" {
+  source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
+  enabled = "${contains(var.accounts_enabled, "testing") == true ? "true" : "false"}"
+
+  parameter_write = [
+    {
+      name        = "/${var.namespace}/testing/admin_group"
+      value       = "${module.organization_access_group_testing.group_name}"
+      type        = "String"
+      overwrite   = "true"
+      description = "IAM admin group name for the 'testing' account"
+    },
+  ]
+}

--- a/aws/root-iam/main.tf
+++ b/aws/root-iam/main.tf
@@ -4,15 +4,6 @@ terraform {
   backend "s3" {}
 }
 
-variable "aws_assume_role_arn" {
-  type = "string"
-}
-
-variable "namespace" {
-  type        = "string"
-  description = "Namespace (e.g. `cp` or `cloudposse`)"
-}
-
 provider "aws" {
   assume_role {
     role_arn = "${var.aws_assume_role_arn}"

--- a/aws/root-iam/root.tf
+++ b/aws/root-iam/root.tf
@@ -21,6 +21,27 @@ module "organization_access_group_root" {
   readonly_user_names = ["${var.root_account_readonly_user_names}"]
 }
 
+module "organization_access_group_ssm_root" {
+  source = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
+
+  parameter_write = [
+    {
+      name        = "/${var.namespace}/${var.stage}/admin_group"
+      value       = "${module.organization_access_group_root.group_admin_name}"
+      type        = "String"
+      overwrite   = "true"
+      description = "IAM admin group name for the '${var.stage}' account"
+    },
+    {
+      name        = "/${var.namespace}/${var.stage}/readonly_group"
+      value       = "${module.organization_access_group_root.group_readonly_name}"
+      type        = "String"
+      overwrite   = "true"
+      description = "IAM readonly group name for the '${var.stage}' account"
+    },
+  ]
+}
+
 output "admin_group" {
   value = "${module.organization_access_group_root.group_admin_name}"
 }

--- a/aws/root-iam/variables.tf
+++ b/aws/root-iam/variables.tf
@@ -1,0 +1,13 @@
+variable "aws_assume_role_arn" {
+  type = "string"
+}
+
+variable "namespace" {
+  type        = "string"
+  description = "Namespace (e.g. `cp` or `cloudposse`)"
+}
+
+variable "stage" {
+  type        = "string"
+  description = "Stage (e.g. `prod`, `dev`, `staging`)"
+}

--- a/aws/users/main.tf
+++ b/aws/users/main.tf
@@ -28,10 +28,16 @@ data "terraform_remote_state" "root_iam" {
   }
 }
 
+# Fetch the OrganizationAccountAccessRole ARNs from SSM
+module "admin_groups" {
+  source         = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
+  parameter_read = "${formatlist("/${var.namespace}/%s/admin_group", var.accounts_enabled)}"
+}
+
 locals {
   account_alias   = "${data.terraform_remote_state.account_settings.account_alias}"
   signin_url      = "${data.terraform_remote_state.account_settings.signin_url}"
-  admin_groups    = ["${data.terraform_remote_state.root_iam.admin_group}"]
+  admin_groups    = ["${module.admin_groups.values}"]
   readonly_groups = ["${data.terraform_remote_state.root_iam.readonly_group}"]
 }
 

--- a/aws/users/variables.tf
+++ b/aws/users/variables.tf
@@ -38,3 +38,9 @@ variable "smtp_port" {
   description = "SMTP Port"
   default     = "587"
 }
+
+variable "accounts_enabled" {
+  type        = "list"
+  description = "Accounts to enable"
+  default     = ["dev", "staging", "prod", "testing", "audit"]
+}


### PR DESCRIPTION
## what
* Write admin/readonly groups to SSM
* Use groups from SSM to determine membership for `admin_groups`

## why
* Support a dynamic list of admin groups for an arbitrary number of AWS accounts
