### PR TITLE
[ecs/atlantis] Bump `default_backend_web_app` version

### DIFF
--- a/aws/ecs/default-backend.tf
+++ b/aws/ecs/default-backend.tf
@@ -8,7 +8,7 @@ variable "default_backend_name" {
 
 # default backend app
 module "default_backend_web_app" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.18.0"
+  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.19.0"
   name       = "${var.name}"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"


### PR DESCRIPTION
## what
* [ecs/atlantis] Bump `default_backend_web_app` version

## why
* Use the same version of `web-app` for default backend and atlantis app
