### PR TITLE
[*/Makefile] Use explicit targets 

### DIFF
--- a/aws/account-dns/Makefile
+++ b/aws/account-dns/Makefile
@@ -1,11 +1,15 @@
 ## Initialize terraform remote state
 init:
-	[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
 	terraform $@

--- a/aws/account-settings/Makefile
+++ b/aws/account-settings/Makefile
@@ -1,11 +1,15 @@
 ## Initialize terraform remote state
 init:
-	[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
 	terraform $@

--- a/aws/accounts/Makefile
+++ b/aws/accounts/Makefile
@@ -1,11 +1,15 @@
 ## Initialize terraform remote state
 init:
-	[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
 	terraform $@

--- a/aws/acm-cloudfront/Makefile
+++ b/aws/acm-cloudfront/Makefile
@@ -1,11 +1,15 @@
 ## Initialize terraform remote state
 init:
-	[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
 	terraform $@

--- a/aws/acm/Makefile
+++ b/aws/acm/Makefile
@@ -1,11 +1,15 @@
 ## Initialize terraform remote state
 init:
-	[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
 	terraform $@

--- a/aws/audit-cloudtrail/Makefile
+++ b/aws/audit-cloudtrail/Makefile
@@ -1,11 +1,15 @@
 ## Initialize terraform remote state
 init:
-	[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
 	terraform $@

--- a/aws/backing-services/Makefile
+++ b/aws/backing-services/Makefile
@@ -1,11 +1,15 @@
 ## Initialize terraform remote state
 init:
-	[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
 	terraform $@

--- a/aws/bootstrap/Makefile
+++ b/aws/bootstrap/Makefile
@@ -1,11 +1,15 @@
 ## Initialize terraform remote state
 init:
-	[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
 	terraform $@

--- a/aws/chamber/Makefile
+++ b/aws/chamber/Makefile
@@ -1,11 +1,15 @@
 ## Initialize terraform remote state
 init:
-	[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
 	terraform $@

--- a/aws/cloudtrail/Makefile
+++ b/aws/cloudtrail/Makefile
@@ -1,11 +1,15 @@
 ## Initialize terraform remote state
 init:
-	[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
 	terraform $@

--- a/aws/docs/Makefile
+++ b/aws/docs/Makefile
@@ -1,11 +1,15 @@
 ## Initialize terraform remote state
 init:
-	[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
 	terraform $@

--- a/aws/ecr/Makefile
+++ b/aws/ecr/Makefile
@@ -1,11 +1,15 @@
 ## Initialize terraform remote state
 init:
-	[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
 	terraform $@

--- a/aws/eks-backing-services-peering/Makefile
+++ b/aws/eks-backing-services-peering/Makefile
@@ -1,11 +1,15 @@
 ## Initialize terraform remote state
 init:
-	[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
 	terraform $@

--- a/aws/eks/Makefile
+++ b/aws/eks/Makefile
@@ -1,11 +1,15 @@
 ## Initialize terraform remote state
 init:
-	[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
 	terraform $@

--- a/aws/iam/Makefile
+++ b/aws/iam/Makefile
@@ -1,11 +1,15 @@
 ## Initialize terraform remote state
 init:
-	[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
 	terraform $@

--- a/aws/kops-aws-platform/Makefile
+++ b/aws/kops-aws-platform/Makefile
@@ -1,11 +1,15 @@
 ## Initialize terraform remote state
 init:
-	[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
 	terraform $@

--- a/aws/kops/Makefile
+++ b/aws/kops/Makefile
@@ -1,11 +1,15 @@
 ## Initialize terraform remote state
 init:
-	[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
 	terraform $@

--- a/aws/organization/Makefile
+++ b/aws/organization/Makefile
@@ -1,11 +1,15 @@
 ## Initialize terraform remote state
 init:
-	[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
 	terraform $@

--- a/aws/root-dns/Makefile
+++ b/aws/root-dns/Makefile
@@ -1,11 +1,15 @@
 ## Initialize terraform remote state
 init:
-	[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
 	terraform $@

--- a/aws/root-iam/Makefile
+++ b/aws/root-iam/Makefile
@@ -1,11 +1,15 @@
 ## Initialize terraform remote state
 init:
-	[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
 	terraform $@

--- a/aws/ses/Makefile
+++ b/aws/ses/Makefile
@@ -1,12 +1,17 @@
 -include .terraform/modules/**/Makefile.ses
 ## Initialize terraform remote state
 init:
-	[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
 	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
+	terraform $@
+

--- a/aws/tfstate-backend/Makefile
+++ b/aws/tfstate-backend/Makefile
@@ -2,7 +2,7 @@
 init:
 	@aws s3 ls s3://${TF_BUCKET}/tfstate-backend/terraform.tfstate > /dev/null || \
 		scripts/$@.sh
-	@[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Destroy the configuration (only works if `force_destroy=true`)
 destroy:
@@ -16,6 +16,10 @@ force-destroy:
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
 	terraform $@

--- a/aws/users/Makefile
+++ b/aws/users/Makefile
@@ -1,11 +1,15 @@
 ## Initialize terraform remote state
 init:
-	[ -d .terraform ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
 clean:
 	rm -rf .terraform *.tfstate*
 
-## Pass argument through to terraform
-%: init
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
 	terraform $@


### PR DESCRIPTION
## what
* Use explicit target names rather than wildcards
* Only initialize state when needed
* Check for statefile, not state directory

## why
* The `%` is tricky when used with build dependencies (e.g. `init`). It passes a target called `Makefile` =)
* Explicit is better b/c it's clear what's going on
