### PR TITLE
Explicitly set codefresh_onprem chamber_service

### DIFF
--- a/aws/codefresh-onprem/main.tf
+++ b/aws/codefresh-onprem/main.tf
@@ -51,4 +51,5 @@ module "codefresh_enterprise_backing_services" {
   subnet_ids      = ["${data.terraform_remote_state.backing_services.private_subnet_ids}"]
   security_groups = ["${module.kops_metadata.nodes_security_group_id}"]
   zone_name       = "${var.zone_name}"
+  chamber_service = "codefresh"
 }


### PR DESCRIPTION
## what

I was wondering what was going on here when applying codefresh-onprem
via Atlantis and getting unexpected SSM param prefixes 
e.g. `/21ba4b10dd0ca831a7458b77c31ee2f6/aurora_postgres_cluster_name`
at which point I realised that Atlantis runs in a scratch directory so
we need to explicitly set `chamber_service` to stop it defaulting to
the scratch directory when running under Atlantis. This will likely bite
us anyplace we do as [1] and run terraform via Atlantis.

[1] https://github.com/cloudposse/terraform-aws-codefresh-backing-services/blob/master/main.tf#L98

## testing

From: 

```terraform
-/+ module.codefresh_enterprise_backing_services.aws_ssm_parameter.s3_user_iam_secret_access_key (new resource required)
      id:          "/21ba4b10dd0ca831a7458b77c31ee2f6/aws_secret_access_key" => <computed> (forces new resource)
      arn:         "arn:aws:ssm:us-west-2:XXXXXXXXXXXXXXX:parameter/21ba4b10dd0ca831a7458b77c31ee2f6/aws_secret_access_key" => <computed>
      description: "S3 user aws_secret_acces_key" => "S3 user aws_secret_acces_key"
      key_id:      "0b36ddeb-0311-45ae-98e9-0586b786abf1" => "0b36ddeb-0311-45ae-98e9-0586b786abf1"
      name:        "/21ba4b10dd0ca831a7458b77c31ee2f6/aws_secret_access_key" => "/7120e72990de4a77a6489461b42f6aeb/aws_secret_access_key" (forces new resource)
      overwrite:   "true" => "true"
      type:        "SecureString" => "SecureString"
      value:       <sensitive> => <sensitive> (attribute changed)
```

to:

```terraform
-/+ module.codefresh_enterprise_backing_services.aws_ssm_parameter.s3_user_iam_secret_access_key (new resource required)
      id:          "/21ba4b10dd0ca831a7458b77c31ee2f6/aws_secret_access_key" => <computed> (forces new resource)
      arn:         "arn:aws:ssm:us-west-2:XXXXXXXXXXXXXXX:parameter/21ba4b10dd0ca831a7458b77c31ee2f6/aws_secret_access_key" => <computed>
      description: "S3 user aws_secret_acces_key" => "S3 user aws_secret_acces_key"
      key_id:      "0b36ddeb-0311-45ae-98e9-0586b786abf1" => "0b36ddeb-0311-45ae-98e9-0586b786abf1"
      name:        "/21ba4b10dd0ca831a7458b77c31ee2f6/aws_secret_access_key" => "/codefresh/aws_secret_access_key" (forces new resource)
      overwrite:   "true" => "true"
      type:        "SecureString" => "SecureString"
      value:       <sensitive> => <sensitive> (attribute changed)
```

Why explicitly set `codefresh` and not `codefresh-onprem` ? We already seem to have populated the `codefresh` SSM parameter prefix so it seems fitting to put these all together.

__NOTE__ this will likely bite us when running `backing-services` via Atlantis too
