### PR TITLE
[kops] Add targets and README.md

### DIFF
--- a/aws/kops/Makefile
+++ b/aws/kops/Makefile
@@ -38,11 +38,14 @@ kops/plan:
 kops/apply:
 	kops update cluster --yes
 
+## Verify that the cluster is healthy
 kops/validate:
 	kops validate cluster
 
+## Export kubecfg (required to access cluster)
 kops/export:
 	kops export kubecfg
 
+## Delete kubecfg
 kops/clean:
 	rm -f $(KUBECONFIG)

--- a/aws/kops/Makefile
+++ b/aws/kops/Makefile
@@ -3,7 +3,7 @@ init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform
 
 ## Clean up the project
-clean:
+clean: kops/clean
 	rm -rf .terraform *.tfstate*
 
 ## Pass arguments through to terraform which require remote state
@@ -13,3 +13,36 @@ apply console destroy graph plan output providers show: init
 ## Pass arguments through to terraform which do not require remote state
 get fmt validate version:
 	terraform $@
+
+## Launch a shell with the kops environment
+kops/shell:
+	chamber exec kops -- bash -l
+
+## Render the kops manifest template
+kops/build-manifest:
+	build-kops-manifest
+
+## Apply the kops manifest
+kops/create:
+	kops create -f $(KOPS_MANIFEST)
+
+## Create the SSH Public Key secret
+kops/create-secret-sshpublickey:
+	kops create secret sshpublickey admin -i $(KOPS_SSH_PUBLIC_KEY_PATH)
+
+## Show update plan for the kops cluster
+kops/plan:
+	kops update cluster
+
+## Apply changes to the kops cluster
+kops/apply:
+	kops update cluster --yes
+
+kops/validate:
+	kops validate cluster
+
+kops/export:
+	kops export kubecfg
+
+kops/clean:
+	rm -f $(KUBECONFIG)

--- a/aws/kops/README.md
+++ b/aws/kops/README.md
@@ -34,7 +34,7 @@ This is roughly the process to get up and running. These instructions assume you
 
 Once the cluster is online, you can interact with it using `kubectl`. 
 
-To start, first run this to get the credentials:
+To start, first run this to export `kubecfg` from the `kops` state store (required to access the cluster):
 ```
 make kops/export
 ```

