### PR TITLE
[backing services] Fix CIDR range because of new availability zone

### DIFF
--- a/aws/backing-services/vpc.tf
+++ b/aws/backing-services/vpc.tf
@@ -10,6 +10,12 @@ variable "vpc_nat_gateway_enabled" {
   default = "true"
 }
 
+variable "vpc_max_subnet_count" {
+  default     = 0
+  description = "Sets the maximum amount of subnets to deploy.  0 will deploy a subnet for every availablility zone within the region"
+}
+
+
 data "aws_region" "current" {}
 
 module "vpc" {
@@ -31,6 +37,7 @@ module "subnets" {
   igw_id              = "${module.vpc.igw_id}"
   cidr_block          = "${module.vpc.vpc_cidr_block}"
   nat_gateway_enabled = "${var.vpc_nat_gateway_enabled}"
+  max_subnet_count    = "${var.vpc_max_subnet_count}"
 }
 
 output "vpc_id" {

--- a/aws/backing-services/vpc.tf
+++ b/aws/backing-services/vpc.tf
@@ -12,7 +12,7 @@ variable "vpc_nat_gateway_enabled" {
 
 variable "vpc_max_subnet_count" {
   default     = 0
-  description = "Sets the maximum amount of subnets to deploy.  0 will deploy a subnet for every availablility zone within the region"
+  description = "The maximum count of subnets to provision. 0 will provision a subnet for each availability zone within the region"
 }
 
 data "aws_region" "current" {}

--- a/aws/backing-services/vpc.tf
+++ b/aws/backing-services/vpc.tf
@@ -15,7 +15,6 @@ variable "vpc_max_subnet_count" {
   description = "Sets the maximum amount of subnets to deploy.  0 will deploy a subnet for every availablility zone within the region"
 }
 
-
 data "aws_region" "current" {}
 
 module "vpc" {


### PR DESCRIPTION
## What
* Added `vpc_max_subnets_count`

## Why
* Allow specifying the count of ranges CIDR is split to