### PR TITLE
Add `kops-aurora-postgres` module

### DIFF
--- a/aws/kops-aurora-postgres/Makefile
+++ b/aws/kops-aurora-postgres/Makefile
@@ -1,0 +1,15 @@
+## Initialize terraform remote state
+init:
+	[ -f .terraform/terraform.tfstate ] || terraform $@
+
+## Clean up the project
+clean:
+	rm -rf .terraform *.tfstate*
+
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
+	terraform $@

--- a/aws/kops-aurora-postgres/main.tf
+++ b/aws/kops-aurora-postgres/main.tf
@@ -1,0 +1,132 @@
+terraform {
+  required_version = ">= 0.11.2"
+  backend          "s3"             {}
+}
+
+provider "aws" {
+  assume_role {
+    role_arn = "${var.aws_assume_role_arn}"
+  }
+}
+
+module "kops_metadata_vpc" {
+  source       = "git::https://github.com/cloudposse/terraform-aws-kops-data-network.git?ref=tags/0.1.1"
+  cluster_name = "${var.kops_cluster_name}"
+  vpc_id       = "${var.vpc_id}"
+}
+
+locals {
+  zone_id                  = "${join("", data.aws_route53_zone.default.*.zone_id)}"
+  chamber_service          = "${var.chamber_service == "" ? basename(pathexpand(path.module)) : var.chamber_service}"
+  postgres_cluster_enabled = "${var.postgres_cluster_enabled == "true"}"
+  postgres_admin_user      = "${length(var.postgres_admin_user) > 0 ? var.postgres_admin_user : join("", random_string.postgres_admin_user.*.result)}"
+  postgres_admin_password  = "${length(var.postgres_admin_password) > 0 ? var.postgres_admin_password : join("", random_string.postgres_admin_password.*.result)}"
+  postgres_db_name         = "${length(var.postgres_db_name) > 0 ? var.postgres_db_name : join("", random_pet.postgres_db_name.*.id)}"
+  kms_key_id               = "${length(var.kms_key_id) > 0 ? var.kms_key_id : format("alias/%s-%s-chamber", var.namespace, var.stage)}"
+}
+
+data "aws_route53_zone" "default" {
+  count = "${local.postgres_cluster_enabled ? 1 : 0}"
+  name  = "${var.zone_name == "" ? var.kops_cluster_name : var.zone_name}"
+}
+
+resource "random_pet" "postgres_db_name" {
+  count     = "${local.postgres_cluster_enabled && length(var.postgres_db_name) == 0 ? 1 : 0}"
+  separator = "_"
+}
+
+resource "random_string" "postgres_admin_user" {
+  count   = "${local.postgres_cluster_enabled && length(var.postgres_admin_user) == 0 ? 1 : 0}"
+  length  = 8
+  special = false
+  number  = false
+}
+
+resource "random_string" "postgres_admin_password" {
+  count   = "${local.postgres_cluster_enabled && length(var.postgres_admin_password) == 0 ? 1 : 0}"
+  length  = 16
+  special = true
+}
+
+module "aurora_postgres" {
+  source                              = "git::https://github.com/cloudposse/terraform-aws-rds-cluster.git?ref=tags/0.15.0"
+  enabled                             = "${var.postgres_cluster_enabled}"
+  namespace                           = "${var.namespace}"
+  stage                               = "${var.stage}"
+  name                                = "${var.postgres_name}"
+  engine                              = "aurora-postgresql"
+  cluster_family                      = "aurora-postgresql9.6"
+  instance_type                       = "${var.postgres_instance_type}"
+  cluster_size                        = "${var.postgres_cluster_size}"
+  admin_user                          = "${local.postgres_admin_user}"
+  admin_password                      = "${local.postgres_admin_password}"
+  db_name                             = "${local.postgres_db_name}"
+  db_port                             = "5432"
+  vpc_id                              = "${module.kops_metadata_vpc.vpc_id}"
+  subnets                             = ["${module.kops_metadata_vpc.private_subnet_ids}"]
+  zone_id                             = "${local.zone_id}"
+  security_groups                     = ["${module.kops_metadata_vpc.nodes_security_group_id}"]
+  iam_database_authentication_enabled = "${var.postgres_iam_database_authentication_enabled}"
+  cluster_dns_name                    = "${var.postgres_cluster_dns_name}"
+  reader_dns_name                     = "${var.postgres_reader_dns_name}"
+}
+
+data "aws_kms_key" "chamber_kms_key" {
+  count  = "${local.postgres_cluster_enabled ? 1 : 0}"
+  key_id = "${local.kms_key_id}"
+}
+
+resource "aws_ssm_parameter" "aurora_postgres_database_name" {
+  count       = "${local.postgres_cluster_enabled ? 1 : 0}"
+  name        = "${format(var.chamber_parameter_name, local.chamber_service, "aurora_postgres_database_name")}"
+  value       = "${join("", module.aurora_postgres.*.name)}"
+  description = "Aurora Postgres Database Name"
+  type        = "String"
+  overwrite   = "${var.overwrite_ssm_parameter}"
+}
+
+resource "aws_ssm_parameter" "aurora_postgres_master_username" {
+  count       = "${local.postgres_cluster_enabled ? 1 : 0}"
+  name        = "${format(var.chamber_parameter_name, local.chamber_service, "aurora_postgres_master_username")}"
+  value       = "${join("", module.aurora_postgres.*.user)}"
+  description = "Aurora Postgres Username for the master DB user"
+  type        = "String"
+  overwrite   = "${var.overwrite_ssm_parameter}"
+}
+
+resource "aws_ssm_parameter" "aurora_postgres_master_password" {
+  count       = "${local.postgres_cluster_enabled ? 1 : 0}"
+  name        = "${format(var.chamber_parameter_name, local.chamber_service, "aurora_postgres_master_password")}"
+  value       = "${join("", module.aurora_postgres.*.password)}"
+  description = "Aurora Postgres Password for the master DB user"
+  type        = "SecureString"
+  key_id      = "${join("", data.aws_kms_key.chamber_kms_key.*.id)}"
+  overwrite   = "${var.overwrite_ssm_parameter}"
+}
+
+resource "aws_ssm_parameter" "aurora_postgres_master_hostname" {
+  count       = "${local.postgres_cluster_enabled ? 1 : 0}"
+  name        = "${format(var.chamber_parameter_name, local.chamber_service, "aurora_postgres_master_hostname")}"
+  value       = "${join("", module.aurora_postgres.*.master_host)}"
+  description = "Aurora Postgres DB Master hostname"
+  type        = "String"
+  overwrite   = "${var.overwrite_ssm_parameter}"
+}
+
+resource "aws_ssm_parameter" "aurora_postgres_replicas_hostname" {
+  count       = "${local.postgres_cluster_enabled ? 1 : 0}"
+  name        = "${format(var.chamber_parameter_name, local.chamber_service, "aurora_postgres_replicas_hostname")}"
+  value       = "${join("", module.aurora_postgres.*.replicas_host)}"
+  description = "Aurora Postgres DB Replicas hostname"
+  type        = "String"
+  overwrite   = "${var.overwrite_ssm_parameter}"
+}
+
+resource "aws_ssm_parameter" "aurora_postgres_cluster_name" {
+  count       = "${local.postgres_cluster_enabled ? 1 : 0}"
+  name        = "${format(var.chamber_parameter_name, local.chamber_service, "aurora_postgres_cluster_name")}"
+  value       = "${join("", module.aurora_postgres.*.cluster_name)}"
+  description = "Aurora Postgres DB Cluster Identifier"
+  type        = "String"
+  overwrite   = "${var.overwrite_ssm_parameter}"
+}

