### PR TITLE
[ecs/atlantis] Add `Cognito` and `OIDC` authentication

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 Cloud Posse, LLC
+   Copyright 2018-2019 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/aws/ecs/README.md
+++ b/aws/ecs/README.md
@@ -50,7 +50,7 @@ artifacts:
 
 </details>
 
-## Trouble Shooting
+## Troubleshooting
 
 
 ### InvalidParameterException: Long arn format must be used for tagging operations

--- a/aws/ecs/atlantis.auto.tfvars.example
+++ b/aws/ecs/atlantis.auto.tfvars.example
@@ -12,4 +12,23 @@ atlantis_allow_repo_config = "true"
 atlantis_gh_user = "examplebot"
 atlantis_gh_team_whitelist = "engineering:plan,devops:*"
 
-atlantis_wake_word = "atlantis" 
+atlantis_wake_word = "atlantis"
+
+atlantis_authentication_enabled = "true"
+
+# https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html
+atlantis_authentication_action = {
+  type = "authenticate-oidc"
+
+  authenticate_oidc = [{
+    # Use this URL to create a Google OAuth 2.0 Client and obtain the Client ID and Client Secret: https://console.developers.google.com/apis/credentials
+    client_id     = "XXXXXXXXXXXXXXXXXXXX"
+    client_secret = "XXXXXXXXXXXX_XXXXXX"
+
+    # Use this URL to get Google Auth endpoints: https://accounts.google.com/.well-known/openid-configuration
+    issuer                 = "https://accounts.google.com"
+    authorization_endpoint = "https://accounts.google.com/o/oauth2/v2/auth"
+    token_endpoint         = "https://oauth2.googleapis.com/token"
+    user_info_endpoint     = "https://openidconnect.googleapis.com/v1/userinfo"
+  }]
+}

--- a/aws/ecs/atlantis.auto.tfvars.example
+++ b/aws/ecs/atlantis.auto.tfvars.example
@@ -14,7 +14,6 @@ atlantis_gh_team_whitelist = "engineering:plan,devops:*"
 
 atlantis_wake_word = "atlantis"
 
-atlantis_authentication_enabled = "true"
 
 # https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html
 atlantis_authentication_action = {

--- a/aws/ecs/atlantis.tf
+++ b/aws/ecs/atlantis.tf
@@ -50,16 +50,10 @@ variable "atlantis_container_memory" {
   default     = "512"
 }
 
-variable "atlantis_authentication_enabled" {
-  type        = "string"
-  default     = "false"
-  description = "Whether to enable authentication action for ALB listener to authenticate users with Cognito or OIDC"
-}
-
 variable "atlantis_authentication_action" {
   type        = "map"
   default     = {}
-  description = "Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `authentication_enabled=true`"
+  description = "Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC"
 }
 
 module "atlantis" {
@@ -93,8 +87,7 @@ module "atlantis" {
   security_group_ids = ["${module.vpc.vpc_default_security_group_id}"]
   vpc_id             = "${module.vpc.vpc_id}"
 
-  authentication_enabled = "${var.atlantis_authentication_enabled}"
-  authentication_action  = "${var.atlantis_authentication_action}"
+  authentication_action = "${var.atlantis_authentication_action}"
 }
 
 output "atlantis_url" {

--- a/aws/ecs/atlantis.tf
+++ b/aws/ecs/atlantis.tf
@@ -50,8 +50,20 @@ variable "atlantis_container_memory" {
   default     = "512"
 }
 
+variable "atlantis_authentication_enabled" {
+  type        = "string"
+  default     = "false"
+  description = "Whether to enable authentication action for ALB listener to authenticate users with Cognito or OIDC"
+}
+
+variable "atlantis_authentication_action" {
+  type        = "map"
+  default     = {}
+  description = "Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `authentication_enabled=true`"
+}
+
 module "atlantis" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-ecs-atlantis.git?ref=tags/0.3.0"
+  source    = "git::https://github.com/cloudposse/terraform-aws-ecs-atlantis.git?ref=tags/0.4.0"
   enabled   = "${var.atlantis_enabled}"
   name      = "${var.name}"
   namespace = "${var.namespace}"
@@ -80,6 +92,9 @@ module "atlantis" {
   private_subnet_ids = ["${module.subnets.private_subnet_ids}"]
   security_group_ids = ["${module.vpc.vpc_default_security_group_id}"]
   vpc_id             = "${module.vpc.vpc_id}"
+
+  authentication_enabled = "${var.atlantis_authentication_enabled}"
+  authentication_action  = "${var.atlantis_authentication_action}"
 }
 
 output "atlantis_url" {

--- a/aws/ecs/default-backend.tf
+++ b/aws/ecs/default-backend.tf
@@ -8,7 +8,7 @@ variable "default_backend_name" {
 
 # default backend app
 module "default_backend_web_app" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.14.0"
+  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.15.0"
   name       = "${var.name}"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
@@ -44,4 +44,7 @@ module "default_backend_web_app" {
   alb_target_group_alarms_response_time_threshold = "0.5"
   alb_target_group_alarms_period                  = "300"
   alb_target_group_alarms_evaluation_periods      = "1"
+
+  alb_ingress_unauthenticated_paths = ["/*"]
+  alb_ingress_authenticated_paths   = []
 }

--- a/aws/ecs/default-backend.tf
+++ b/aws/ecs/default-backend.tf
@@ -8,7 +8,7 @@ variable "default_backend_name" {
 
 # default backend app
 module "default_backend_web_app" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.10.0"
+  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.14.0"
   name       = "${var.name}"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"


### PR DESCRIPTION
## what
* Add `Cognito` and `OIDC` authentication to ECS for Atlantis

## why
* To be able to authenticate Atlantis ALB endpoints with Cognito or OIDC (e.g. Google, GitHub)
