### PR TITLE
Add kops efs-provisioner IAM role

### DIFF
--- a/aws/kops-aws-platform/efs-provisioner.tf
+++ b/aws/kops-aws-platform/efs-provisioner.tf
@@ -1,0 +1,23 @@
+module "kops_efs_provisioner" {
+  source       = "git::https://github.com/cloudposse/terraform-aws-kops-efs.git?ref=tags/0.1.0"
+  namespace    = "${var.namespace}"
+  stage        = "${var.stage}"
+  name         = "efs-provisioner"
+  cluster_name = "${var.region}.${var.zone_name}"
+
+  tags = {
+    Cluster = "${var.region}.${var.zone_name}"
+  }
+}
+
+output "kops_efs_provisioner_role_name" {
+  value = "${module.kops_efs_provisioner.role_name}"
+}
+
+output "kops_efs_provisioner_role_unique_id" {
+  value = "${module.kops_efs_provisioner.role_unique_id}"
+}
+
+output "kops_efs_provisioner_role_arn" {
+  value = "${module.kops_efs_provisioner.role_arn}"
+}


### PR DESCRIPTION
## what 
Creates an IAM role with EFS permissions

## why
This IAM role will be used to annotate the efs-provisioner helmfile so
that we can mount EFS volumes into our k8s clusters.