### PR TITLE
Add option to pass domain_name to ECS ACM module

### DIFF
--- a/aws/ecs/acm.tf
+++ b/aws/ecs/acm.tf
@@ -3,14 +3,20 @@ variable "subject_alternative_names" {
   default     = []
 }
 
+variable "domain_name" {
+  type        = "string"
+  description = "Domain name (E.g. staging.cloudposse.co)"
+  default     = ""
+}
+
 locals {
-  domain_name               = "${module.dns.zone_name}"
+  domain_name               = "${var.domain_name != "" ? var.domain_name : module.dns.zone_name }"
   subject_alternative_names = "${distinct(concat(var.subject_alternative_names, formatlist("*.%s", list(local.domain_name))))}"
 }
 
 module "acm_request_certificate" {
   source                    = "git::https://github.com/cloudposse/terraform-aws-acm-request-certificate.git?ref=tags/0.1.1"
-  domain_name               = "${module.dns.zone_name}"
+  domain_name               = "${local.domain_name}"
   ttl                       = "300"
   subject_alternative_names = "${local.subject_alternative_names}"
   tags                      = "${var.tags}"


### PR DESCRIPTION
## what

There is no cpco.co parent domain, allow for overriding.

## why

In its current implementation this works all fine and well with AWS
accounts setup the new way where namespace ends up building parent 
domain, like evenco.io, but not so well with accounts setup the old way 
e.g. cloudposse where namespace is `cpco` but FQDN is cloudposse.co. For
this reason we need to allow passing in an explicit domain_name as we 
already set in `cloudposse.co` Dockerfiles.