### PR TITLE
Label per account

### DIFF
--- a/aws/kops-iam-users/corp.tf
+++ b/aws/kops-iam-users/corp.tf
@@ -1,11 +1,33 @@
+module "kops_admin_corp_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
+  namespace  = "${var.namespace}"
+  name       = "kops"
+  stage      = "corp"
+  attributes = ["admin"]
+  delimiter  = "${var.delimiter}"
+  tags       = "${var.tags}"
+  enabled    = "true"
+}
+
+module "kops_readonly_corp_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
+  namespace  = "${var.namespace}"
+  name       = "kops"
+  stage      = "corp"
+  attributes = ["readonly"]
+  delimiter  = "${var.delimiter}"
+  tags       = "${var.tags}"
+  enabled    = "true"
+}
+
 module "kops_admin_access_group_corp" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
   enabled           = "${contains(var.kops_iam_accounts_enabled, "corp") == true ? "true" : "false"}"
   namespace         = "${var.namespace}"
   stage             = "corp"
-  name              = "admin"
-  attributes        = ["kops"]
-  role_name         = "${module.kops_admin_label.id}"
+  name              = "kops"
+  attributes        = ["admin"]
+  role_name         = "${module.kops_admin_corp_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.corp_account_id}"
   require_mfa       = "true"
@@ -16,9 +38,9 @@ module "kops_readonly_access_group_corp" {
   enabled           = "${contains(var.kops_iam_accounts_enabled, "corp") == true ? "true" : "false"}"
   namespace         = "${var.namespace}"
   stage             = "corp"
-  name              = "readonly"
-  attributes        = ["kops"]
-  role_name         = "${module.kops_readonly_label.id}"
+  name              = "kops"
+  attributes        = ["readonly"]
+  role_name         = "${module.kops_readonly_corp_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.corp_account_id}"
   require_mfa       = "true"

--- a/aws/kops-iam-users/data.tf
+++ b/aws/kops-iam-users/data.tf
@@ -1,11 +1,33 @@
+module "kops_admin_data_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
+  namespace  = "${var.namespace}"
+  name       = "kops"
+  stage      = "data"
+  attributes = ["admin"]
+  delimiter  = "${var.delimiter}"
+  tags       = "${var.tags}"
+  enabled    = "true"
+}
+
+module "kops_readonly_data_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
+  namespace  = "${var.namespace}"
+  name       = "kops"
+  stage      = "data"
+  attributes = ["readonly"]
+  delimiter  = "${var.delimiter}"
+  tags       = "${var.tags}"
+  enabled    = "true"
+}
+
 module "kops_admin_access_group_data" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
   enabled           = "${contains(var.kops_iam_accounts_enabled, "data") == true ? "true" : "false"}"
   namespace         = "${var.namespace}"
   stage             = "data"
-  name              = "admin"
-  attributes        = ["kops"]
-  role_name         = "${module.kops_admin_label.id}"
+  name              = "kops"
+  attributes        = ["admin"]
+  role_name         = "${module.kops_admin_data_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.data_account_id}"
   require_mfa       = "true"
@@ -16,9 +38,9 @@ module "kops_readonly_access_group_data" {
   enabled           = "${contains(var.kops_iam_accounts_enabled, "data") == true ? "true" : "false"}"
   namespace         = "${var.namespace}"
   stage             = "data"
-  name              = "readonly"
-  attributes        = ["kops"]
-  role_name         = "${module.kops_readonly_label.id}"
+  name              = "kops"
+  attributes        = ["readonly"]
+  role_name         = "${module.kops_readonly_data_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.data_account_id}"
   require_mfa       = "true"

--- a/aws/kops-iam-users/dev.tf
+++ b/aws/kops-iam-users/dev.tf
@@ -1,11 +1,33 @@
+module "kops_admin_dev_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
+  namespace  = "${var.namespace}"
+  name       = "kops"
+  stage      = "dev"
+  attributes = ["admin"]
+  delimiter  = "${var.delimiter}"
+  tags       = "${var.tags}"
+  enabled    = "true"
+}
+
+module "kops_readonly_dev_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
+  namespace  = "${var.namespace}"
+  name       = "kops"
+  stage      = "dev"
+  attributes = ["readonly"]
+  delimiter  = "${var.delimiter}"
+  tags       = "${var.tags}"
+  enabled    = "true"
+}
+
 module "kops_admin_access_group_dev" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
   enabled           = "${contains(var.kops_iam_accounts_enabled, "dev") == true ? "true" : "false"}"
   namespace         = "${var.namespace}"
   stage             = "dev"
