### PR TITLE
[root-dns] Update to work with Terraform AWS provider version 2.0

### DIFF
--- a/aws/root-dns/parent.tf
+++ b/aws/root-dns/parent.tf
@@ -9,10 +9,11 @@ resource "aws_route53_zone" "parent_dns_zone" {
 }
 
 resource "aws_route53_record" "parent_dns_zone_soa" {
-  zone_id = "${aws_route53_zone.parent_dns_zone.id}"
-  name    = "${aws_route53_zone.parent_dns_zone.name}"
-  type    = "SOA"
-  ttl     = "60"
+  allow_overwrite = true
+  zone_id         = "${aws_route53_zone.parent_dns_zone.id}"
+  name            = "${aws_route53_zone.parent_dns_zone.name}"
+  type            = "SOA"
+  ttl             = "60"
 
   records = [
     "${aws_route53_zone.parent_dns_zone.name_servers.0}. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400",

--- a/aws/root-dns/root.tf
+++ b/aws/root-dns/root.tf
@@ -9,10 +9,11 @@ resource "aws_route53_zone" "root_dns_zone" {
 }
 
 resource "aws_route53_record" "root_dns_zone_soa" {
-  zone_id = "${aws_route53_zone.root_dns_zone.id}"
-  name    = "${aws_route53_zone.root_dns_zone.name}"
-  type    = "SOA"
-  ttl     = "60"
+  allow_overwrite = true
+  zone_id         = "${aws_route53_zone.root_dns_zone.id}"
+  name            = "${aws_route53_zone.root_dns_zone.name}"
+  type            = "SOA"
+  ttl             = "60"
 
   records = [
     "${aws_route53_zone.root_dns_zone.name_servers.0}. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400",


### PR DESCRIPTION
## what
[root-dns] Update to work with Terraform AWS provider version 2.0
## why
Version 2.0 introduced a breaking change that broke `root-dns`. This fixes it.