### PR TITLE
[aws/account-dns] Add allow_override for SOA record

### DIFF
--- a/aws/account-dns/main.tf
+++ b/aws/account-dns/main.tf
@@ -24,10 +24,11 @@ resource "aws_route53_zone" "dns_zone" {
 }
 
 resource "aws_route53_record" "dns_zone_soa" {
-  zone_id = "${aws_route53_zone.dns_zone.id}"
-  name    = "${aws_route53_zone.dns_zone.name}"
-  type    = "SOA"
-  ttl     = "60"
+  allow_overwrite = true
+  zone_id         = "${aws_route53_zone.dns_zone.id}"
+  name            = "${aws_route53_zone.dns_zone.name}"
+  type            = "SOA"
+  ttl             = "60"
 
   records = [
     "${aws_route53_zone.dns_zone.name_servers.0}. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400",


### PR DESCRIPTION
Because of [changes to the terraform aws provider](https://www.terraform.io/docs/providers/aws/guides/version-2-upgrade.html#allow_overwrite-default-value-change), the account-dns module needs to be updated to allow for overwriting the SOA dns record.