### PR TITLE
[aws/ecs] Fix `allow_overwrite` for SOA

### DIFF
--- a/aws/ecs/dns.tf
+++ b/aws/ecs/dns.tf
@@ -12,8 +12,7 @@ variable "dns_zone_name" {
 }
 
 module "dns" {
-  #source           = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-zone.git?ref=tags/0.3.0"
-  source           = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-zone.git?ref=fix-allow-overwrite"
+  source           = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-zone.git?ref=tags/0.3.1"
   enabled          = "${var.dns_enabled}"
   namespace        = "${var.namespace}"
   stage            = "${var.stage}"

--- a/aws/ecs/dns.tf
+++ b/aws/ecs/dns.tf
@@ -12,7 +12,8 @@ variable "dns_zone_name" {
 }
 
 module "dns" {
-  source           = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-zone.git?ref=tags/0.3.0"
+  #source           = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-zone.git?ref=tags/0.3.0"
+  source           = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-zone.git?ref=fix-allow-overwrite"
   enabled          = "${var.dns_enabled}"
   namespace        = "${var.namespace}"
   stage            = "${var.stage}"


### PR DESCRIPTION
## what
* Explicitly set `allow_overwrite=true` via https://github.com/cloudposse/terraform-aws-route53-cluster-zone/pull/19

## why
* This is required to set the `SOA` for a zone, which will be created automatically by AWS
* Functionality changed in the latest `terraform-aws-provider`

## references
* https://www.terraform.io/docs/providers/aws/guides/version-2-upgrade.html#allow_overwrite-default-value-change
* https://github.com/terraform-providers/terraform-provider-aws/issues/7846