### PR TITLE
[kops-aws-platform] Add "view" role to k8s

### DIFF
--- a/aws/kops-aws-platform/iam-authenticator.tf
+++ b/aws/kops-aws-platform/iam-authenticator.tf
@@ -34,19 +34,21 @@ variable "readonly_k8s_groups" {
 }
 
 resource "kubernetes_cluster_role_binding" "view" {
-    metadata {
-        name = "view-binding"
-    }
-    role_ref {
-        api_group = "rbac.authorization.k8s.io"
-        kind = "ClusterRole"
-        name = "view"
-    }
-    subject {
-        kind = "Group"
-        name = "view"
-        api_group = "rbac.authorization.k8s.io"
-    }
+  metadata {
+    name = "view-binding"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "view"
+  }
+
+  subject {
+    kind      = "Group"
+    name      = "view"
+    api_group = "rbac.authorization.k8s.io"
+  }
 }
 
 variable "aws_root_account_id" {

--- a/aws/kops-aws-platform/iam-authenticator.tf
+++ b/aws/kops-aws-platform/iam-authenticator.tf
@@ -30,7 +30,23 @@ variable "readonly_k8s_username" {
 variable "readonly_k8s_groups" {
   type        = "list"
   description = "List of Kops groups to be mapped to `readonly_iam_role_arn`"
-  default     = ["system:authenticated"]
+  default     = ["view"]
+}
+
+resource "kubernetes_cluster_role_binding" "view" {
+    metadata {
+        name = "view-binding"
+    }
+    role_ref {
+        api_group = "rbac.authorization.k8s.io"
+        kind = "ClusterRole"
+        name = "view"
+    }
+    subject {
+        kind = "Group"
+        name = "view"
+        api_group = "rbac.authorization.k8s.io"
+    }
 }
 
 variable "aws_root_account_id" {


### PR DESCRIPTION
## what
Add a "view" group to Kubernetes for the read-only IAM role 

## why
Kubernetes has a default ClusterRole called `view` but it is not bound to anything. By creating a binding to a group named `view` we can give the read-only IAM role this ClusterRole, which is a default Kubernetes ClusterRole designed for read-only viewers. 