### PR TITLE
[aws/account-settings] add var to module: minimum_password_length

### DIFF
--- a/aws/account-settings/main.tf
+++ b/aws/account-settings/main.tf
@@ -16,4 +16,6 @@ module "account_settings" {
   stage     = "${var.stage}"
   name      = "${var.name}"
   enabled   = "${var.enabled}"
+
+  minimum_password_length = "${var.minimum_password_length}"
 }

--- a/aws/account-settings/outputs.tf
+++ b/aws/account-settings/outputs.tf
@@ -2,6 +2,10 @@ output "account_alias" {
   value = "${module.account_settings.account_alias}"
 }
 
+output "minimum_password_length" {
+  value = "${module.account_settings.minimum_password_length}"
+}
+
 output "signin_url" {
   value = "${module.account_settings.signin_url}"
 }

--- a/aws/account-settings/variables.tf
+++ b/aws/account-settings/variables.tf
@@ -1,6 +1,7 @@
 variable "minimum_password_length" {
   type        = "string"
   description = "Minimum number of characters allowed in an IAM user password.  Integer between 6 and 128, per https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_account-policy.html"
+  default     = "8"  ## Same default as https://github.com/cloudposse/terraform-aws-iam-account-settings
 }
 
 variable "aws_assume_role_arn" {

--- a/aws/account-settings/variables.tf
+++ b/aws/account-settings/variables.tf
@@ -1,7 +1,9 @@
 variable "minimum_password_length" {
   type        = "string"
   description = "Minimum number of characters allowed in an IAM user password.  Integer between 6 and 128, per https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_account-policy.html"
-  default     = "8"  ## Same default as https://github.com/cloudposse/terraform-aws-iam-account-settings
+
+  ## Same default as https://github.com/cloudposse/terraform-aws-iam-account-settings:
+  default = "8"
 }
 
 variable "aws_assume_role_arn" {

--- a/aws/account-settings/variables.tf
+++ b/aws/account-settings/variables.tf
@@ -1,3 +1,8 @@
+variable "minimum_password_length" {
+  type        = "string"
+  description = "Minimum number of characters allowed in an IAM user password.  Integer between 6 and 128, per https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_account-policy.html"
+}
+
 variable "aws_assume_role_arn" {
   type = "string"
 }


### PR DESCRIPTION
## What's changing

Adding a new variable `minimum_password_length` to the `aws/account-settings` module.

## Why

Account settings should write and output the account-level minimum password lengths so that
our https://github.com/cloudposse/terraform-aws-iam-user module can use the output value when createing users, so valid password lengths can be used.
