### PR TITLE
[aws/chamber] add 'enable' variable

### DIFF
--- a/aws/chamber/user.tf
+++ b/aws/chamber/user.tf
@@ -10,6 +10,7 @@ module "chamber_user" {
   name        = "chamber"
   attributes  = ["codefresh"]
   kms_key_arn = "${module.chamber_kms_key.key_arn}"
+  enabled     = "${var.enabled}"
 
   ssm_resources = [
     "${formatlist("arn:aws:ssm:%s:%s:parameter/%s/*", data.aws_region.default.name, data.aws_caller_identity.default.account_id, var.parameter_groups)}",

--- a/aws/chamber/variables.tf
+++ b/aws/chamber/variables.tf
@@ -1,0 +1,4 @@
+variable "enabled" {
+    description = "Whether or not to create any chamber resources"
+    default     = "true"
+}


### PR DESCRIPTION
## What's changing

Adds `enabled` param when calling module `cloudposse/terraform-aws-iam-chamber-user`.
Module already supports it.
Maintains historical users: default=`true`

## Why

We have an environment where we'd like to set this to disabled.