### PR TITLE
[teleport] Update teleport module to work in shared VPC, add acm-teleport module

### DIFF
--- a/aws/acm-teleport/Makefile
+++ b/aws/acm-teleport/Makefile
@@ -1,0 +1,15 @@
+## Initialize terraform remote state
+init:
+	[ -f .terraform/terraform.tfstate ] || terraform $@
+
+## Clean up the project
+clean:
+	rm -rf .terraform *.tfstate*
+
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
+	terraform $@

--- a/aws/acm-teleport/main.tf
+++ b/aws/acm-teleport/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_version = ">= 0.11.2"
+
+  backend "s3" {}
+}
+
+variable "aws_assume_role_arn" {}
+
+provider "aws" {
+  assume_role {
+    role_arn = "${var.aws_assume_role_arn}"
+  }
+}
+
+
+module "certificate" {
+  #  source                           = "git::https://github.com/cloudposse/terraform-aws-acm-request-certificate.git?ref=tags/0.3.0"
+   source                           = "git::https://github.com/cloudposse/terraform-aws-acm-request-certificate.git?ref=tags/0.1.1"
+#  source                           = "/Users/jgro/CP_dev/terraform-aws-acm-request-certificate"
+  domain_name                      = "${var.domain_name}"
+  proces_domain_validation_options = "true"
+  ttl                              = "300"
+  subject_alternative_names        = ["*.${var.domain_name}"]
+}
+
+resource "aws_ssm_parameter" "certificate_arn_parameter" {
+  name        = "${format(var.chamber_parameter_name, var.chamber_service, var.certificate_arn_parameter_name)}"
+  value       = "${module.certificate.arn}"
+  description = "Teleport ACM-issued TLS Certificate AWS ARN"
+  type        = "String"
+  overwrite   = "true"
+}

--- a/aws/acm-teleport/main.tf
+++ b/aws/acm-teleport/main.tf
@@ -13,10 +13,7 @@ provider "aws" {
 }
 
 module "certificate" {
-  #  source                           = "git::https://github.com/cloudposse/terraform-aws-acm-request-certificate.git?ref=tags/0.3.0"
-  source = "git::https://github.com/cloudposse/terraform-aws-acm-request-certificate.git?ref=tags/0.1.1"
-
-  #  source                           = "/Users/jgro/CP_dev/terraform-aws-acm-request-certificate"
+  source                           = "git::https://github.com/cloudposse/terraform-aws-acm-request-certificate.git?ref=tags/0.1.1"
   domain_name                      = "${var.domain_name}"
   proces_domain_validation_options = "true"
   ttl                              = "300"

--- a/aws/acm-teleport/main.tf
+++ b/aws/acm-teleport/main.tf
@@ -12,11 +12,11 @@ provider "aws" {
   }
 }
 
