### PR TITLE
Add [kops-legacy-account-vpc-peering]

### DIFF
--- a/aws/kops-legacy-account-vpc-peering/Makefile
+++ b/aws/kops-legacy-account-vpc-peering/Makefile
@@ -1,0 +1,15 @@
+## Initialize terraform remote state
+init:
+	[ -f .terraform/terraform.tfstate ] || terraform $@
+
+## Clean up the project
+clean:
+	rm -rf .terraform *.tfstate*
+
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
+	terraform $@

--- a/aws/kops-legacy-account-vpc-peering/README.md
+++ b/aws/kops-legacy-account-vpc-peering/README.md
@@ -1,0 +1,82 @@
+# kops-legacy-account-vpc-peering
+
+Terraform module to provision VPC peering between a `kops` VPC and a VPC from a legacy AWS account.
+
+From the legacy AWS account, which will be the accepter of the VPC peering connection, the following values are required:
+
+- `legacy_account_assume_role_arn` - Legacy account assume role ARN
+- `legacy_account_region` -  Legacy account AWS region (e.g. `us-west-2`)
+- `legacy_account_vpc_id` - Legacy account VPC ID (the VPC which will accept peering connection from the `kops` VPC). __NOTE:__ the CIDR blocks of the `kops` VPC and the legacy account VPC must not overlap
+
+The `legacy_account_assume_role_arn` IAM Role should have the following Trust Policy:
+
+```js
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::<KOPS AWS Account ID>:root"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {}
+    }
+  ]
+}
+```
+
+and the following IAM Policy attached to it:
+
+__NOTE:__ the policy specifies the minimum permission set required to create (with `terraform plan/apply`) and delete (with `terraform destroy`) all the VPC peering connection resources in the accepter (legacy) AWS account
+
+```js
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateRoute",
+        "ec2:DeleteRoute"
+      ],
+      "Resource": "arn:aws:ec2:*:<Legacy AWS Account ID>:route-table/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeVpcPeeringConnections",
+        "ec2:DescribeVpcs",
+        "ec2:ModifyVpcPeeringConnectionOptions",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeVpcAttribute",
+        "ec2:DescribeRouteTables"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AcceptVpcPeeringConnection",
+        "ec2:DeleteVpcPeeringConnection",
+        "ec2:CreateVpcPeeringConnection",
+        "ec2:RejectVpcPeeringConnection"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:<Legacy AWS Account ID>:vpc-peering-connection/*",
+        "arn:aws:ec2:*:<Legacy AWS Account ID>:vpc/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteTags",
+        "ec2:CreateTags"
+      ],
+      "Resource": "arn:aws:ec2:*:<Legacy AWS Account ID>:vpc-peering-connection/*"
+    }
+  ]
+}
+```
+
+For more information on IAM policies and permissions for VPC peering, see [Creating and managing VPC peering connections](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_IAM.html#vpcpeeringiam).

--- a/aws/kops-legacy-account-vpc-peering/main.tf
+++ b/aws/kops-legacy-account-vpc-peering/main.tf
@@ -1,0 +1,40 @@
+terraform {
+  required_version = ">= 0.11.2"
+
+  backend "s3" {}
+}
+
+provider "aws" {
+  assume_role {
+    role_arn = "${var.aws_assume_role_arn}"
+  }
+}
+
+# Lookup VPC of the kops cluster
+module "kops_metadata" {
+  source   = "git::https://github.com/cloudposse/terraform-aws-kops-metadata.git?ref=tags/0.2.1"
+  dns_zone = "${var.region}.${var.zone_name}"
+  enabled  = "${var.enabled}"
+}
+
+module "kops_legacy_account_vpc_peering" {
+  source = "git::https://github.com/cloudposse/terraform-aws-vpc-peering-multi-account.git?ref=tags/0.5.0"
+
+  enabled = "${var.enabled}"
+
+  namespace = "${var.namespace}"
+  stage     = "${var.stage}"
+  name      = "${var.name}"
+
+  auto_accept = true
+
+  # Requester
+  requester_vpc_id              = "${module.kops_metadata.vpc_id}"
+  requester_region              = "${var.region}"
+  requester_aws_assume_role_arn = "${var.aws_assume_role_arn}"
+
+  # Accepter
+  accepter_vpc_id              = "${var.legacy_account_vpc_id}"
+  accepter_region              = "${var.legacy_account_region}"
+  accepter_aws_assume_role_arn = "${var.legacy_account_assume_role_arn}"
+}

--- a/aws/kops-legacy-account-vpc-peering/main.tf
+++ b/aws/kops-legacy-account-vpc-peering/main.tf
@@ -12,14 +12,15 @@ provider "aws" {
 
 # Lookup VPC of the kops cluster
 module "kops_metadata" {
-  source   = "git::https://github.com/cloudposse/terraform-aws-kops-metadata.git?ref=tags/0.2.1"
-  dns_zone = "${var.region}.${var.zone_name}"
-  enabled  = "${var.enabled}"
+  source         = "git::https://github.com/cloudposse/terraform-aws-kops-metadata.git?ref=tags/0.2.1"
+  enabled        = "${var.enabled}"
+  dns_zone       = "${var.region}.${var.zone_name}"
+  vpc_tag        = "${var.vpc_tag}"
+  vpc_tag_values = ["${var.vpc_tag_values}"]
 }
 
 module "kops_legacy_account_vpc_peering" {
-  source = "git::https://github.com/cloudposse/terraform-aws-vpc-peering-multi-account.git?ref=tags/0.5.0"
-
+  source  = "git::https://github.com/cloudposse/terraform-aws-vpc-peering-multi-account.git?ref=tags/0.5.0"
   enabled = "${var.enabled}"
 
   namespace = "${var.namespace}"

--- a/aws/kops-legacy-account-vpc-peering/outputs.tf
+++ b/aws/kops-legacy-account-vpc-peering/outputs.tf
@@ -1,0 +1,19 @@
+output "accepter_accept_status" {
+  description = "Accepter VPC peering connection request status"
+  value       = "${module.kops_legacy_account_vpc_peering.accepter_accept_status}"
+}
+
+output "accepter_connection_id" {
+  description = "Accepter VPC peering connection ID"
+  value       = "${module.kops_legacy_account_vpc_peering.accepter_connection_id}"
+}
+
+output "requester_accept_status" {
+  description = "Requester VPC peering connection request status"
+  value       = "${module.kops_legacy_account_vpc_peering.requester_accept_status}"
+}
+
+output "requester_connection_id" {
+  description = "Requester VPC peering connection ID"
+  value       = "${module.kops_legacy_account_vpc_peering.requester_connection_id}"
+}

--- a/aws/kops-legacy-account-vpc-peering/terraform.tfvars.example
+++ b/aws/kops-legacy-account-vpc-peering/terraform.tfvars.example
@@ -1,0 +1,5 @@
+region = "us-west-2"
+zone_name="staging.example.io"
+legacy_account_assume_role_arn = "arn:aws:iam::XXXXXXXXXXXX:role/cross-account-vpc-peering"
+legacy_account_region = "us-east-1"
+legacy_account_vpc_id = "vpc-xxxxxxxx"

--- a/aws/kops-legacy-account-vpc-peering/variables.tf
+++ b/aws/kops-legacy-account-vpc-peering/variables.tf
@@ -32,6 +32,18 @@ variable "zone_name" {
   description = "DNS zone name"
 }
 
+variable "vpc_tag" {
+  type        = "string"
+  default     = "Name"
+  description = "Tag used to lookup the Kops VPC"
+}
+
+variable "vpc_tag_values" {
+  type        = "list"
+  default     = []
+  description = "Tag values list to lookup the Kops VPC"
+}
+
 variable "legacy_account_assume_role_arn" {
   type        = "string"
   description = "Legacy account assume role ARN"

--- a/aws/kops-legacy-account-vpc-peering/variables.tf
+++ b/aws/kops-legacy-account-vpc-peering/variables.tf
@@ -1,0 +1,48 @@
+variable "aws_assume_role_arn" {}
+
+variable "enabled" {
+  type        = "string"
+  description = "Whether to create the resources. Set to `false` to prevent the module from creating any resources"
+  default     = "true"
+}
+
+variable "namespace" {
+  type        = "string"
+  description = "Namespace (e.g. `eg` or `cp`)"
+}
+
+variable "stage" {
+  type        = "string"
+  description = "Stage (e.g. `prod`, `dev`, `staging`)"
+}
+
+variable "name" {
+  type        = "string"
+  description = "Application or solution name (e.g. `app`)"
+  default     = "vpc-peering"
+}
+
+variable "region" {
+  type        = "string"
+  description = "AWS region"
+}
+
+variable "zone_name" {
+  type        = "string"
+  description = "DNS zone name"
+}
+
+variable "legacy_account_assume_role_arn" {
+  type        = "string"
+  description = "Legacy account assume role ARN"
+}
+
+variable "legacy_account_region" {
+  type        = "string"
+  description = "Legacy account AWS region"
+}
+
+variable "legacy_account_vpc_id" {
+  type        = "string"
+  description = "Legacy account VPC ID"
+}


### PR DESCRIPTION
## what
* Add `kops-legacy-account-vpc-peering` project

## why
* Provision VPC peering connection between a `kops` VPC and a legacy VPC in a different AWS account (possibly provisioned manually without using Terraform or other automation tools)
* Specify what parameters are needed from the legacy AWS account to be able to provision a VPC peering connection
* Show the IAM role, policies and permissions required in the legacy account 
