### PR TITLE
[vpc][kops]Create VPC by itself and have kops adopt it

### DIFF
--- a/aws/kops-aws-platform/variables.tf
+++ b/aws/kops-aws-platform/variables.tf
@@ -45,3 +45,8 @@ variable "tags" {
   default     = {}
   description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`"
 }
+
+variable "vpc_peering_enabled" {
+  default     = "true"
+  description = "Set to false to prevent the vpc-peering module from creating or accessing any resources"
+}

--- a/aws/kops-aws-platform/vpc-peering.tf
+++ b/aws/kops-aws-platform/vpc-peering.tf
@@ -8,6 +8,7 @@ data "aws_vpc" "backing_services_vpc" {
 
 module "kops_vpc_peering" {
   source                  = "git::https://github.com/cloudposse/terraform-aws-kops-vpc-peering.git?ref=tags/0.1.2"
+  enabled                 = "${var.vpc_peering_enabled}"
   namespace               = "${var.namespace}"
   stage                   = "${var.stage}"
   name                    = "kops-peering"

--- a/aws/kops/Makefile
+++ b/aws/kops/Makefile
@@ -32,7 +32,7 @@ kops/replace:
 
 ## Create the SSH Public Key secret
 kops/create-secret-sshpublickey:
-	echo "$(KOPS_SSH_PUBLIC_KEY)" > /dev/shm/$(KOPS_CLUSTER_NAME).pub
+	echo "$${KOPS_SSH_PUBLIC_KEY}" > /dev/shm/$(KOPS_CLUSTER_NAME).pub
 	kops create secret sshpublickey admin -i /dev/shm/$(KOPS_CLUSTER_NAME).pub
 
 ## Show update plan for the kops cluster

--- a/aws/kops/main.tf
+++ b/aws/kops/main.tf
@@ -17,8 +17,10 @@ locals {
   computed_availability_zones = "${data.aws_availability_zones.default.names}"
   distinct_availability_zones = "${distinct(compact(concat(var.availability_zones, local.computed_availability_zones)))}"
 
-  # Concatenate the predefined AZs with the computed AZs and select the first N distinct AZs. 
-  availability_zones      = "${slice(local.distinct_availability_zones, 0, var.availability_zone_count)}"
+  # If we are creating the VPC, concatenate the predefined AZs with the computed AZs and select the first N distinct AZs.
+  # If we are using a shared VPC, use the availability zones dictated by the VPC
+  availability_zones = "${split(",", var.create_vpc == "true" ? join(",", slice(local.distinct_availability_zones, 0, var.availability_zone_count)) : join("",data.aws_ssm_parameter.availability_zones.*.value))}"
+
   availability_zone_count = "${length(local.availability_zones)}"
 }
 
@@ -53,7 +55,7 @@ module "ssh_key_pair" {
 # Allocate one large subnet for each AZ, plus one additional one for the utility subnets.
 module "private_subnets" {
   source       = "subnets"
-  iprange      = "${var.network_cidr}"
+  iprange      = "${local.vpc_network_cidr}"
   newbits      = "${var.private_subnets_newbits > 0 ? var.private_subnets_newbits : local.availability_zone_count}"
   netnum       = "${var.private_subnets_netnum}"
   subnet_count = "${local.availability_zone_count+1}"
@@ -68,9 +70,65 @@ module "utility_subnets" {
   subnet_count = "${local.availability_zone_count}"
 }
 
+#######
+# If create_vpc is not true, then we import all the VPC configuration from the VPC chamber service
+#
+data "aws_ssm_parameter" "vpc_id" {
+  count = "${var.create_vpc == "true" ? 0 : 1}"
+  name  = "${format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "vpc_id")}"
+}
+
+data "aws_ssm_parameter" "vpc_cidr_block" {
+  count = "${var.create_vpc == "true" ? 0 : 1}"
+  name  = "${format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "cidr_block")}"
+}
+
+###
+# The following are lists, and must all be the same size and in the same order
+#
+data "aws_ssm_parameter" "availability_zones" {
+  count = "${var.create_vpc == "true" ? 0 : 1}"
+  name  = "${format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "availability_zones")}"
+}
+
+# List of NAT gateways from private subnet to public, one per subnet, which is one per availability zone
+data "aws_ssm_parameter" "nat_gateways" {
+  count = "${var.create_vpc == "true" ? 0 : 1}"
+  name  = "${format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "nat_gateways")}"
+}
+
+# List of private subnet CIDR blocks, one per availability zone
+data "aws_ssm_parameter" "private_subnet_cidrs" {
+  count = "${var.create_vpc == "true" ? 0 : 1}"
+  name  = "${format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "private_subnet_cidrs")}"
+}
+
+# List of private subnet AWS IDs, one per availability zone
+data "aws_ssm_parameter" "private_subnet_ids" {
+  count = "${var.create_vpc == "true" ? 0 : 1}"
+  name  = "${format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "private_subnet_ids")}"
+}
+
+# List of public subnet CIDR blocks, one per availability zone
+data "aws_ssm_parameter" "public_subnet_cidrs" {
+  count = "${var.create_vpc == "true" ? 0 : 1}"
+  name  = "${format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "public_subnet_cidrs")}"
+}
+
+# List of public subnet AWS IDs, one per availability zone
+data "aws_ssm_parameter" "public_subnet_ids" {
+  count = "${var.create_vpc == "true" ? 0 : 1}"
+  name  = "${format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "public_subnet_ids")}"
+}
+
+#
+# End of VPC data import
+######
+
 locals {
-  private_subnets = "${join(",", slice(module.private_subnets.cidrs, 1, local.availability_zone_count+1))}"
-  utility_subnets = "${join(",", module.utility_subnets.cidrs)}"
+  vpc_network_cidr     = "${var.create_vpc == "true" ? var.network_cidr : join("",data.aws_ssm_parameter.vpc_cidr_block.*.value)}"
+  private_subnet_cidrs = "${var.create_vpc == "true" ? join(",", slice(module.private_subnets.cidrs, 1, local.availability_zone_count+1)) : join("",data.aws_ssm_parameter.private_subnet_cidrs.*.value)}"
+  utility_subnet_cidrs = "${var.create_vpc == "true" ? join(",", module.utility_subnets.cidrs): join("",data.aws_ssm_parameter.public_subnet_cidrs.*.value)}"
 }
 
 # These parameters correspond to the kops manifest template:
@@ -110,15 +168,55 @@ resource "aws_ssm_parameter" "kops_dns_zone" {
 
 resource "aws_ssm_parameter" "kops_network_cidr" {
   name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_network_cidr")}"
-  value       = "${var.network_cidr}"
+  value       = "${local.vpc_network_cidr}"
   description = "CIDR block of the kops virtual network"
+  type        = "String"
+  overwrite   = "true"
+}
+
+# If we are using a shared VPC, we save its AWS ID here. If kops is creating the VPC, we do not export the ID
+resource "aws_ssm_parameter" "kops_configured_vpc_id" {
+  count       = "${var.create_vpc == "true" ? 0 : 1}"
+  name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_configured_vpc_id")}"
+  value       = "${join("", data.aws_ssm_parameter.vpc_id.*.value)}"
+  description = "Kops (shared) VPC AWS ID"
+  type        = "String"
+  overwrite   = "true"
+}
+
+# If we are using a shared VPC, we save the list of NAT gateway IDs here. If kops is creating the VPC, we do not export the IDs
+resource "aws_ssm_parameter" "kops_configured_nat_gateways" {
+  count       = "${var.create_vpc == "true" ? 0 : 1}"
+  name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_configured_nat_gateways")}"
+  value       = "${join("", data.aws_ssm_parameter.nat_gateways.*.value)}"
+  description = "Kops (shared) private subnet NAT gateway AWS IDs"
+  type        = "String"
+  overwrite   = "true"
+}
+
+# If we are using a shared VPC, we save the list of private subnet IDs here. If kops is creating the VPC, we do not export the IDs
+resource "aws_ssm_parameter" "kops_configured_private_subnet_ids" {
+  count       = "${var.create_vpc == "true" ? 0 : 1}"
+  name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_configured_private_subnet_ids")}"
+  value       = "${join("", data.aws_ssm_parameter.private_subnet_ids.*.value)}"
+  description = "Kops private subnet AWS IDs"
+  type        = "String"
+  overwrite   = "true"
+}
+
+# If we are using a shared VPC, we save the list of utility (public) subnet IDs here. If kops is creating the VPC, we do not export the IDs
+resource "aws_ssm_parameter" "kops_configured_utility_subnet_ids" {
+  count       = "${var.create_vpc == "true" ? 0 : 1}"
+  name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_configured_utility_subnet_ids")}"
+  value       = "${join("", data.aws_ssm_parameter.public_subnet_ids.*.value)}"
+  description = "Kops utility subnet AWS IDs"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "kops_private_subnets" {
   name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_private_subnets")}"
-  value       = "${local.private_subnets}"
+  value       = "${local.private_subnet_cidrs}"
   description = "Kops private subnet CIDRs"
   type        = "String"
   overwrite   = "true"
@@ -126,7 +224,7 @@ resource "aws_ssm_parameter" "kops_private_subnets" {
 
 resource "aws_ssm_parameter" "kops_utility_subnets" {
   name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_utility_subnets")}"
-  value       = "${local.utility_subnets}"
+  value       = "${local.utility_subnet_cidrs}"
   description = "Kops utility subnet CIDRs"
   type        = "String"
   overwrite   = "true"

--- a/aws/kops/outputs.tf
+++ b/aws/kops/outputs.tf
@@ -42,10 +42,26 @@ output "availability_zones" {
   value = "${join(",", local.availability_zones)}"
 }
 
+output "kops_configured_vpc_id" {
+  value = "${join("", aws_ssm_parameter.kops_configured_vpc_id.*.value)}"
+}
+
+output "kops_configured_nat_gateways" {
+  value = "${join("", aws_ssm_parameter.kops_configured_nat_gateways.*.value)}"
+}
+
+output "kops_configured_utility_subnet_ids" {
+  value = "${join("", aws_ssm_parameter.kops_configured_utility_subnet_ids.*.value)}"
+}
+
+output "kops_configured_private_subnet_ids" {
+  value = "${join("", aws_ssm_parameter.kops_configured_private_subnet_ids.*.value)}"
+}
+
 output "private_subnets" {
-  value = "${local.private_subnets}"
+  value = "${local.private_subnet_cidrs}"
 }
 
 output "utility_subnets" {
-  value = "${local.utility_subnets}"
+  value = "${local.utility_subnet_cidrs}"
 }

--- a/aws/kops/variables.tf
+++ b/aws/kops/variables.tf
@@ -120,3 +120,22 @@ variable "chamber_service" {
 variable "chamber_parameter_name" {
   default = "/%s/%s"
 }
+
+variable "create_vpc" {
+  default     = "true"
+  description = "Set to false to use VPC specified in Chamber VPC parameters, true to create a new VPC"
+}
+
+variable "vpc_chamber_service" {
+  default     = "vpc"
+  description = "`chamber` service name where shared vpc parameters are stored"
+}
+
+variable "vpc_chamber_parameter_name" {
+  default = "/%s/%s_%s"
+}
+
+variable "vpc_paramter_prefix" {
+  default     = "vpc_common"
+  description = "parameter name prefix to use when looking up VPC parameters in chamber"
+}

--- a/aws/vpc/Makefile
+++ b/aws/vpc/Makefile
@@ -1,0 +1,15 @@
+## Initialize terraform remote state
+init:
+	[ -f .terraform/terraform.tfstate ] || terraform $@
+
+## Clean up the project
+clean:
+	rm -rf .terraform *.tfstate*
+
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
+	terraform $@

--- a/aws/vpc/main.tf
+++ b/aws/vpc/main.tf
@@ -1,0 +1,124 @@
+terraform {
+  required_version = ">= 0.11.2"
+
+  backend "s3" {}
+}
+
+provider "aws" {
+  assume_role {
+    role_arn = "${var.aws_assume_role_arn}"
+  }
+}
+
+locals {
+  chamber_service = "${var.chamber_service == "" ? basename(pathexpand(path.module)) : var.chamber_service}"
+}
+
+module "parameter_prefix" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
+  namespace  = ""
+  stage      = ""
+  name       = "${var.name}"
+  attributes = "${var.attributes}"
+  delimiter  = "_"
+}
+
+data "aws_availability_zones" "available" {}
+
+module "vpc" {
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.3.3"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  cidr_block = "${var.vpc_cidr_block}"
+  attributes = "${var.attributes}"
+  tags       = "${var.tags}"
+}
+
+module "subnets" {
+  source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.7.1"
+  availability_zones  = ["${data.aws_availability_zones.available.names}"]
+  namespace           = "${var.namespace}"
+  stage               = "${var.stage}"
+  name                = "${var.name}"
+  region              = "${var.region}"
+  vpc_id              = "${module.vpc.vpc_id}"
+  igw_id              = "${module.vpc.igw_id}"
+  cidr_block          = "${module.vpc.vpc_cidr_block}"
+  nat_gateway_enabled = "${var.vpc_nat_gateway_enabled}"
+  attributes          = "${var.attributes}"
+  tags                = "${var.tags}"
+}
+
+resource "aws_ssm_parameter" "vpc_id" {
+  description = "VPC ID of backing services"
+  name        = "${format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "vpc_id")}"
+  value       = "${module.vpc.vpc_id}"
+  type        = "String"
+  overwrite   = "true"
+}
+
+resource "aws_ssm_parameter" "igw_id" {
+  description = "VPC ID of backing services"
+  name        = "${format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "igw_id")}"
+  value       = "${module.vpc.igw_id}"
+  type        = "String"
+  overwrite   = "true"
+}
+
+resource "aws_ssm_parameter" "cidr_block" {
+  description = "VPC ID of backing services"
+  name        = "${format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "cidr_block")}"
+  value       = "${module.vpc.vpc_cidr_block}"
+  type        = "String"
+  overwrite   = "true"
+}
+
+resource "aws_ssm_parameter" "availability_zones" {
+  name        = "${format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "availability_zones")}"
+  value       = "${join(",", data.aws_availability_zones.available.names)}"
+  description = "VPC subnet availability zones"
+  type        = "String"
+  overwrite   = "true"
+}
+
+resource "aws_ssm_parameter" "nat_gateways" {
+  count       = "${var.vpc_nat_gateway_enabled == "true" ? 1 : 0}"
+  name        = "${format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "nat_gateways")}"
+  value       = "${join(",", module.subnets.nat_gateway_ids)}"
+  description = "VPC private NAT gateways"
+  type        = "String"
+  overwrite   = "true"
+}
+
+resource "aws_ssm_parameter" "private_subnet_cidrs" {
+  name        = "${format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "private_subnet_cidrs")}"
+  value       = "${join(",", module.subnets.private_subnet_cidrs)}"
+  description = "VPC private subnet CIDRs"
+  type        = "String"
+  overwrite   = "true"
+}
+
+resource "aws_ssm_parameter" "private_subnet_ids" {
+  name        = "${format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "private_subnet_ids")}"
+  value       = "${join(",", module.subnets.private_subnet_ids)}"
+  description = "VPC private subnet AWS IDs"
+  type        = "String"
+  overwrite   = "true"
+}
+
+resource "aws_ssm_parameter" "public_subnet_cidrs" {
+  name        = "${format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "public_subnet_cidrs")}"
+  value       = "${join(",", module.subnets.public_subnet_cidrs)}"
+  description = "VPC public subnet CIDRs"
+  type        = "String"
+  overwrite   = "true"
+}
+
+resource "aws_ssm_parameter" "public_subnet_ids" {
+  name        = "${format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "public_subnet_ids")}"
+  value       = "${join(",", module.subnets.public_subnet_ids)}"
+  description = "VPC public subnet AWS IDs"
+  type        = "String"
+  overwrite   = "true"
+}

--- a/aws/vpc/outputs.tf
+++ b/aws/vpc/outputs.tf
@@ -1,0 +1,48 @@
+output "parameter_store_prefix" {
+  value = "${format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "")}"
+}
+
+output "vpc_id" {
+  description = "AWS ID of the VPC created"
+  value       = "${aws_ssm_parameter.vpc_id.value}"
+}
+
+output "igw_id" {
+  description = "AWS ID of Internet Gateway for the VPC"
+  value       = "${aws_ssm_parameter.igw_id.value}"
+}
+
+output "nat_gateways" {
+  description = "Comma-separated string list of AWS IDs of NAT Gateways for the VPC"
+  value       = "${join("",aws_ssm_parameter.nat_gateways.*.value)}"
+}
+
+output "cidr_block" {
+  description = "CIDR block of the VPC"
+  value       = "${aws_ssm_parameter.cidr_block.value}"
+}
+
+output "availability_zones" {
+  description = "Comma-separated string list of avaialbility zones where subnets have been created"
+  value       = "${aws_ssm_parameter.availability_zones.value}"
+}
+
+output "public_subnet_cidrs" {
+  description = "Comma-separated string list of CIDR blocks of public VPC subnets"
+  value       = "${aws_ssm_parameter.public_subnet_cidrs.value}"
+}
+
+output "public_subnet_ids" {
+  description = "Comma-separated string list of AWS IDs of public VPC subnets"
+  value       = "${aws_ssm_parameter.public_subnet_ids.value}"
+}
+
+output "private_subnet_cidrs" {
+  description = "Comma-separated string list of CIDR blocks of private VPC subnets"
+  value       = "${aws_ssm_parameter.private_subnet_cidrs.value}"
+}
+
+output "private_subnet_ids" {
+  description = "Comma-separated string list of AWS IDs of private VPC subnets"
+  value       = "${aws_ssm_parameter.private_subnet_ids.value}"
+}

--- a/aws/vpc/variables.tf
+++ b/aws/vpc/variables.tf
@@ -1,0 +1,53 @@
+variable "namespace" {
+  type        = "string"
+  description = "Namespace (e.g. `cp` or `cloudposse`)"
+}
+
+variable "stage" {
+  type        = "string"
+  description = "Stage (e.g. `prod`, `dev`, `staging`)"
+}
+
+variable "name" {
+  type        = "string"
+  description = "Name to distinguish this VPC from others in this account"
+  default     = "vpc"
+}
+
+variable "attributes" {
+  type        = "list"
+  description = "Additional attributes to distinguish this VPC from others in this account"
+  default     = ["common"]
+}
+
+variable "aws_assume_role_arn" {
+  type = "string"
+}
+
+variable "region" {
+  type = "string"
+}
+
+variable "tags" {
+  type        = "map"
+  default     = {}
+  description = "Additional tags, for example map(`KubernetesCluster`,`us-west-2.prod.example.com`)"
+}
+
+variable "vpc_cidr_block" {
+  default = "10.0.0.0/16"
+}
+
+variable "vpc_nat_gateway_enabled" {
+  default = "true"
+}
+
+variable "chamber_service" {
+  default     = ""
+  description = "`chamber` service name. See [chamber usage](https://github.com/segmentio/chamber#usage) for more details"
+}
+
+variable "chamber_parameter_name" {
+  description = "format string for creating SSM parameter name used to store chamber parameters"
+  default     = "/%s/%s_%s"
+}


### PR DESCRIPTION
## what
New `vpc` module creates these parameters in `chamber vpc`:
```
vpc_common_availability_zones
vpc_common_cidr_block	
vpc_common_igw_id	
vpc_common_nat_gateways	
vpc_common_private_subnet_cidrs
vpc_common_private_subnet_ids
vpc_common_public_subnet_cidrs
vpc_common_public_subnet_ids
vpc_common_vpc_id	
```
Tag labels are like (for example, for a subnet in one AZ) `cpco-prod-vpc-common-us-west-2a`

Updated [kops] module imports VPC made by new [vpc] module. Depends on `kops-private-topology.yaml.gotmpl` from https://github.com/cloudposse/reference-architectures/releases/tag/0.7.0

## why
Make it easier to add additional services to the same VPC kubernetes is using.