--- a/aws/kops-aurora-postgres/outputs.tf
+++ b/aws/kops-aurora-postgres/outputs.tf
@@ -1,0 +1,24 @@
+output "aurora_postgres_database_name" {
+  value       = "${module.aurora_postgres.name}"
+  description = "Aurora Postgres Database name"
+}
+
+output "aurora_postgres_master_username" {
+  value       = "${module.aurora_postgres.user}"
+  description = "Aurora Postgres Username for the master DB user"
+}
+
+output "aurora_postgres_master_hostname" {
+  value       = "${module.aurora_postgres.master_host}"
+  description = "Aurora Postgres DB Master hostname"
+}
+
+output "aurora_postgres_replicas_hostname" {
+  value       = "${module.aurora_postgres.replicas_host}"
+  description = "Aurora Postgres Replicas hostname"
+}
+
+output "aurora_postgres_cluster_name" {
+  value       = "${module.aurora_postgres.cluster_name}"
+  description = "Aurora Postgres Cluster Identifier"
+}

--- a/aws/kops-aurora-postgres/variables.tf
+++ b/aws/kops-aurora-postgres/variables.tf
@@ -1,0 +1,119 @@
+variable "aws_assume_role_arn" {
+  type = "string"
+}
+
+variable "namespace" {
+  type        = "string"
+  description = "Namespace (e.g. `eg` or `cp`)"
+}
+
+variable "stage" {
+  type        = "string"
+  description = "Stage (e.g. `prod`, `dev`, `staging`)"
+}
+
+variable "zone_name" {
+  type        = "string"
+  default     = ""
+  description = "Domain name of DNS zone in which to add subdomain records, optional, defaults to cluster_name"
+}
+
+variable "kops_cluster_name" {
+  type        = "string"
+  description = "Kops cluster name (e.g. `us-east-1.prod.cloudposse.co` or `cluster-1.cloudposse.co`)"
+}
+
+variable "vpc_id" {
+  type        = "string"
+  default     = ""
+  description = "VPC ID of the Kubernetes cluster (optional, will try to auto-detect by using `cluster_name` tag)"
+}
+
+variable "chamber_service" {
+  default     = ""
+  description = "`chamber` service name. See [chamber usage](https://github.com/segmentio/chamber#usage) for more details"
+}
+
+variable "chamber_parameter_name" {
+  default     = "/%s/%s"
+  description = "`chamber` parameter name template"
+}
+
+variable "kms_key_id" {
+  type        = "string"
+  default     = ""
+  description = "KMS key ID used to encrypt SSM SecureString parameters"
+}
+
+variable "overwrite_ssm_parameter" {
+  type        = "string"
+  default     = "true"
+  description = "Whether to overwrite an existing SSM parameter"
+}
+
+variable "postgres_name" {
+  type        = "string"
+  description = "Name of the application, e.g. `app` or `analytics`"
+  default     = "postgres"
+}
+
+# Don't use `admin`
+# Read more: <https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html>
+# ("MasterUsername admin cannot be used as it is a reserved word used by the engine")
+variable "postgres_admin_user" {
+  type        = "string"
+  description = "Postgres admin user name"
+  default     = ""
+}
+
+# Must be longer than 8 chars
+# Read more: <https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html>
+# ("The parameter MasterUserPassword is not a valid password because it is shorter than 8 characters")
+variable "postgres_admin_password" {
+  type        = "string"
+  description = "Postgres password for the admin user"
+  default     = ""
+}
+
+variable "postgres_db_name" {
+  type        = "string"
+  description = "Postgres database name"
+  default     = ""
+}
+
+# https://aws.amazon.com/rds/aurora/pricing
+variable "postgres_instance_type" {
+  type        = "string"
+  default     = "db.r4.large"
+  description = "EC2 instance type for Postgres cluster"
+}
+
+variable "postgres_cluster_size" {
+  type        = "string"
+  default     = "2"
+  description = "Postgres cluster size"
+}
+
+variable "postgres_cluster_enabled" {
+  type        = "string"
+  default     = "true"
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "postgres_iam_database_authentication_enabled" {
+  type        = "string"
+  default     = "false"
+  description = "Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled"
+}
+
+variable "postgres_cluster_dns_name" {
+  type        = "string"
+  description = "Name of the cluster CNAME record to create in the parent DNS zone specified by `zone_name`. If left empty, the name will be auto-asigned using the format `master.var.postgres_name`"
+  default     = ""
+}
+
+variable "postgres_reader_dns_name" {
+  type        = "string"
+  description = "Name of the reader endpoint CNAME record to create in the parent DNS zone specified by `zone_name`. If left empty, the name will be auto-asigned using the format `replicas.var.postgres_name`"
+  default     = ""
+}


### PR DESCRIPTION
## what
* Add `kops-aurora-postgres` module

## why
* To provision Aurora Postgres cluster in an existing `kops` VPC
* It's different from `backing-services/aurora-postgres.tf`, which provisions Aurora Postgres cluster in a backing services VPC which is separate from `kops` VPC
