### PR TITLE
Add Datadog provisioning

### DIFF
--- a/aws/datadog/Makefile
+++ b/aws/datadog/Makefile
@@ -1,0 +1,15 @@
+## Initialize terraform remote state
+init:
+	[ -f .terraform/terraform.tfstate ] || terraform $@
+
+## Clean up the project
+clean:
+	rm -rf .terraform *.tfstate*
+
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
+	terraform $@

--- a/aws/datadog/main.tf
+++ b/aws/datadog/main.tf
@@ -4,7 +4,7 @@ module "datadog_ids" {
 }
 
 module "datadog_aws_integration" {
-  source              = "git::https://github.com/cloudposse/terraform-datadog-aws-integration.git?ref=tags/0.1.5"
+  source              = "git::https://github.com/cloudposse/terraform-datadog-aws-integration.git?ref=split-policies"
   namespace           = "${var.namespace}"
   stage               = "${var.stage}"
   name                = "datadog"

--- a/aws/datadog/main.tf
+++ b/aws/datadog/main.tf
@@ -1,0 +1,14 @@
+module "datadog_ids" {
+  source         = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
+  parameter_read = ["/datadog/datadog_external_id"]
+}
+
+module "datadog_aws_integration" {
+  source                     = "git::https://github.com/cloudposse/terraform-datadog-aws-integration.git?ref=tags/0.1.5"
+  namespace                  = "${var.namespace}"
+  stage                      = "${var.stage}"
+  name                       = "datadog"
+  datadog_external_id        = "${lookup(module.datadog_ids.map, "/datadog/datadog_external_id")}"
+  integrations               = "${var.integrations}"
+}
+

--- a/aws/datadog/main.tf
+++ b/aws/datadog/main.tf
@@ -4,7 +4,7 @@ module "datadog_ids" {
 }
 
 module "datadog_aws_integration" {
-  source              = "git::https://github.com/cloudposse/terraform-datadog-aws-integration.git?ref=split-policies"
+  source              = "git::https://github.com/cloudposse/terraform-datadog-aws-integration.git?ref=tags/0.2.0"
   namespace           = "${var.namespace}"
   stage               = "${var.stage}"
   name                = "datadog"

--- a/aws/datadog/main.tf
+++ b/aws/datadog/main.tf
@@ -4,11 +4,10 @@ module "datadog_ids" {
 }
 
 module "datadog_aws_integration" {
-  source                     = "git::https://github.com/cloudposse/terraform-datadog-aws-integration.git?ref=tags/0.1.5"
-  namespace                  = "${var.namespace}"
-  stage                      = "${var.stage}"
-  name                       = "datadog"
-  datadog_external_id        = "${lookup(module.datadog_ids.map, "/datadog/datadog_external_id")}"
-  integrations               = "${var.integrations}"
+  source              = "git::https://github.com/cloudposse/terraform-datadog-aws-integration.git?ref=tags/0.1.5"
+  namespace           = "${var.namespace}"
+  stage               = "${var.stage}"
+  name                = "datadog"
+  datadog_external_id = "${lookup(module.datadog_ids.map, "/datadog/datadog_external_id")}"
+  integrations        = "${var.integrations}"
 }
-

--- a/aws/datadog/terraform.tfvars.example
+++ b/aws/datadog/terraform.tfvars.example
@@ -1,0 +1,3 @@
+namespace="cp"
+stage="staging"
+integrations=["all"]

--- a/aws/datadog/variables.tf
+++ b/aws/datadog/variables.tf
@@ -8,5 +8,5 @@ variable "stage" {
 
 variable "integrations" {
   type        = "list"
-  description = "List of AWS integration permissions sets to apply (all, core, rds)"
+  description = "List of integration names with permissions to apply (`all`, `core`, `rds`)"
 }

--- a/aws/datadog/variables.tf
+++ b/aws/datadog/variables.tf
@@ -1,0 +1,13 @@
+
+variable "namespace" {
+  description = "Namespace (e.g. `cp` or `cloudposse`)"
+}
+
+variable "stage" {
+  description = "Stage (e.g. `prod`, `dev`, `staging`)"
+}
+
+variable "integrations" {
+  type        = "list"
+  description = "List of AWS integration permissions sets to apply (all, core, rds)"
+}

--- a/aws/datadog/variables.tf
+++ b/aws/datadog/variables.tf
@@ -1,4 +1,3 @@
-
 variable "namespace" {
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }


### PR DESCRIPTION
## what
* Add IAM role required by Datadog for AWS integration
* Use SSM Parameter store retrieve External ID

## why
* To support the Datadog official integration with AWS


## references
* https://docs.datadoghq.com/integrations/amazon_web_services/

Requires [terraform-aws-datadog-integration PR 8](https://github.com/cloudposse/terraform-aws-datadog-integration/pull/8) version 0.2.0 