-  name              = "admin"
-  attributes        = ["kops"]
-  role_name         = "${module.kops_admin_label.id}"
+  name              = "kops"
+  attributes        = ["admin"]
+  role_name         = "${module.kops_admin_dev_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.dev_account_id}"
   require_mfa       = "true"
@@ -16,9 +38,9 @@ module "kops_readonly_access_group_dev" {
   enabled           = "${contains(var.kops_iam_accounts_enabled, "dev") == true ? "true" : "false"}"
   namespace         = "${var.namespace}"
   stage             = "dev"
-  name              = "readonly"
-  attributes        = ["kops"]
-  role_name         = "${module.kops_readonly_label.id}"
+  name              = "kops"
+  attributes        = ["readonly"]
+  role_name         = "${module.kops_readonly_dev_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.dev_account_id}"
   require_mfa       = "true"

--- a/aws/kops-iam-users/main.tf
+++ b/aws/kops-iam-users/main.tf
@@ -18,25 +18,3 @@ data "terraform_remote_state" "accounts" {
     key    = "accounts/terraform.tfstate"
   }
 }
-
-module "kops_admin_label" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
-  namespace  = "${var.namespace}"
-  name       = "kops"
-  stage      = "${var.stage}"
-  attributes = ["admin"]
-  delimiter  = "${var.delimiter}"
-  tags       = "${var.tags}"
-  enabled    = "true"
-}
-
-module "kops_readonly_label" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
-  namespace  = "${var.namespace}"
-  name       = "kops"
-  stage      = "${var.stage}"
-  attributes = ["readonly"]
-  delimiter  = "${var.delimiter}"
-  tags       = "${var.tags}"
-  enabled    = "true"
-}

--- a/aws/kops-iam-users/prod.tf
+++ b/aws/kops-iam-users/prod.tf
@@ -1,11 +1,33 @@
+module "kops_admin_prod_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
+  namespace  = "${var.namespace}"
+  name       = "kops"
+  stage      = "prod"
+  attributes = ["admin"]
+  delimiter  = "${var.delimiter}"
+  tags       = "${var.tags}"
+  enabled    = "true"
+}
+
+module "kops_readonly_prod_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
+  namespace  = "${var.namespace}"
+  name       = "kops"
+  stage      = "prod"
+  attributes = ["readonly"]
+  delimiter  = "${var.delimiter}"
+  tags       = "${var.tags}"
+  enabled    = "true"
+}
+
 module "kops_admin_access_group_prod" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
   enabled           = "${contains(var.kops_iam_accounts_enabled, "prod") == true ? "true" : "false"}"
   namespace         = "${var.namespace}"
   stage             = "prod"
-  name              = "admin"
-  attributes        = ["kops"]
-  role_name         = "${module.kops_admin_label.id}"
+  name              = "kops"
+  attributes        = ["admin"]
+  role_name         = "${module.kops_admin_prod_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.prod_account_id}"
   require_mfa       = "true"
