### PR TITLE
Disable TLS by default

### DIFF
--- a/aws/codefresh-onprem/main.tf
+++ b/aws/codefresh-onprem/main.tf
@@ -104,7 +104,12 @@ variable "documentdb_preferred_backup_window" {
 
 variable "documentdb_cluster_parameters" {
   type        = "list"
-  default     = []
+  default = [
+    {
+      name  = "tls"
+      value = "disabled"
+    },
+  ]
   description = "List of DocumentDB parameters to apply"
 }
 
@@ -157,7 +162,7 @@ data "terraform_remote_state" "backing_services" {
 }
 
 module "codefresh_enterprise_backing_services" {
-  source          = "git::https://github.com/cloudposse/terraform-aws-codefresh-backing-services.git?ref=tags/0.5.0"
+  source          = "git::https://github.com/cloudposse/terraform-aws-codefresh-backing-services.git?ref=tags/0.6.0"
   namespace       = "${var.namespace}"
   stage           = "${var.stage}"
   vpc_id          = "${data.terraform_remote_state.backing_services.vpc_id}"

--- a/aws/codefresh-onprem/main.tf
+++ b/aws/codefresh-onprem/main.tf
@@ -103,13 +103,15 @@ variable "documentdb_preferred_backup_window" {
 }
 
 variable "documentdb_cluster_parameters" {
-  type        = "list"
+  type = "list"
+
   default = [
     {
       name  = "tls"
       value = "disabled"
     },
   ]
+
   description = "List of DocumentDB parameters to apply"
 }
 


### PR DESCRIPTION
## What
* Disable TLS for document DB

## Why
* Codefresh does not support TLS  connection to MongoDB