### PR TITLE
Fix authentication action. Don't use `map` variable for authentication action

### DIFF
--- a/aws/ecs/default-backend.tf
+++ b/aws/ecs/default-backend.tf
@@ -8,7 +8,7 @@ variable "default_backend_name" {
 
 # default backend app
 module "default_backend_web_app" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.15.0"
+  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.17.0"
   name       = "${var.name}"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
@@ -21,8 +21,6 @@ module "default_backend_web_app" {
   container_port   = "80"
 
   #launch_type                 = "FARGATE"
-  listener_arns                = "${module.alb.listener_arns}"
-  listener_arns_count          = "1"
   aws_logs_region              = "${var.region}"
   ecs_cluster_arn              = "${aws_ecs_cluster.default.arn}"
   ecs_cluster_name             = "${aws_ecs_cluster.default.name}"
@@ -43,6 +41,9 @@ module "default_backend_web_app" {
   alb_target_group_alarms_response_time_threshold = "0.5"
   alb_target_group_alarms_period                  = "300"
   alb_target_group_alarms_evaluation_periods      = "1"
+
+  alb_ingress_unauthenticated_listener_arns       = ["${module.alb.listener_arns}"]
+  alb_ingress_unauthenticated_listener_arns_count = 1
 
   alb_ingress_unauthenticated_paths = ["/*"]
   alb_ingress_authenticated_paths   = []


### PR DESCRIPTION
## what
* Fix authentication action
* Don't use `map` variable for authentication action

## why
* Using `authentication_action` variable as `map` breaks when this module is used in a chain of calls from other modules
For example:
   * Providing `authentication_action` map from Module B to `alb-ingress` - works
   * Providing `authentication_action` map from Module C to Module B to `alb-ingress` - works
   * Providing `authentication_action` map from Module D to Module C to Module B to `alb-ingress` - breaks (in a way that is very difficult to understand and debug; the end result is that `alb-ingress` receives an empty or incomplete map)

