### PR TITLE
Add Kops IAM authenticator

### DIFF
--- a/aws/kops-aws-platform/iam-authenticator.tf
+++ b/aws/kops-aws-platform/iam-authenticator.tf
@@ -1,0 +1,105 @@
+variable "cluster_id" {
+  type        = "string"
+  description = "A unique-per-cluster identifier to prevent replay attacks. Good choices are a random token or a domain name that will be unique to your cluster"
+}
+
+variable "kube_config_path" {
+  type        = "string"
+  default     = "/dev/shm/kubecfg"
+  description = "Path to the kube config file"
+}
+
+variable "admin_k8s_username" {
+  type        = "string"
+  description = "Kops admin username to be mapped to `admin_iam_role_arn`"
+  default     = "kubernetes-admin"
+}
+
+variable "admin_k8s_groups" {
+  type        = "list"
+  description = "List of Kops groups to be mapped to `admin_iam_role_arn`"
+  default     = ["system:masters"]
+}
+
+variable "readonly_k8s_username" {
+  type        = "string"
+  description = "Kops readonly username to be mapped to `readonly_iam_role_arn`"
+  default     = "kubernetes-readonly"
+}
+
+variable "readonly_k8s_groups" {
+  type        = "list"
+  description = "List of Kops groups to be mapped to `readonly_iam_role_arn`"
+  default     = ["system:authenticated"]
+}
+
+variable "aws_root_account_id" {
+  type        = "string"
+  description = "AWS root account ID"
+}
+
+variable "kops_readonly_role_name" {
+  type        = "string"
+  default     = "KopsReadOnly"
+  description = "IAM role name for the Kubernetes readonly user, used by aws-iam-authenticator"
+}
+
+variable "kops_admin_role_name" {
+  type        = "string"
+  default     = "KopsAdmin"
+  description = "IAM role name for the Kubernetes admin user, used by aws-iam-authenticator"
+}
+
+data "aws_iam_policy_document" "readonly" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.aws_root_account_id}:root"]
+    }
+
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_role" "readonly" {
+  name               = "${var.kops_readonly_role_name}"
+  assume_role_policy = "${data.aws_iam_policy_document.readonly.json}"
+  description        = "The Kops readonly role for aws-iam-authenticator"
+}
+
+data "aws_iam_policy_document" "admin" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.aws_root_account_id}:root"]
+    }
+
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_role" "admin" {
+  name               = "${var.kops_admin_role_name}"
+  assume_role_policy = "${data.aws_iam_policy_document.admin.json}"
+  description        = "The Kops admin role for aws-iam-authenticator"
+}
+
+module "iam_authenticator_config" {
+  source                = "git::https://github.com/cloudposse/terraform-aws-kops-iam-authenticator-config.git?ref=tags/0.1.1"
+  cluster_id            = "${var.cluster_id}"
+  kube_config_path      = "${var.kube_config_path}"
+  admin_iam_role_arn    = "${aws_iam_role.admin.arn}"
+  admin_k8s_username    = "${var.admin_k8s_username}"
+  admin_k8s_groups      = "${var.admin_k8s_groups}"
+  readonly_iam_role_arn = "${aws_iam_role.readonly.arn}"
+  readonly_k8s_username = "${var.readonly_k8s_username}"
+  readonly_k8s_groups   = "${var.readonly_k8s_groups}"
+}

--- a/aws/kops-aws-platform/iam-authenticator.tf
+++ b/aws/kops-aws-platform/iam-authenticator.tf
@@ -38,16 +38,26 @@ variable "aws_root_account_id" {
   description = "AWS root account ID"
 }
 
-variable "kops_readonly_role_name" {
-  type        = "string"
-  default     = "KopsReadOnly"
-  description = "IAM role name for the Kubernetes readonly user, used by aws-iam-authenticator"
+module "kops_admin_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
+  namespace  = "${var.namespace}"
+  name       = "kops"
+  stage      = "${var.stage}"
+  attributes = ["admin"]
+  delimiter  = "${var.delimiter}"
+  tags       = "${var.tags}"
+  enabled    = "true"
 }
 