-
 module "certificate" {
   #  source                           = "git::https://github.com/cloudposse/terraform-aws-acm-request-certificate.git?ref=tags/0.3.0"
-   source                           = "git::https://github.com/cloudposse/terraform-aws-acm-request-certificate.git?ref=tags/0.1.1"
-#  source                           = "/Users/jgro/CP_dev/terraform-aws-acm-request-certificate"
+  source = "git::https://github.com/cloudposse/terraform-aws-acm-request-certificate.git?ref=tags/0.1.1"
+
+  #  source                           = "/Users/jgro/CP_dev/terraform-aws-acm-request-certificate"
   domain_name                      = "${var.domain_name}"
   proces_domain_validation_options = "true"
   ttl                              = "300"

--- a/aws/acm-teleport/outputs.tf
+++ b/aws/acm-teleport/outputs.tf
@@ -1,0 +1,15 @@
+output "certificate_domain_name" {
+  value = "${var.domain_name}"
+}
+
+output "certificate_id" {
+  value = "${module.certificate.id}"
+}
+
+output "certificate_arn" {
+  value = "${module.certificate.arn}"
+}
+
+output "certificate_domain_validation_options" {
+  value = "${module.certificate.domain_validation_options}"
+}

--- a/aws/acm-teleport/terraform.tfvars.example
+++ b/aws/acm-teleport/terraform.tfvars.example
@@ -1,0 +1,1 @@
+domain_name="staging.cloudposse.co"

--- a/aws/acm-teleport/variables.tf
+++ b/aws/acm-teleport/variables.tf
@@ -2,7 +2,6 @@ variable "domain_name" {
   description = "Domain name for which to issue a certificate"
 }
 
-
 variable "chamber_service" {
   description = "`chamber` service name to use for storing the certificate ARN"
   default     = "teleport"
@@ -10,10 +9,10 @@ variable "chamber_service" {
 
 variable "chamber_parameter_name" {
   description = "Format string for combining `chamber` service name and parameter name. It is rare to need to set this."
-  default = "/%s/%s"
+  default     = "/%s/%s"
 }
 
 variable "certificate_arn_parameter_name" {
   description = "Chamber parameter name in which to store the AWS ARN of the issued certificate"
-  default = "teleport_ssl_certificate_arn"
+  default     = "teleport_ssl_certificate_arn"
 }

--- a/aws/acm-teleport/variables.tf
+++ b/aws/acm-teleport/variables.tf
@@ -1,0 +1,19 @@
+variable "domain_name" {
+  description = "Domain name for which to issue a certificate"
+}
+
+
+variable "chamber_service" {
+  description = "`chamber` service name to use for storing the certificate ARN"
+  default     = "teleport"
+}
+
+variable "chamber_parameter_name" {
+  description = "Format string for combining `chamber` service name and parameter name. It is rare to need to set this."
+  default = "/%s/%s"
+}
+
+variable "certificate_arn_parameter_name" {
+  description = "Chamber parameter name in which to store the AWS ARN of the issued certificate"
+  default = "teleport_ssl_certificate_arn"
+}

--- a/aws/teleport/main.tf
+++ b/aws/teleport/main.tf
@@ -45,7 +45,7 @@ module "teleport_role_name" {
 
 module "kops_metadata" {
   source       = "git::https://github.com/cloudposse/terraform-aws-kops-data-iam.git?ref=tags/0.1.0"
-  cluster_name     = "${var.cluster_name}"
+  cluster_name = "${var.cluster_name}"
 }
 
 locals {

--- a/aws/teleport/main.tf
+++ b/aws/teleport/main.tf
@@ -44,10 +44,8 @@ module "teleport_role_name" {
 }
 
 module "kops_metadata" {
-  source       = "git::https://github.com/cloudposse/terraform-aws-kops-metadata.git?ref=tags/0.1.1"
-  dns_zone     = "${var.cluster_name}"
-  masters_name = "${var.masters_name}"
-  nodes_name   = "${var.nodes_name}"
+  source       = "git::https://github.com/cloudposse/terraform-aws-kops-data-iam.git?ref=tags/0.1.0"
+  cluster_name     = "${var.cluster_name}"
 }
 
 locals {
@@ -174,7 +172,7 @@ locals {
 }
 
 resource "random_string" "tokens" {
-  count   = 3
+  count   = "${length(local.token_names)}"
   length  = 32
   special = false
 
@@ -184,7 +182,7 @@ resource "random_string" "tokens" {
 }
 
 resource "aws_ssm_parameter" "teleport_tokens" {
-  count       = 3
+  count       = "${length(local.token_names)}"
   name        = "${format(var.chamber_parameter_name, local.chamber_service, "${element(local.token_names, count.index)}")}"
   value       = "${element(random_string.tokens.*.result, count.index)}"
   description = "Teleport join token: ${element(local.token_names, count.index)}"


### PR DESCRIPTION
## what
- [teleport] Update teleport module to work in shared VPC
- [acm-teleport] Create teleport-specific module for generating Teleport TLS certificate via ACM
## why
More automation of Teleport install process. 