### PR TITLE
[ecs/atlantis] Update `atlantis` version. Add `atlantis_repo_config` variable

### DIFF
--- a/aws/ecs/atlantis-repo-config.yaml
+++ b/aws/ecs/atlantis-repo-config.yaml
@@ -1,0 +1,22 @@
+# https://www.runatlantis.io/docs/configuring-atlantis.html
+# https://www.runatlantis.io/docs/server-configuration.html
+# https://www.runatlantis.io/docs/server-side-repo-config.html
+# https://www.runatlantis.io/docs/repo-level-atlantis-yaml.html
+
+# repos lists the config for specific repos
+repos:
+  # id can either be an exact repo ID or a regex.
+  # If using a regex, it must start and end with a slash
+  # Repo ID's are of the form {VCS hostname}/{org}/{repo name}
+  - id: /.*/
+
+    # apply_requirements sets the Apply Requirements for all repos that match
+    apply_requirements: [approved]
+
+    # allowed_overrides specifies which keys can be overridden by this repo in
+    # its atlantis.yaml file
+    allowed_overrides: [apply_requirements, workflow]
+
+    # allow_custom_workflows defines whether this repo can define its own
+    # workflows. If false (default), the repo can only use server-side defined workflows
+    allow_custom_workflows: true

--- a/aws/ecs/atlantis-repo-config.yaml
+++ b/aws/ecs/atlantis-repo-config.yaml
@@ -11,7 +11,7 @@ repos:
   - id: /.*/
 
     # apply_requirements sets the Apply Requirements for all repos that match
-    apply_requirements: [approved]
+    apply_requirements: [approved, mergeable]
 
     # allowed_overrides specifies which keys can be overridden by this repo in
     # its atlantis.yaml file

--- a/aws/ecs/atlantis.auto.tfvars.example
+++ b/aws/ecs/atlantis.auto.tfvars.example
@@ -11,14 +11,19 @@
 # chamber write atlantis atlantis_oidc_client_secret "....."
 
 atlantis_enabled = "true"
+
 atlantis_branch = "master"
+
 atlantis_repo_name = "testing.example.co"
+
 atlantis_repo_owner = "example"
+
 atlantis_repo_whitelist = ["github.com/example/*"]
 
-atlantis_allow_repo_config = "true"
+atlantis_repo_config = "atlantis-repo-config.yaml"
 
 atlantis_gh_user = "examplebot"
+
 atlantis_gh_team_whitelist = "engineering:plan,devops:*"
 
 atlantis_wake_word = "atlantis"

--- a/aws/ecs/atlantis.auto.tfvars.example
+++ b/aws/ecs/atlantis.auto.tfvars.example
@@ -20,7 +20,7 @@ atlantis_repo_owner = "example"
 
 atlantis_repo_whitelist = ["github.com/example/*"]
 
-atlantis_repo_config = "atlantis-repo-config.yaml"
+atlantis_repo_config = "/conf/ecs/atlantis-repo-config.yaml"
 
 atlantis_gh_user = "examplebot"
 

--- a/aws/ecs/atlantis.tf
+++ b/aws/ecs/atlantis.tf
@@ -15,6 +15,12 @@ variable "atlantis_gh_user" {
   default     = "undefined"
 }
 
+variable "atlantis_repo_config" {
+  type        = "string"
+  description = "Path to atlantis server-side repo config file (https://www.runatlantis.io/docs/server-side-repo-config.html)"
+  default     = "atlantis-repo-config.yaml"
+}
+
 variable "atlantis_repo_whitelist" {
   type        = "list"
   description = "Whitelist of repositories Atlantis will accept webhooks from"
@@ -165,7 +171,7 @@ variable "atlantis_alb_ingress_authenticated_paths" {
 }
 
 module "atlantis" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-ecs-atlantis.git?ref=tags/0.7.0"
+  source    = "git::https://github.com/cloudposse/terraform-aws-ecs-atlantis.git?ref=tags/0.8.0"
   enabled   = "${var.atlantis_enabled}"
   name      = "${var.name}"
   namespace = "${var.namespace}"
@@ -175,6 +181,7 @@ module "atlantis" {
   atlantis_gh_team_whitelist = "${var.atlantis_gh_team_whitelist}"
   atlantis_gh_user           = "${var.atlantis_gh_user}"
   atlantis_repo_whitelist    = ["${var.atlantis_repo_whitelist}"]
+  atlantis_repo_config       = "${var.atlantis_repo_config}"
 
   alb_arn_suffix = "${module.alb.alb_arn_suffix}"
   alb_dns_name   = "${module.alb.alb_dns_name}"


### PR DESCRIPTION
## what
* Update `atlantis` version
* Add `atlantis_repo_config` variable
* Remove `--allow-repo-config` variable

## why
* https://github.com/cloudposse/terraform-aws-ecs-atlantis/pull/7
* Flag `--allow-repo-config` has been deprecated in favor of creating a server-side repo config file that applies the same configuration
* Use a server-side config file and point `--repo-config` to it

## references
* https://github.com/runatlantis/atlantis/releases/tag/v0.7.0
* https://www.runatlantis.io/docs/configuring-atlantis.html
* https://www.runatlantis.io/docs/server-configuration.html
* https://www.runatlantis.io/docs/server-side-repo-config.html
* https://www.runatlantis.io/docs/repo-level-atlantis-yaml.html
