### PR TITLE
Remove references to init-terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ We recommend that you start with your clean `terraform-root-module` repo. Then s
 Here's a good example of a `Makefile` for a terraform project:
 
 ```
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/README.yaml
+++ b/README.yaml
@@ -102,8 +102,6 @@ introduction: |-
   Here's a good example of a `Makefile` for a terraform project:
 
   ```
-  -include Makefile.*
-
   ## Initialize terraform remote state
   init:
   	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/account-dns/Makefile
+++ b/aws/account-dns/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/account-settings/Makefile
+++ b/aws/account-settings/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/accounts/Makefile
+++ b/aws/accounts/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/acm-cloudfront/Makefile
+++ b/aws/acm-cloudfront/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/acm/Makefile
+++ b/aws/acm/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/artifacts/Makefile
+++ b/aws/artifacts/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/audit-cloudtrail/Makefile
+++ b/aws/audit-cloudtrail/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/backing-services/Makefile
+++ b/aws/backing-services/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/bootstrap/Makefile
+++ b/aws/bootstrap/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/chamber/Makefile
+++ b/aws/chamber/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/cloudtrail/Makefile
+++ b/aws/cloudtrail/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/docs/Makefile
+++ b/aws/docs/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/ecr/Makefile
+++ b/aws/ecr/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/eks-backing-services-peering/Makefile
+++ b/aws/eks-backing-services-peering/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/eks/Makefile
+++ b/aws/eks/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/iam/Makefile
+++ b/aws/iam/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/kops-aws-platform/Makefile
+++ b/aws/kops-aws-platform/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/kops/Makefile
+++ b/aws/kops/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/organization/Makefile
+++ b/aws/organization/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/root-dns/Makefile
+++ b/aws/root-dns/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/root-iam/Makefile
+++ b/aws/root-iam/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/ses/Makefile
+++ b/aws/ses/Makefile
@@ -1,4 +1,3 @@
--include Makefile.*
 -include .terraform/modules/**/Makefile.ses
 
 ## Initialize terraform remote state

--- a/aws/tfstate-backend/Makefile
+++ b/aws/tfstate-backend/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize the terraform state backend
 init:
 	@aws s3 ls s3://${TF_BUCKET}/tfstate-backend/terraform.tfstate > /dev/null || \

--- a/aws/tfstate-backend/scripts/destroy.sh
+++ b/aws/tfstate-backend/scripts/destroy.sh
@@ -13,7 +13,7 @@ rm -rf .terraform terraform.tfstate
 [ "${DISABLE_ROLE_ARN}" == "true" ] || sed -Ei 's/^(\s+role_arn\s+)/#\1/' main.tf
 
 # Init terraform with S3 state enabled. Assumes state was previously initialized.
-init-terraform
+terraform init
 
 # Unmount remote bucket (if mounted)
 s3 unmount

--- a/aws/tfstate-backend/scripts/init.sh
+++ b/aws/tfstate-backend/scripts/init.sh
@@ -18,7 +18,7 @@ sed -Ei 's/^(\s+backend\s+)/#\1/' main.tf
 [ "${DISABLE_ROLE_ARN}" == "true" ] || sed -Ei 's/^(\s+role_arn\s+)/#\1/' main.tf
 
 # Initialize terraform modules and providers
-init-terraform
+terraform init
 
 # Provision S3 bucket and dynamodb tables
 terraform apply -auto-approve -input=false
@@ -26,11 +26,14 @@ terraform apply -auto-approve -input=false
 export TF_BUCKET=$(terraform output tfstate_backend_s3_bucket_id)
 export TF_DYNAMODB_TABLE=$(terraform output tfstate_backend_dynamodb_table_id)
 
+# Cast to terraform envs
+eval "$(tfenv)"
+
 # Re-enable S3 backend
 sed -Ei 's/^#(\s+backend\s+)/\1/' main.tf
 
 # Reinitialize terraform to import state to remote backend
-echo "yes" | init-terraform
+terraform init -force-copy
 
 # Re-enable Role ARN
 [ "${DISABLE_ROLE_ARN}" == "true" ] || sed -Ei 's/^#(\s+role_arn\s+)/\1/' main.tf

--- a/aws/users/Makefile
+++ b/aws/users/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@

--- a/aws/vpc-peering/Makefile
+++ b/aws/vpc-peering/Makefile
@@ -1,5 +1,3 @@
--include Makefile.*
-
 ## Initialize terraform remote state
 init:
 	[ -f .terraform/terraform.tfstate ] || terraform $@


### PR DESCRIPTION
## what
* Remove `include Makefile.*` as it caused some problems [this pr](https://github.com/cloudposse/geodesic/pull/354) and introduced in #92.
* Remove remaining references to `init-terraform` since we can achieve the same thing using `tfenv`

## why
* Part of the refactoring to better support `terraform init -from-module=...`