### PR TITLE
[aws/codefresh-onprem] Add Enterprise backing services

### DIFF
--- a/aws/backing-services/vpc.tf
+++ b/aws/backing-services/vpc.tf
@@ -38,6 +38,16 @@ output "vpc_id" {
   value       = "${module.vpc.vpc_id}"
 }
 
+output "public_subnet_ids" {
+  description = "Public subnet IDs of backing services"
+  value       = ["${module.subnets.public_subnet_ids}"]
+}
+
+output "private_subnet_ids" {
+  description = "Private subnet IDs of backing services"
+  value       = ["${module.subnets.private_subnet_ids}"]
+}
+
 output "region" {
   description = "AWS region of backing services"
   value       = "${data.aws_region.current.name}"

--- a/aws/codefresh-onprem/kops-metadata.tf
+++ b/aws/codefresh-onprem/kops-metadata.tf
@@ -1,0 +1,11 @@
+variable "kops_metadata_enabled" {
+  description = "Set to false to prevent the module from creating any resources"
+  type        = "string"
+  default     = "false"
+}
+
+module "kops_metadata" {
+  source   = "git::https://github.com/cloudposse/terraform-aws-kops-metadata.git?ref=tags/0.2.0"
+  dns_zone = "${var.region}.${var.zone_name}"
+  enabled  = "${var.kops_metadata_enabled}"
+}

--- a/aws/codefresh-onprem/main.tf
+++ b/aws/codefresh-onprem/main.tf
@@ -1,0 +1,54 @@
+terraform {
+  required_version = ">= 0.11.2"
+
+  backend "s3" {}
+}
+
+provider "aws" {
+  assume_role {
+    role_arn = "${var.aws_assume_role_arn}"
+  }
+}
+
+variable "aws_assume_role_arn" {
+  type = "string"
+}
+
+variable "namespace" {
+  type        = "string"
+  description = "Namespace (e.g. `eg` or `cp`)"
+}
+
+variable "stage" {
+  type        = "string"
+  description = "Stage (e.g. `prod`, `dev`, `staging`)"
+}
+
+variable "region" {
+  type        = "string"
+  description = "AWS region"
+}
+
+variable "zone_name" {
+  type        = "string"
+  description = "DNS zone name"
+}
+
+data "terraform_remote_state" "backing_services" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.namespace}-${var.stage}-terraform-state"
+    key    = "backing-services/terraform.tfstate"
+  }
+}
+
+module "codefresh_enterprise_backing_services" {
+  source          = "git::https://github.com/cloudposse/terraform-aws-codefresh-backing-services.git?ref=tags/0.1.0"
+  namespace       = "${var.namespace}"
+  stage           = "${var.stage}"
+  vpc_id          = "${data.terraform_remote_state.backing_services.vpc_id}"
+  subnet_ids      = ["${data.terraform_remote_state.backing_services.private_subnet_ids}"]
+  security_groups = ["${module.kops_metadata.nodes_security_group_id}"]
+  zone_name       = "${var.zone_name}"
+}


### PR DESCRIPTION
## what

PR to add CodeFresh Enterprise backing services to terraform-root-modules

## why

so we can provision these CodeFresh Enterprise backing services into the backing service VPC and subnets.

Note that I have had to add some new outputs to the `backing-services` module so that I can import these as remote state to pass into the `terraform-aws-codefresh-backing-services` module