@@ -16,9 +38,9 @@ module "kops_readonly_access_group_prod" {
   enabled           = "${contains(var.kops_iam_accounts_enabled, "prod") == true ? "true" : "false"}"
   namespace         = "${var.namespace}"
   stage             = "prod"
-  name              = "readonly"
-  attributes        = ["kops"]
-  role_name         = "${module.kops_readonly_label.id}"
+  name              = "kops"
+  attributes        = ["readonly"]
+  role_name         = "${module.kops_readonly_prod_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.prod_account_id}"
   require_mfa       = "true"

--- a/aws/kops-iam-users/staging.tf
+++ b/aws/kops-iam-users/staging.tf
@@ -1,11 +1,33 @@
+module "kops_admin_staging_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
+  namespace  = "${var.namespace}"
+  name       = "kops"
+  stage      = "staging"
+  attributes = ["admin"]
+  delimiter  = "${var.delimiter}"
+  tags       = "${var.tags}"
+  enabled    = "true"
+}
+
+module "kops_readonly_staging_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
+  namespace  = "${var.namespace}"
+  name       = "kops"
+  stage      = "staging"
+  attributes = ["readonly"]
+  delimiter  = "${var.delimiter}"
+  tags       = "${var.tags}"
+  enabled    = "true"
+}
+
 module "kops_admin_access_group_staging" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
   enabled           = "${contains(var.kops_iam_accounts_enabled, "staging") == true ? "true" : "false"}"
   namespace         = "${var.namespace}"
   stage             = "staging"
-  name              = "admin"
-  attributes        = ["kops"]
-  role_name         = "${module.kops_admin_label.id}"
+  name              = "kops"
+  attributes        = ["admin"]
+  role_name         = "${module.kops_admin_staging_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.staging_account_id}"
   require_mfa       = "true"
@@ -16,9 +38,9 @@ module "kops_readonly_access_group_staging" {
   enabled           = "${contains(var.kops_iam_accounts_enabled, "staging") == true ? "true" : "false"}"
   namespace         = "${var.namespace}"
   stage             = "staging"
-  name              = "readonly"
-  attributes        = ["kops"]
-  role_name         = "${module.kops_readonly_label.id}"
+  name              = "kops"
+  attributes        = ["readonly"]
+  role_name         = "${module.kops_readonly_staging_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.staging_account_id}"
   require_mfa       = "true"

--- a/aws/kops-iam-users/testing.tf
+++ b/aws/kops-iam-users/testing.tf
@@ -1,11 +1,33 @@
+module "kops_admin_testing_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
+  namespace  = "${var.namespace}"
+  name       = "kops"
+  stage      = "testing"
+  attributes = ["admin"]
+  delimiter  = "${var.delimiter}"
+  tags       = "${var.tags}"
+  enabled    = "true"
+}
+
+module "kops_readonly_testing_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
+  namespace  = "${var.namespace}"
+  name       = "kops"
+  stage      = "testing"
+  attributes = ["readonly"]
+  delimiter  = "${var.delimiter}"
+  tags       = "${var.tags}"
+  enabled    = "true"
+}
+
 module "kops_admin_access_group_testing" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
   enabled           = "${contains(var.kops_iam_accounts_enabled, "testing") == true ? "true" : "false"}"
   namespace         = "${var.namespace}"
   stage             = "testing"
-  name              = "admin"
-  attributes        = ["kops"]
-  role_name         = "${module.kops_admin_label.id}"
+  name              = "kops"
+  attributes        = ["admin"]
+  role_name         = "${module.kops_admin_testing_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.testing_account_id}"
   require_mfa       = "true"
@@ -16,9 +38,9 @@ module "kops_readonly_access_group_testing" {
   enabled           = "${contains(var.kops_iam_accounts_enabled, "testing") == true ? "true" : "false"}"
   namespace         = "${var.namespace}"
   stage             = "testing"
-  name              = "readonly"
-  attributes        = ["kops"]
-  role_name         = "${module.kops_readonly_label.id}"
+  name              = "kops"
+  attributes        = ["readonly"]
+  role_name         = "${module.kops_readonly_testing_label.id}"
   user_names        = []
   member_account_id = "${data.terraform_remote_state.accounts.testing_account_id}"
   require_mfa       = "true"


### PR DESCRIPTION
## what

Have a module per account for `kops-iam-users`

## why

Otherwise we are passing the wrong stage e.g. root, when it should be
testing for this role.