### PR TITLE
[backing-services] Add flags, change defaults to false

### DIFF
--- a/aws/backing-services/aurora-postgres.tf
+++ b/aws/backing-services/aurora-postgres.tf
@@ -39,7 +39,7 @@ variable "postgres_cluster_size" {
 
 variable "postgres_cluster_enabled" {
   type        = "string"
-  default     = "true"
+  default     = "false"
   description = "Set to false to prevent the module from creating any resources"
 }
 

--- a/aws/backing-services/elasticache-redis.tf
+++ b/aws/backing-services/elasticache-redis.tf
@@ -18,7 +18,7 @@ variable "redis_cluster_size" {
 
 variable "redis_cluster_enabled" {
   type        = "string"
-  default     = "true"
+  default     = "false"
   description = "Set to false to prevent the module from creating any resources"
 }
 

--- a/aws/backing-services/elasticsearch.tf
+++ b/aws/backing-services/elasticsearch.tf
@@ -43,7 +43,7 @@ variable "elasticsearch_iam_actions" {
 
 variable "elasticsearch_enabled" {
   type        = "string"
-  default     = "true"
+  default     = "false"
   description = "Set to false to prevent the module from creating any resources"
 }
 

--- a/aws/backing-services/kops-metadata.tf
+++ b/aws/backing-services/kops-metadata.tf
@@ -1,4 +1,11 @@
+variables "kops_metadata_enabled" {
+  description = "Set to false to prevent the module from creating any resources"
+  type        = "string"
+  default     = "false"
+}
+
 module "kops_metadata" {
   source   = "git::https://github.com/cloudposse/terraform-aws-kops-metadata.git?ref=tags/0.2.0"
   dns_zone = "${var.region}.${var.zone_name}"
+  enabled  = "${var.kops_metadata_enabled}"
 }


### PR DESCRIPTION
## what
* Ensure all backing services have flags
* Default flags to false

## why
* The default state should be disabled for everything, so we explicitly enable services

## upgrading

To maintain backwards compatibility, create a `terraform.tfvars` file with the following content:

```
postgres_cluster_enabled = "true"
redis_cluster_enabled = "true"
elasticsearch_enabled = "true"
kops_metadata_enabled = "true"
```