### PR TITLE
[*/Makefile] include `Makefile.*`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ We recommend that you start with your clean `terraform-root-module` repo. Then s
 Here's a good example of a `Makefile` for a terraform project:
 
 ```
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/README.yaml
+++ b/README.yaml
@@ -102,9 +102,11 @@ introduction: |-
   Here's a good example of a `Makefile` for a terraform project:
 
   ```
+  -include Makefile.*
+
   ## Initialize terraform remote state
   init:
-  	[ -f .terraform/terraform.tfstate ] || init-terraform
+  	[ -f .terraform/terraform.tfstate ] || terraform $@
 
   ## Clean up the project
   clean:

--- a/aws/account-dns/Makefile
+++ b/aws/account-dns/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/account-dns/Makefile
+++ b/aws/account-dns/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform

--- a/aws/account-settings/Makefile
+++ b/aws/account-settings/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/account-settings/Makefile
+++ b/aws/account-settings/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform

--- a/aws/accounts/Makefile
+++ b/aws/accounts/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/accounts/Makefile
+++ b/aws/accounts/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform

--- a/aws/acm-cloudfront/Makefile
+++ b/aws/acm-cloudfront/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/acm-cloudfront/Makefile
+++ b/aws/acm-cloudfront/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform

--- a/aws/acm/Makefile
+++ b/aws/acm/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/acm/Makefile
+++ b/aws/acm/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform

--- a/aws/artifacts/Makefile
+++ b/aws/artifacts/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/artifacts/Makefile
+++ b/aws/artifacts/Makefile
@@ -1,8 +1,17 @@
-plan:
-	@tfenv terraform $@
+-include Makefile.*
 
-apply:
-	@tfenv terraform $@
+## Initialize terraform remote state
+init:
+	[ -f .terraform/terraform.tfstate ] || init-terraform
 
-destroy:
-	@tfenv terraform $@
+## Clean up the project
+clean:
+	rm -rf .terraform *.tfstate*
+
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
+	terraform $@

--- a/aws/audit-cloudtrail/Makefile
+++ b/aws/audit-cloudtrail/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/audit-cloudtrail/Makefile
+++ b/aws/audit-cloudtrail/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform

--- a/aws/backing-services/Makefile
+++ b/aws/backing-services/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/backing-services/Makefile
+++ b/aws/backing-services/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform

--- a/aws/bootstrap/Makefile
+++ b/aws/bootstrap/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/bootstrap/Makefile
+++ b/aws/bootstrap/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform

--- a/aws/chamber/Makefile
+++ b/aws/chamber/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/chamber/Makefile
+++ b/aws/chamber/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform

--- a/aws/cloudtrail/Makefile
+++ b/aws/cloudtrail/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/cloudtrail/Makefile
+++ b/aws/cloudtrail/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform

--- a/aws/docs/Makefile
+++ b/aws/docs/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/docs/Makefile
+++ b/aws/docs/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform

--- a/aws/ecr/Makefile
+++ b/aws/ecr/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/ecr/Makefile
+++ b/aws/ecr/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform

--- a/aws/eks-backing-services-peering/Makefile
+++ b/aws/eks-backing-services-peering/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/eks-backing-services-peering/Makefile
+++ b/aws/eks-backing-services-peering/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform

--- a/aws/eks/Makefile
+++ b/aws/eks/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/eks/Makefile
+++ b/aws/eks/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform

--- a/aws/iam/Makefile
+++ b/aws/iam/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/iam/Makefile
+++ b/aws/iam/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform

--- a/aws/kops-aws-platform/Makefile
+++ b/aws/kops-aws-platform/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/kops-aws-platform/Makefile
+++ b/aws/kops-aws-platform/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform

--- a/aws/kops/Makefile
+++ b/aws/kops/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform

--- a/aws/kops/Makefile
+++ b/aws/kops/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean: kops/clean

--- a/aws/organization/Makefile
+++ b/aws/organization/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/organization/Makefile
+++ b/aws/organization/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform

--- a/aws/root-dns/Makefile
+++ b/aws/root-dns/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/root-dns/Makefile
+++ b/aws/root-dns/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform

--- a/aws/root-iam/Makefile
+++ b/aws/root-iam/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/root-iam/Makefile
+++ b/aws/root-iam/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform

--- a/aws/ses/Makefile
+++ b/aws/ses/Makefile
@@ -1,4 +1,6 @@
+-include Makefile.*
 -include .terraform/modules/**/Makefile.ses
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform

--- a/aws/ses/Makefile
+++ b/aws/ses/Makefile
@@ -3,7 +3,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/tfstate-backend/Makefile
+++ b/aws/tfstate-backend/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize the terraform state backend
 init:
 	@aws s3 ls s3://${TF_BUCKET}/tfstate-backend/terraform.tfstate > /dev/null || \
@@ -17,7 +19,7 @@ clean:
 	rm -rf .terraform *.tfstate*
 
 ## Pass arguments through to terraform which require remote state
-apply console destroy graph plan output providers show: init
+apply console graph plan output providers show: init
 	terraform $@
 
 ## Pass arguments through to terraform which do not require remote state

--- a/aws/tfstate-backend/Makefile
+++ b/aws/tfstate-backend/Makefile
@@ -4,7 +4,7 @@
 init:
 	@aws s3 ls s3://${TF_BUCKET}/tfstate-backend/terraform.tfstate > /dev/null || \
 		scripts/$@.sh
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Destroy the configuration (only works if `force_destroy=true`)
 destroy:

--- a/aws/users/Makefile
+++ b/aws/users/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/users/Makefile
+++ b/aws/users/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform

--- a/aws/vpc-peering/Makefile
+++ b/aws/vpc-peering/Makefile
@@ -2,7 +2,7 @@
 
 ## Initialize terraform remote state
 init:
-	[ -f .terraform/terraform.tfstate ] || init-terraform
+	[ -f .terraform/terraform.tfstate ] || terraform $@
 
 ## Clean up the project
 clean:

--- a/aws/vpc-peering/Makefile
+++ b/aws/vpc-peering/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.*
+
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || init-terraform


### PR DESCRIPTION
## what
* Update all `Makefiles` to have an include

## why
* When importing the root modules into accounts, it's convenient to have multiple makefiles
* Allow inheriters to define `Makefile.something` where `something` can be anything =)