### PR TITLE
Add standard makefile for codefresh-onprem

### DIFF
--- a/aws/codefresh-onprem/Makefile
+++ b/aws/codefresh-onprem/Makefile
@@ -1,0 +1,15 @@
+## Initialize terraform remote state
+init:
+	[ -f .terraform/terraform.tfstate ] || terraform $@
+
+## Clean up the project
+clean:
+	rm -rf .terraform *.tfstate*
+
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
+	terraform $@


### PR DESCRIPTION
## what

This adds the standard makefile to codefresh-onprem

## why

So Atlantis can plan / apply steps using the makefile wrapper.