### PR TITLE
[kops] Add kops/replace target

### DIFF
--- a/aws/kops/Makefile
+++ b/aws/kops/Makefile
@@ -26,6 +26,10 @@ kops/build-manifest:
 kops/create:
 	kops create -f $(KOPS_MANIFEST)
 
+## Apply the kops manifest
+kops/replace:
+	kops replace -f $(KOPS_MANIFEST)
+
 ## Create the SSH Public Key secret
 kops/create-secret-sshpublickey:
 	echo "$(KOPS_SSH_PUBLIC_KEY)" > /dev/shm/$(KOPS_CLUSTER_NAME).pub


### PR DESCRIPTION
## what
Add `kops/replace` target form `make`

## why
When updating a cluster with a new configuration, you need to use `replace` instead of `update`