### PR TITLE
Surface codefresh-onprem outputs

### DIFF
--- a/aws/codefresh-onprem/main.tf
+++ b/aws/codefresh-onprem/main.tf
@@ -53,3 +53,75 @@ module "codefresh_enterprise_backing_services" {
   zone_name       = "${var.zone_name}"
   chamber_service = "codefresh"
 }
+
+output "elasticache_redis_id" {
+  value       = "${module.codefresh_enterprise_backing_services.elasticache_redis_id}"
+  description = "Elasticache Redis cluster ID"
+}
+
+output "elasticache_redis_security_group_id" {
+  value       = "${module.codefresh_enterprise_backing_services.elasticache_redis_security_group_id}"
+  description = "Elasticache Redis security group ID"
+}
+
+output "elasticache_redis_host" {
+  value       = "${module.codefresh_enterprise_backing_services.elasticache_redis_security_group_id}"
+  description = "Elasticache Redis host"
+}
+
+output "aurora_postgres_database_name" {
+  value       = "${module.codefresh_enterprise_backing_services.aurora_postgres_database_name}"
+  description = "Aurora Postgres Database name"
+}
+
+output "aurora_postgres_master_username" {
+  value       = "${module.codefresh_enterprise_backing_services.aurora_postgres_master_username}"
+  description = "Aurora Postgres Username for the master DB user"
+}
+
+output "aurora_postgres_master_hostname" {
+  value       = "${module.codefresh_enterprise_backing_services.aurora_postgres_master_hostname}"
+  description = "Aurora Postgres DB Master hostname"
+}
+
+output "aurora_postgres_replicas_hostname" {
+  value       = "${module.codefresh_enterprise_backing_services.aurora_postgres_replicas_hostname}"
+  description = "Aurora Postgres Replicas hostname"
+}
+
+output "aurora_postgres_cluster_name" {
+  value       = "${module.codefresh_enterprise_backing_services.aurora_postgres_cluster_name}"
+  description = "Aurora Postgres Cluster Identifier"
+}
+
+output "s3_user_name" {
+  value       = "${module.codefresh_enterprise_backing_services.s3_user_name}"
+  description = "Normalized IAM user name"
+}
+
+output "s3_user_arn" {
+  value       = "${module.codefresh_enterprise_backing_services.s3_user_arn}"
+  description = "The ARN assigned by AWS for the user"
+}
+
+output "s3_user_unique_id" {
+  value       = "${module.codefresh_enterprise_backing_services.s3_user_unique_id}"
+  description = "The user unique ID assigned by AWS"
+}
+
+output "s3_access_key_id" {
+  sensitive   = true
+  value       = "${module.codefresh_enterprise_backing_services.s3_access_key_id}"
+  description = "The access key ID"
+}
+
+output "s3_secret_access_key" {
+  sensitive   = true
+  value       = "${module.codefresh_enterprise_backing_services.s3_secret_access_key}"
+  description = "The secret access key. This will be written to the state file in plain-text"
+}
+
+output "s3_bucket_arn" {
+  value       = "${module.codefresh_enterprise_backing_services.s3_bucket_arn}"
+  description = "The s3 bucket ARN"
+}

--- a/aws/codefresh-onprem/main.tf
+++ b/aws/codefresh-onprem/main.tf
@@ -44,7 +44,7 @@ data "terraform_remote_state" "backing_services" {
 }
 
 module "codefresh_enterprise_backing_services" {
-  source          = "git::https://github.com/cloudposse/terraform-aws-codefresh-backing-services.git?ref=tags/0.1.0"
+  source          = "git::https://github.com/cloudposse/terraform-aws-codefresh-backing-services.git?ref=tags/0.2.0"
   namespace       = "${var.namespace}"
   stage           = "${var.stage}"
   vpc_id          = "${data.terraform_remote_state.backing_services.vpc_id}"


### PR DESCRIPTION
## what

Surfaces codefresh-onprem outputs to the caller module

## why

So we correctly output codefresh-onprem outputs

## testing

Running the thing for `corp.even.co`:

```
Outputs:

aurora_postgres_cluster_name = <redacted>
aurora_postgres_database_name = <redacted>
aurora_postgres_master_hostname = <redacted>
aurora_postgres_master_username = <redacted>
aurora_postgres_replicas_hostname = <redacted>
elasticache_redis_host = <redacted>
elasticache_redis_id = <redacted>
elasticache_redis_security_group_id = <redacted>
s3_access_key_id = <sensitive>
s3_bucket_arn = <redacted>
s3_secret_access_key = <sensitive>
s3_user_arn = <redacted>
s3_user_name = <redacted>
s3_user_unique_id = <sensitive>
```

Note that I have redacted all outputs in this PR, not that that these things are particularly sensitive.