-variable "kops_admin_role_name" {
-  type        = "string"
-  default     = "KopsAdmin"
-  description = "IAM role name for the Kubernetes admin user, used by aws-iam-authenticator"
+module "kops_readonly_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
+  namespace  = "${var.namespace}"
+  name       = "kops"
+  stage      = "${var.stage}"
+  attributes = ["readonly"]
+  delimiter  = "${var.delimiter}"
+  tags       = "${var.tags}"
+  enabled    = "true"
 }
 
 data "aws_iam_policy_document" "readonly" {
@@ -66,7 +76,7 @@ data "aws_iam_policy_document" "readonly" {
 }
 
 resource "aws_iam_role" "readonly" {
-  name               = "${var.kops_readonly_role_name}"
+  name               = "${module.kops_readonly_label.id}"
   assume_role_policy = "${data.aws_iam_policy_document.readonly.json}"
   description        = "The Kops readonly role for aws-iam-authenticator"
 }
@@ -87,7 +97,7 @@ data "aws_iam_policy_document" "admin" {
 }
 
 resource "aws_iam_role" "admin" {
-  name               = "${var.kops_admin_role_name}"
+  name               = "${module.kops_admin_label.id}"
   assume_role_policy = "${data.aws_iam_policy_document.admin.json}"
   description        = "The Kops admin role for aws-iam-authenticator"
 }

--- a/aws/kops-aws-platform/main.tf
+++ b/aws/kops-aws-platform/main.tf
@@ -18,6 +18,18 @@ variable "stage" {
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
+variable "delimiter" {
+  type        = "string"
+  default     = "-"
+  description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
+}
+
+variable "tags" {
+  type        = "map"
+  default     = {}
+  description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`"
+}
+
 variable "region" {
   type        = "string"
   description = "AWS region"

--- a/aws/kops-iam-users/corp.tf
+++ b/aws/kops-iam-users/corp.tf
@@ -5,7 +5,7 @@ module "kops_admin_access_group_corp" {
   stage             = "corp"
   name              = "admin"
   attributes        = ["kops"]
-  role_name         = "${var.kops_admin_role_name}"
+  role_name         = "${module.kops_admin_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.corp_account_id}"
   require_mfa       = "true"
@@ -18,7 +18,7 @@ module "kops_readonly_access_group_corp" {
   stage             = "corp"
   name              = "readonly"
   attributes        = ["kops"]
-  role_name         = "${var.kops_readonly_role_name}"
+  role_name         = "${module.kops_readonly_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.corp_account_id}"
   require_mfa       = "true"

--- a/aws/kops-iam-users/corp.tf
+++ b/aws/kops-iam-users/corp.tf
@@ -1,0 +1,25 @@
+module "kops_admin_access_group_corp" {
+  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.3.0"
+  enabled           = "${contains(var.kops_iam_accounts_enabled, "corp") == true ? "true" : "false"}"
+  namespace         = "${var.namespace}"
+  stage             = "corp"
+  name              = "admin"
+  attributes        = ["kops"]
+  role_name         = "${var.kops_admin_role_name}"
+  user_names        = []
+  member_account_id = "${data.terraform_remote_state.accounts.corp_account_id}"
+  require_mfa       = "true"
+}
+
+module "kops_readonly_access_group_corp" {
+  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.3.0"
+  enabled           = "${contains(var.kops_iam_accounts_enabled, "corp") == true ? "true" : "false"}"
+  namespace         = "${var.namespace}"
+  stage             = "corp"
+  name              = "readonly"
+  attributes        = ["kops"]
+  role_name         = "${var.kops_readonly_role_name}"
+  user_names        = []
+  member_account_id = "${data.terraform_remote_state.accounts.corp_account_id}"
+  require_mfa       = "true"
+}

--- a/aws/kops-iam-users/data.tf
+++ b/aws/kops-iam-users/data.tf
@@ -5,7 +5,7 @@ module "kops_admin_access_group_data" {
   stage             = "data"
   name              = "admin"
   attributes        = ["kops"]
-  role_name         = "${var.kops_admin_role_name}"
+  role_name         = "${module.kops_admin_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.data_account_id}"
   require_mfa       = "true"
@@ -18,7 +18,7 @@ module "kops_readonly_access_group_data" {
   stage             = "data"
   name              = "readonly"
   attributes        = ["kops"]
-  role_name         = "${var.kops_readonly_role_name}"
+  role_name         = "${module.kops_readonly_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.data_account_id}"
   require_mfa       = "true"

--- a/aws/kops-iam-users/data.tf
+++ b/aws/kops-iam-users/data.tf
@@ -1,0 +1,25 @@
+module "kops_admin_access_group_data" {
+  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.3.0"
+  enabled           = "${contains(var.kops_iam_accounts_enabled, "data") == true ? "true" : "false"}"
+  namespace         = "${var.namespace}"
+  stage             = "data"
+  name              = "admin"
+  attributes        = ["kops"]
+  role_name         = "${var.kops_admin_role_name}"
+  user_names        = []
+  member_account_id = "${data.terraform_remote_state.accounts.data_account_id}"
+  require_mfa       = "true"
+}
+
+module "kops_readonly_access_group_data" {
+  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.3.0"
+  enabled           = "${contains(var.kops_iam_accounts_enabled, "data") == true ? "true" : "false"}"
+  namespace         = "${var.namespace}"
+  stage             = "data"
+  name              = "readonly"
+  attributes        = ["kops"]
+  role_name         = "${var.kops_readonly_role_name}"
+  user_names        = []
+  member_account_id = "${data.terraform_remote_state.accounts.data_account_id}"
+  require_mfa       = "true"
+}

--- a/aws/kops-iam-users/dev.tf
+++ b/aws/kops-iam-users/dev.tf
@@ -1,0 +1,25 @@
+module "kops_admin_access_group_dev" {
+  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.3.0"
+  enabled           = "${contains(var.kops_iam_accounts_enabled, "dev") == true ? "true" : "false"}"
+  namespace         = "${var.namespace}"
+  stage             = "dev"
+  name              = "admin"
+  attributes        = ["kops"]
+  role_name         = "${var.kops_admin_role_name}"
+  user_names        = []
+  member_account_id = "${data.terraform_remote_state.accounts.dev_account_id}"
+  require_mfa       = "true"
+}
+
+module "kops_readonly_access_group_dev" {
+  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.3.0"
+  enabled           = "${contains(var.kops_iam_accounts_enabled, "dev") == true ? "true" : "false"}"
+  namespace         = "${var.namespace}"
+  stage             = "dev"
+  name              = "readonly"
+  attributes        = ["kops"]
+  role_name         = "${var.kops_readonly_role_name}"
+  user_names        = []
+  member_account_id = "${data.terraform_remote_state.accounts.dev_account_id}"
+  require_mfa       = "true"
+}

--- a/aws/kops-iam-users/dev.tf
+++ b/aws/kops-iam-users/dev.tf
@@ -5,7 +5,7 @@ module "kops_admin_access_group_dev" {
   stage             = "dev"
   name              = "admin"
   attributes        = ["kops"]
-  role_name         = "${var.kops_admin_role_name}"
+  role_name         = "${module.kops_admin_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.dev_account_id}"
   require_mfa       = "true"
@@ -18,7 +18,7 @@ module "kops_readonly_access_group_dev" {
   stage             = "dev"
   name              = "readonly"
   attributes        = ["kops"]
-  role_name         = "${var.kops_readonly_role_name}"
+  role_name         = "${module.kops_readonly_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.dev_account_id}"
   require_mfa       = "true"

--- a/aws/kops-iam-users/main.tf
+++ b/aws/kops-iam-users/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 0.11.2"
+
+  backend "s3" {}
+}
+
+provider "aws" {
+  assume_role {
+    role_arn = "${var.aws_assume_role_arn}"
+  }
+}
+
+data "terraform_remote_state" "accounts" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.namespace}-${var.stage}-terraform-state"
+    key    = "accounts/terraform.tfstate"
+  }
+}

--- a/aws/kops-iam-users/main.tf
+++ b/aws/kops-iam-users/main.tf
@@ -18,3 +18,25 @@ data "terraform_remote_state" "accounts" {
     key    = "accounts/terraform.tfstate"
   }
 }
+
+module "kops_admin_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
+  namespace  = "${var.namespace}"
+  name       = "kops"
+  stage      = "${var.stage}"
+  attributes = ["admin"]
+  delimiter  = "${var.delimiter}"
+  tags       = "${var.tags}"
+  enabled    = "true"
+}
+
+module "kops_readonly_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
+  namespace  = "${var.namespace}"
+  name       = "kops"
+  stage      = "${var.stage}"
+  attributes = ["readonly"]
+  delimiter  = "${var.delimiter}"
+  tags       = "${var.tags}"
+  enabled    = "true"
+}

--- a/aws/kops-iam-users/prod.tf
+++ b/aws/kops-iam-users/prod.tf
@@ -1,0 +1,25 @@
+module "kops_admin_access_group_prod" {
+  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.3.0"
+  enabled           = "${contains(var.kops_iam_accounts_enabled, "prod") == true ? "true" : "false"}"
+  namespace         = "${var.namespace}"
+  stage             = "prod"
+  name              = "admin"
+  attributes        = ["kops"]
+  role_name         = "${var.kops_admin_role_name}"
+  user_names        = []
+  member_account_id = "${data.terraform_remote_state.accounts.prod_account_id}"
+  require_mfa       = "true"
+}
+
+module "kops_readonly_access_group_prod" {
+  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.3.0"
+  enabled           = "${contains(var.kops_iam_accounts_enabled, "prod") == true ? "true" : "false"}"
+  namespace         = "${var.namespace}"
+  stage             = "prod"
+  name              = "readonly"
+  attributes        = ["kops"]
+  role_name         = "${var.kops_readonly_role_name}"
+  user_names        = []
+  member_account_id = "${data.terraform_remote_state.accounts.prod_account_id}"
+  require_mfa       = "true"
+}

--- a/aws/kops-iam-users/prod.tf
+++ b/aws/kops-iam-users/prod.tf
@@ -5,7 +5,7 @@ module "kops_admin_access_group_prod" {
   stage             = "prod"
   name              = "admin"
   attributes        = ["kops"]
-  role_name         = "${var.kops_admin_role_name}"
+  role_name         = "${module.kops_admin_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.prod_account_id}"
   require_mfa       = "true"
@@ -18,7 +18,7 @@ module "kops_readonly_access_group_prod" {
   stage             = "prod"
   name              = "readonly"
   attributes        = ["kops"]
-  role_name         = "${var.kops_readonly_role_name}"
+  role_name         = "${module.kops_readonly_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.prod_account_id}"
   require_mfa       = "true"

--- a/aws/kops-iam-users/staging.tf
+++ b/aws/kops-iam-users/staging.tf
@@ -1,0 +1,25 @@
+module "kops_admin_access_group_staging" {
+  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.3.0"
+  enabled           = "${contains(var.kops_iam_accounts_enabled, "staging") == true ? "true" : "false"}"
+  namespace         = "${var.namespace}"
+  stage             = "staging"
+  name              = "admin"
+  attributes        = ["kops"]
+  role_name         = "${var.kops_admin_role_name}"
+  user_names        = []
+  member_account_id = "${data.terraform_remote_state.accounts.staging_account_id}"
+  require_mfa       = "true"
+}
+
+module "kops_readonly_access_group_staging" {
+  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.3.0"
+  enabled           = "${contains(var.kops_iam_accounts_enabled, "staging") == true ? "true" : "false"}"
+  namespace         = "${var.namespace}"
+  stage             = "staging"
+  name              = "readonly"
+  attributes        = ["kops"]
+  role_name         = "${var.kops_readonly_role_name}"
+  user_names        = []
+  member_account_id = "${data.terraform_remote_state.accounts.staging_account_id}"
+  require_mfa       = "true"
+}

--- a/aws/kops-iam-users/staging.tf
+++ b/aws/kops-iam-users/staging.tf
@@ -5,7 +5,7 @@ module "kops_admin_access_group_staging" {
   stage             = "staging"
   name              = "admin"
   attributes        = ["kops"]
-  role_name         = "${var.kops_admin_role_name}"
+  role_name         = "${module.kops_admin_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.staging_account_id}"
   require_mfa       = "true"
@@ -18,7 +18,7 @@ module "kops_readonly_access_group_staging" {
   stage             = "staging"
   name              = "readonly"
   attributes        = ["kops"]
-  role_name         = "${var.kops_readonly_role_name}"
+  role_name         = "${module.kops_readonly_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.staging_account_id}"
   require_mfa       = "true"

--- a/aws/kops-iam-users/testing.tf
+++ b/aws/kops-iam-users/testing.tf
@@ -1,0 +1,25 @@
+module "kops_admin_access_group_testing" {
+  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.3.0"
+  enabled           = "${contains(var.kops_iam_accounts_enabled, "testing") == true ? "true" : "false"}"
+  namespace         = "${var.namespace}"
+  stage             = "testing"
+  name              = "admin"
+  attributes        = ["kops"]
+  role_name         = "${var.kops_admin_role_name}"
+  user_names        = []
+  member_account_id = "${data.terraform_remote_state.accounts.testing_account_id}"
+  require_mfa       = "true"
+}
+
+module "kops_readonly_access_group_testing" {
+  source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.3.0"
+  enabled           = "${contains(var.kops_iam_accounts_enabled, "testing") == true ? "true" : "false"}"
+  namespace         = "${var.namespace}"
+  stage             = "testing"
+  name              = "readonly"
+  attributes        = ["kops"]
+  role_name         = "${var.kops_readonly_role_name}"
+  user_names        = []
+  member_account_id = "${data.terraform_remote_state.accounts.testing_account_id}"
+  require_mfa       = "true"
+}

--- a/aws/kops-iam-users/testing.tf
+++ b/aws/kops-iam-users/testing.tf
@@ -5,7 +5,7 @@ module "kops_admin_access_group_testing" {
   stage             = "testing"
   name              = "admin"
   attributes        = ["kops"]
-  role_name         = "${var.kops_admin_role_name}"
+  role_name         = "${module.kops_admin_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.testing_account_id}"
   require_mfa       = "true"
@@ -18,7 +18,7 @@ module "kops_readonly_access_group_testing" {
   stage             = "testing"
   name              = "readonly"
   attributes        = ["kops"]
-  role_name         = "${var.kops_readonly_role_name}"
+  role_name         = "${module.kops_readonly_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.testing_account_id}"
   require_mfa       = "true"

--- a/aws/kops-iam-users/variables.tf
+++ b/aws/kops-iam-users/variables.tf
@@ -18,14 +18,14 @@ variable "stage" {
   description = "Stage, e.g. 'prod', 'staging', 'dev', or 'test'"
 }
 
-variable "kops_readonly_role_name" {
+variable "delimiter" {
   type        = "string"
-  default     = "KopsReadOnly"
-  description = "IAM role name for the Kubernetes readonly user, used by aws-iam-authenticator"
+  default     = "-"
+  description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
 }
 
-variable "kops_admin_role_name" {
-  type        = "string"
-  default     = "KopsAdmin"
-  description = "IAM role name for the Kubernetes admin user, used by aws-iam-authenticator"
+variable "tags" {
+  type        = "map"
+  default     = {}
+  description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`"
 }

--- a/aws/kops-iam-users/variables.tf
+++ b/aws/kops-iam-users/variables.tf
@@ -1,0 +1,31 @@
+variable "aws_assume_role_arn" {
+  type = "string"
+}
+
+variable "kops_iam_accounts_enabled" {
+  type        = "list"
+  description = "Accounts to create an IAM role and group for Kops users"
+  default     = ["dev", "staging", "prod", "testing"]
+}
+
+variable "namespace" {
+  type        = "string"
+  description = "Namespace (e.g. `cp` or `cloudposse`)"
+}
+
+variable "stage" {
+  type        = "string"
+  description = "Stage, e.g. 'prod', 'staging', 'dev', or 'test'"
+}
+
+variable "kops_readonly_role_name" {
+  type        = "string"
+  default     = "KopsReadOnly"
+  description = "IAM role name for the Kubernetes readonly user, used by aws-iam-authenticator"
+}
+
+variable "kops_admin_role_name" {
+  type        = "string"
+  default     = "KopsAdmin"
+  description = "IAM role name for the Kubernetes admin user, used by aws-iam-authenticator"
+}


### PR DESCRIPTION
## what

Adds terraform-aws-kops-iam-authenticator-config module to terraform-root-modules so we can write a configMap for `aws-iam-authenticator` to our kops clusters. 

It also adds kubernetes admin (default: `KubernetesAdmin`) and readonly (default: `KubernetesReadOnly`) IAM groups and associated IAM roles (no policy required) to our root AWS account allowing sub accounts to assume the role.

## why
* Fine grained access controls to Kubernetes 

## references

See https://github.com/kubernetes-sigs/aws-iam-authenticator#full-configuration-format