--- a/aws/kops/README.md
+++ b/aws/kops/README.md
@@ -1,0 +1,43 @@
+# Kubernetes Ops (kops)
+
+This project provisions dependencies for `kops` clusters including the DNS zone, S3 bucket for state storage, SSH keypair. 
+
+It also writes the computed settings to SSM for usage by other modules or tools.
+
+## Configuration Settings
+
+
+The minimum recommended settings are the following (`terraform.tfvars`):
+
+```
+# EC2 Virtual Network
+network_cidr = "10.100.0.0/16"
+# Service discovery domain (should exist)
+zone_name = "staging.example.io"
+# Desired region of cluster
+region = "us-west-2"
+```
+
+## Quick Start
+
+This is roughly the process to get up and running. These instructions assume you're running inside of a Geodesic shell..
+
+1. Update the `terraform.tfvars` with [desired settings](#configuration-settings).
+2. Run `make apply` to provision kops dependencies (not the cluster itself)
+3. Run `make kops/shell` to drop into a shell with configured environment for `kops`. Do this any time you want to interact with the cluster.
+4. Run `make kops/build-manifest` to compile the configuration template with current environment settings
+5. Run `make kops/create` to submit the cluster state manifest. Note, no resources will be provisioned.
+6. Run `make kops/create-secret-sshpublickey` to provision the SSH public key. Note, the public key was created in the `make apply` step and requires `/secrets/tf` to be mounted. Mount this directory by running `mount -a`.
+7. Run `make kops/plan` to view the proposed cluster
+8. Run `make kops/apply` to build the cluster
+9. Run `make kops/validate` to view cluster status. Note, it will take ~10 minutes to come online (depending on cluster size)
+
+Once the cluster is online, you can interact with it using `kubectl`. 
+
+To start, first run this to get the credentials:
+```
+make kops/export
+```
+
+Then all the standard `kubectl` commands will work (e.g. `kubectl get nodes`).
+

--- a/aws/kops/README.md
+++ b/aws/kops/README.md
@@ -21,16 +21,16 @@ region = "us-west-2"
 ## Quick Start
 
 This is roughly the process to get up and running. These instructions assume you're running inside of a [Geodesic shell](https://github.com/cloudposse/geodesic).
-
-1. Update the `terraform.tfvars` with [desired settings](#configuration-settings).
-2. Run `make apply` to provision kops dependencies (not the cluster itself)
-3. Run `make kops/shell` to drop into a shell with configured environment for `kops`. Do this any time you want to interact with the cluster.
-4. Run `make kops/build-manifest` to compile the configuration template with current environment settings
-5. Run `make kops/create` to submit the cluster state manifest. Note, no resources will be provisioned.
-6. Run `make kops/create-secret-sshpublickey` to provision the SSH public key. Note, the public key was created in the `make apply` step and requires `/secrets/tf` to be mounted. Mount this directory by running `mount -a`.
-7. Run `make kops/plan` to view the proposed cluster
-8. Run `make kops/apply` to build the cluster
-9. Run `make kops/validate` to view cluster status. Note, it will take ~10 minutes to come online (depending on cluster size)
+1. Update the `terraform.tfvars` with [desired settings](#configuration-settings). Rebuild the container if necessary.
+2. Run `assume-role` to obtain a session.
+3. Run `make apply` to provision kops dependencies with terraform (not the cluster itself)
+4. Run `make kops/shell` to drop into a shell with configured environment for `kops`. Do this any time you want to interact with the cluster.
+5. Run `make kops/build-manifest` to compile the configuration template with current environment settings
+6. Run `make kops/create` to submit the cluster state manifest. Note, no resources will be provisioned.
+7. Run `make kops/create-secret-sshpublickey` to provision the SSH public key. Note, the public key was created in the `make apply` step and requires `/secrets/tf` to be mounted. Mount this directory by running `mount -a`.
+8. Run `make kops/plan` to view the proposed cluster
+9. Run `make kops/apply` to build the cluster
+10. Run `make kops/validate` to view cluster status. Note, it will take ~10 minutes to come online (depending on cluster size)
 
 Once the cluster is online, you can interact with it using `kubectl`. 
 

--- a/aws/kops/README.md
+++ b/aws/kops/README.md
@@ -26,7 +26,7 @@ This is roughly the process to get up and running. These instructions assume you
 3. Run `make apply` to provision kops dependencies with terraform (not the cluster itself)
 4. Run `make kops/shell` to drop into a shell with configured environment for `kops`. Do this any time you want to interact with the cluster.
 5. Run `make kops/build-manifest` to compile the configuration template with current environment settings
-6. Run `make kops/create` to submit the cluster state manifest. Note, no resources will be provisioned.
+6. Run `make kops/create` to submit the cluster state manifest to the cluster state store. Note, no resources will be provisioned.
 7. Run `make kops/create-secret-sshpublickey` to provision the SSH public key. Note, the public key was created in the `make apply` step and requires `/secrets/tf` to be mounted. Mount this directory by running `mount -a`.
 8. Run `make kops/plan` to view the proposed cluster
 9. Run `make kops/apply` to build the cluster

--- a/aws/kops/README.md
+++ b/aws/kops/README.md
@@ -20,7 +20,7 @@ region = "us-west-2"
 
 ## Quick Start
 
-This is roughly the process to get up and running. These instructions assume you're running inside of a Geodesic shell..
+This is roughly the process to get up and running. These instructions assume you're running inside of a [Geodesic shell](https://github.com/cloudposse/geodesic).
 
 1. Update the `terraform.tfvars` with [desired settings](#configuration-settings).
 2. Run `make apply` to provision kops dependencies (not the cluster itself)

--- a/aws/kops/main.tf
+++ b/aws/kops/main.tf
@@ -144,6 +144,14 @@ resource "aws_ssm_parameter" "kops_utility_subnets" {
   overwrite   = "true"
 }
 
+resource "aws_ssm_parameter" "kops_non_masquerade_cidr" {
+  name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_non_masquerade_cidr")}"
+  value       = "${var.kops_non_masquerade_cidr}"
+  description = "Kops utility subnet CIDRs"
+  type        = "String"
+  overwrite   = "true"
+}
+
 resource "aws_ssm_parameter" "kops_availability_zones" {
   name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_availability_zones")}"
   value       = "${join(",", local.availability_zones)}"

--- a/aws/kops/main.tf
+++ b/aws/kops/main.tf
@@ -147,7 +147,7 @@ resource "aws_ssm_parameter" "kops_utility_subnets" {
 resource "aws_ssm_parameter" "kops_non_masquerade_cidr" {
   name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_non_masquerade_cidr")}"
   value       = "${var.kops_non_masquerade_cidr}"
-  description = "Kops utility subnet CIDRs"
+  description = "The CIDR range for Pod IPs"
   type        = "String"
   overwrite   = "true"
 }

--- a/aws/kops/variables.tf
+++ b/aws/kops/variables.tf
@@ -74,6 +74,12 @@ variable "network_cidr" {
   default     = "172.20.0.0/16"
 }
 
+# Read more: <https://kubernetes.io/docs/tasks/administer-cluster/ip-masq-agent/#key-terms>
+variable "kops_non_masquerade_cidr" {
+  description = "The CIDR range for Pod IPs."
+  default     = "100.64.0.0/10"
+}
+
 variable "private_subnets_newbits" {
   description = "This is the new mask for the private subnet within the virtual network"
   default     = "-1"


### PR DESCRIPTION
## what
* Add a `README.md` to roughly describe the process
* Add some **simple** targets that are common when provisioning a new cluster

## why
* The `Makefile` targets serve as *executable documentation*; that is, they can be copied & pasted just as easily as they can be run. They are not difficult to understand.
* This makes writing the documentation easier that pasting commands into the `README.md` which will just grow stale.