### PR TITLE
[aws/kops] Use SSH keys from SSM

### DIFF
--- a/aws/kops/Makefile
+++ b/aws/kops/Makefile
@@ -28,7 +28,8 @@ kops/create:
 
 ## Create the SSH Public Key secret
 kops/create-secret-sshpublickey:
-	kops create secret sshpublickey admin -i $(KOPS_SSH_PUBLIC_KEY_PATH)
+	echo "$(KOPS_SSH_PUBLIC_KEY)" > /dev/shm/$(KOPS_CLUSTER_NAME).pub
+	kops create secret sshpublickey admin -i /dev/shm/$(KOPS_CLUSTER_NAME).pub
 
 ## Show update plan for the kops cluster
 kops/plan:

--- a/aws/kops/main.tf
+++ b/aws/kops/main.tf
@@ -37,17 +37,17 @@ module "kops_state_backend" {
 }
 
 module "ssh_key_pair" {
-  source              = "git::https://github.com/cloudposse/terraform-aws-ssm-tls-ssh-key-pair.git?ref=tags/0.2.0"
-  namespace           = "${var.namespace}"
-  stage               = "${var.stage}"
-  name                = "${var.name}"
-  attributes          = ["${var.region}"]
-  ssm_path_prefix     = "${local.chamber_service}"
-  rsa_bits            = 8096
-  ssh_key_algorithm   = "RSA"
-  ssh_public_key_name = "kops_ssh_public_key"
+  source               = "git::https://github.com/cloudposse/terraform-aws-ssm-tls-ssh-key-pair.git?ref=tags/0.2.0"
+  namespace            = "${var.namespace}"
+  stage                = "${var.stage}"
+  name                 = "${var.name}"
+  attributes           = ["${var.region}"]
+  ssm_path_prefix      = "${local.chamber_service}"
+  rsa_bits             = 8096
+  ssh_key_algorithm    = "RSA"
+  ssh_public_key_name  = "kops_ssh_public_key"
   ssh_private_key_name = "kops_ssh_private_key"
-  generate_ssh_key    = "true"
+  generate_ssh_key     = "true"
 }
 
 # Allocate one large subnet for each AZ, plus one additional one for the utility subnets.

--- a/aws/kops/main.tf
+++ b/aws/kops/main.tf
@@ -47,7 +47,6 @@ module "ssh_key_pair" {
   ssh_key_algorithm    = "RSA"
   ssh_public_key_name  = "kops_ssh_public_key"
   ssh_private_key_name = "kops_ssh_private_key"
-  generate_ssh_key     = "true"
 }
 
 # Allocate one large subnet for each AZ, plus one additional one for the utility subnets.

--- a/aws/kops/main.tf
+++ b/aws/kops/main.tf
@@ -37,12 +37,16 @@ module "kops_state_backend" {
 }
 
 module "ssh_key_pair" {
-  source              = "git::https://github.com/cloudposse/terraform-aws-key-pair.git?ref=tags/0.3.0"
+  source              = "git::https://github.com/cloudposse/terraform-aws-ssm-tls-ssh-key-pair.git?ref=tags/0.2.0"
   namespace           = "${var.namespace}"
   stage               = "${var.stage}"
   name                = "${var.name}"
   attributes          = ["${var.region}"]
-  ssh_public_key_path = "${var.ssh_public_key_path}"
+  ssm_path_prefix     = "${local.chamber_service}"
+  rsa_bits            = 8096
+  ssh_key_algorithm   = "RSA"
+  ssh_public_key_name = "kops_ssh_public_key"
+  ssh_private_key_name = "kops_ssh_private_key"
   generate_ssh_key    = "true"
 }
 
@@ -92,22 +96,6 @@ resource "aws_ssm_parameter" "kops_state_store_region" {
   name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_state_store_region")}"
   value       = "${module.kops_state_backend.bucket_region}"
   description = "Kops state store (S3 bucket) region"
-  type        = "String"
-  overwrite   = "true"
-}
-
-resource "aws_ssm_parameter" "kops_ssh_public_key_path" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_ssh_public_key_path")}"
-  value       = "${module.ssh_key_pair.public_key_filename}"
-  description = "Kops SSH public key filename path"
-  type        = "String"
-  overwrite   = "true"
-}
-
-resource "aws_ssm_parameter" "kops_ssh_private_key_path" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_ssh_private_key_path")}"
-  value       = "${module.ssh_key_pair.private_key_filename}"
-  description = "Kops SSH private key filename path"
   type        = "String"
   overwrite   = "true"
 }

--- a/aws/kops/outputs.tf
+++ b/aws/kops/outputs.tf
@@ -34,10 +34,6 @@ output "bucket_arn" {
   value = "${module.kops_state_backend.bucket_arn}"
 }
 
-output "ssh_key_name" {
-  value = "${module.ssh_key_pair.key_name}"
-}
-
 output "ssh_public_key" {
   value = "${module.ssh_key_pair.public_key}"
 }
@@ -52,12 +48,4 @@ output "private_subnets" {
 
 output "utility_subnets" {
   value = "${local.utility_subnets}"
-}
-
-output "private_key_filename" {
-  value = "${module.ssh_key_pair.private_key_filename}"
-}
-
-output "public_key_filename" {
-  value = "${module.ssh_key_pair.public_key_filename}"
 }


### PR DESCRIPTION
## what
* Write kops keys to SSM

## why
* Writing to disks makes it hard b/c we don't have `goofys` in the ECS task and local filesystems won't be reliable with atlantis running on an ephemeral disk