### PR TITLE
[codefresh-onprem] Add DocumentDB cluster

### DIFF
--- a/aws/codefresh-onprem/main.tf
+++ b/aws/codefresh-onprem/main.tf
@@ -34,15 +34,6 @@ variable "zone_name" {
   description = "DNS zone name"
 }
 
-data "terraform_remote_state" "backing_services" {
-  backend = "s3"
-
-  config {
-    bucket = "${var.namespace}-${var.stage}-terraform-state"
-    key    = "backing-services/terraform.tfstate"
-  }
-}
-
 variable "acm_enabled" {
   description = "Set to false to prevent the acm module from creating any resources"
   default     = "true"
@@ -64,8 +55,109 @@ variable "acm_zone_name" {
   description = "The name of the desired Route53 Hosted Zone"
 }
 
+variable "documentdb_cluster_enabled" {
+  description = "Set to false to prevent the module from creating DocumentDB cluster"
+  default     = "true"
+}
+
+variable "documentdb_instance_class" {
+  type        = "string"
+  default     = "db.r4.large"
+  description = "The instance class to use. For more details, see https://docs.aws.amazon.com/documentdb/latest/developerguide/db-instance-classes.html#db-instance-class-specs"
+}
+
+variable "documentdb_cluster_size" {
+  type        = "string"
+  default     = "3"
+  description = "Number of DocumentDB instances to create in the cluster"
+}
+
+variable "documentdb_port" {
+  type        = "string"
+  default     = "27017"
+  description = "DocumentDB port"
+}
+
+variable "documentdb_master_username" {
+  type        = "string"
+  default     = ""
+  description = "Username for the master DocumentDB user. If left empty, will be generated automatically"
+}
+
+variable "documentdb_master_password" {
+  type        = "string"
+  default     = ""
+  description = "Password for the master DocumentDB user. If left empty, will be generated automatically. Note that this may show up in logs, and it will be stored in the state file"
+}
+
+variable "documentdb_retention_period" {
+  type        = "string"
+  default     = "5"
+  description = "Number of days to retain DocumentDB backups for"
+}
+
+variable "documentdb_preferred_backup_window" {
+  type        = "string"
+  default     = "07:00-09:00"
+  description = "Daily time range during which the DocumentDB backups happen"
+}
+
+variable "documentdb_cluster_parameters" {
+  type        = "list"
+  default     = []
+  description = "List of DocumentDB parameters to apply"
+}
+
+variable "documentdb_cluster_family" {
+  type        = "string"
+  default     = "docdb3.6"
+  description = "The family of the DocumentDB cluster parameter group. For more details, see https://docs.aws.amazon.com/documentdb/latest/developerguide/db-cluster-parameter-group-create.html"
+}
+
+variable "documentdb_engine" {
+  type        = "string"
+  default     = "docdb"
+  description = "The name of the database engine to be used for DocumentDB cluster. Defaults to `docdb`. Valid values: `docdb`"
+}
+
+variable "documentdb_engine_version" {
+  type        = "string"
+  default     = ""
+  description = "The version number of the DocumentDB database engine to use"
+}
+
+variable "documentdb_storage_encrypted" {
+  description = "Specifies whether the DocumentDB cluster is encrypted"
+  default     = "true"
+}
+
+variable "documentdb_skip_final_snapshot" {
+  description = "Determines whether a final DocumentDB snapshot is created before the cluster is deleted"
+  default     = "true"
+}
+
+variable "documentdb_apply_immediately" {
+  description = "Specifies whether any DocumentDB cluster modifications are applied immediately, or during the next maintenance window"
+  default     = "true"
+}
+
+variable "documentdb_enabled_cloudwatch_logs_exports" {
+  type        = "list"
+  description = "List of DocumentDB log types to export to CloudWatch. The following log types are supported: audit, error, general, slowquery"
+  default     = []
+}
+
+data "terraform_remote_state" "backing_services" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.namespace}-${var.stage}-terraform-state"
+    key    = "backing-services/terraform.tfstate"
+  }
+}
+
 module "codefresh_enterprise_backing_services" {
-  source          = "git::https://github.com/cloudposse/terraform-aws-codefresh-backing-services.git?ref=tags/0.3.0"
+  source          = "git::https://github.com/cloudposse/terraform-aws-codefresh-backing-services.git?ref=tags/0.4.0"
   namespace       = "${var.namespace}"
   stage           = "${var.stage}"
   vpc_id          = "${data.terraform_remote_state.backing_services.vpc_id}"
@@ -77,6 +169,24 @@ module "codefresh_enterprise_backing_services" {
   acm_enabled        = "${var.acm_enabled}"
   acm_primary_domain = "${var.acm_primary_domain}"
   acm_san_domains    = ["${var.acm_san_domains}"]
+
+  # DocumentDB
+  documentdb_cluster_enabled                 = "${var.documentdb_cluster_enabled}"
+  documentdb_instance_class                  = "${var.documentdb_instance_class}"
+  documentdb_cluster_size                    = "${var.documentdb_cluster_size}"
+  documentdb_port                            = "${var.documentdb_port}"
+  documentdb_master_username                 = "${var.documentdb_master_username}"
+  documentdb_master_password                 = "${var.documentdb_master_password}"
+  documentdb_retention_period                = "${var.documentdb_retention_period}"
+  documentdb_preferred_backup_window         = "${var.documentdb_preferred_backup_window}"
+  documentdb_cluster_parameters              = ["${var.documentdb_cluster_parameters}"]
+  documentdb_cluster_family                  = "${var.documentdb_cluster_family}"
+  documentdb_engine                          = "${var.documentdb_engine}"
+  documentdb_engine_version                  = "${var.documentdb_engine_version}"
+  documentdb_storage_encrypted               = "${var.documentdb_storage_encrypted}"
+  documentdb_skip_final_snapshot             = "${var.documentdb_skip_final_snapshot}"
+  documentdb_apply_immediately               = "${var.documentdb_apply_immediately}"
+  documentdb_enabled_cloudwatch_logs_exports = ["${var.documentdb_enabled_cloudwatch_logs_exports}"]
 }
 
 output "elasticache_redis_id" {
@@ -159,4 +269,39 @@ output "acm_arn" {
 output "acm_domain_validation_options" {
   value       = "${module.codefresh_enterprise_backing_services.acm_domain_validation_options}"
   description = "CNAME records that are added to the DNS zone to complete certificate validation"
+}
+
+output "documentdb_master_username" {
+  value       = "${module.codefresh_enterprise_backing_services.documentdb_master_username}"
+  description = "DocumentDB Username for the master DB user"
+}
+
+output "documentdb_cluster_name" {
+  value       = "${module.codefresh_enterprise_backing_services.documentdb_cluster_name}"
+  description = "DocumentDB Cluster Identifier"
+}
+
+output "documentdb_arn" {
+  value       = "${module.codefresh_enterprise_backing_services.documentdb_arn}"
+  description = "Amazon Resource Name (ARN) of the DocumentDB cluster"
+}
+
+output "documentdb_endpoint" {
+  value       = "${module.codefresh_enterprise_backing_services.documentdb_endpoint}"
+  description = "Endpoint of the DocumentDB cluster"
+}
+
+output "documentdb_reader_endpoint" {
+  value       = "${module.codefresh_enterprise_backing_services.documentdb_reader_endpoint}"
+  description = "Read-only endpoint of the DocumentDB cluster, automatically load-balanced across replicas"
+}
+
+output "documentdb_master_host" {
+  value       = "${module.codefresh_enterprise_backing_services.documentdb_master_host}"
+  description = "DocumentDB master hostname"
+}
+
+output "documentdb_replicas_host" {
+  value       = "${module.codefresh_enterprise_backing_services.documentdb_replicas_host}"
+  description = "DocumentDB replicas hostname"
 }


### PR DESCRIPTION
## what
* [codefresh-onprem] Add DocumentDB cluster

## why
* Provision Amazon DocumentDB for Codefresh Enterprise and use it instead of MongoDB
