### PR TITLE
[ecs/atlantis] Bump `terraform-aws-ecs-atlantis` version

### DIFF
--- a/aws/ecs/atlantis.tf
+++ b/aws/ecs/atlantis.tf
@@ -171,7 +171,7 @@ variable "atlantis_alb_ingress_authenticated_paths" {
 }
 
 module "atlantis" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-ecs-atlantis.git?ref=tags/0.9.0"
+  source    = "git::https://github.com/cloudposse/terraform-aws-ecs-atlantis.git?ref=tags/0.10.0"
   enabled   = "${var.atlantis_enabled}"
   name      = "${var.name}"
   namespace = "${var.namespace}"


### PR DESCRIPTION
## what
* [ecs/atlantis] Bump `terraform-aws-ecs-atlantis` version

## why
* https://github.com/cloudposse/terraform-aws-ecs-atlantis/releases/tag/0.10.0

