### PR TITLE
[aws/kops] Reduce default ssh key size

### DIFF
--- a/aws/kops/main.tf
+++ b/aws/kops/main.tf
@@ -43,8 +43,9 @@ module "ssh_key_pair" {
   name                 = "${var.name}"
   attributes           = ["${var.region}"]
   ssm_path_prefix      = "${local.chamber_service}"
-  rsa_bits             = 8096
-  ssh_key_algorithm    = "RSA"
+  rsa_bits             = "${var.ssh_key_rsa_bits}"
+  ssh_key_algorithm    = "${var.ssh_key_algorithm}"
+  ecdsa_curve          = "${var.ssh_key_ecdsa_curve}"
   ssh_public_key_name  = "kops_ssh_public_key"
   ssh_private_key_name = "kops_ssh_private_key"
 }

--- a/aws/kops/variables.tf
+++ b/aws/kops/variables.tf
@@ -51,10 +51,22 @@ variable "force_destroy" {
   default     = "false"
 }
 
-variable "ssh_public_key_path" {
+variable "ssh_key_algorithm" {
   type        = "string"
-  description = "SSH public key path to write master public/private key pair for cluster"
-  default     = "/secrets/tf/ssh"
+  default     = "RSA"
+  description = "SSH key algorithm to use. Currently-supported values are 'RSA' and 'ECDSA'"
+}
+
+variable "ssh_key_rsa_bits" {
+  type        = "string"
+  description = "When ssh_key_algorithm is 'RSA', the size of the generated RSA key in bits"
+  default     = "4096"
+}
+
+variable "ssh_key_ecdsa_curve" {
+  type        = "string"
+  description = "When ssh_key_algorithm is 'ECDSA', the name of the elliptic curve to use. May be any one of 'P256', 'P384' or P521'"
+  default     = "P521"
 }
 
 variable "kops_attribute" {


### PR DESCRIPTION
## what
* Reduce default key size

## why
* SSM Parameter store has a max limit of `4096` bytes.