### PR TITLE
Update `ecs/atlantis`

### DIFF
--- a/aws/ecs/alb.tf
+++ b/aws/ecs/alb.tf
@@ -11,7 +11,7 @@ variable "alb_ingress_cidr_blocks_https" {
 }
 
 module "alb" {
-  source             = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.2.6"
+  source             = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.3.0"
   name               = "${var.name}"
   namespace          = "${var.namespace}"
   stage              = "${var.stage}"
@@ -27,4 +27,6 @@ module "alb" {
   https_ingress_cidr_blocks = "${var.alb_ingress_cidr_blocks_https}"
   certificate_arn           = "${module.acm_request_certificate.arn}"
   health_check_interval     = "60"
+
+  alb_access_logs_s3_bucket_force_destroy = true
 }

--- a/aws/ecs/atlantis.tf
+++ b/aws/ecs/atlantis.tf
@@ -171,7 +171,7 @@ variable "atlantis_alb_ingress_authenticated_paths" {
 }
 
 module "atlantis" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-ecs-atlantis.git?ref=tags/0.10.1"
+  source    = "git::https://github.com/cloudposse/terraform-aws-ecs-atlantis.git?ref=tags/0.11.0"
   enabled   = "${var.atlantis_enabled}"
   name      = "${var.name}"
   namespace = "${var.namespace}"
@@ -228,6 +228,8 @@ module "atlantis" {
   authentication_cognito_user_pool_domain_ssm_name    = "${var.atlantis_cognito_user_pool_domain_ssm_name}"
   authentication_oidc_client_id_ssm_name              = "${var.atlantis_oidc_client_id_ssm_name}"
   authentication_oidc_client_secret_ssm_name          = "${var.atlantis_oidc_client_secret_ssm_name}"
+
+  codepipeline_s3_bucket_force_destroy = true
 }
 
 output "atlantis_url" {

--- a/aws/ecs/default-backend.tf
+++ b/aws/ecs/default-backend.tf
@@ -8,7 +8,7 @@ variable "default_backend_name" {
 
 # default backend app
 module "default_backend_web_app" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.19.0"
+  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.21.0"
   name       = "${var.name}"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"


### PR DESCRIPTION
## what
* Update `ecs/atlantis`
* Update `ecs/alb`

## why
* Make GitHub token for creating webhooks optional. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable. Sourcing from the `GITHUB_TOKEN` environment variable is useful when the module is provisioned from `geodesic` or CI/CD that have access to the `GITHUB_TOKEN` environment variable, which in turn could be sourced from SSM using `chamber`
* To be able to force-destroy the CodePipeline artifact storage and ALB access logs buckets without manually deleting the objects from them
* Make the name of the ALB access logs bucket more descriptive: `namespace-stage-name-alb-access-logs` instead of just `namespace-stage-name`

## references
* https://github.com/cloudposse/terraform-github-repository-webhooks/releases/tag/0.4.0
* https://github.com/cloudposse/terraform-aws-ecs-codepipeline/releases/tag/0.8.0
* https://github.com/cloudposse/terraform-aws-ecs-web-app/releases/tag/0.21.0
* https://github.com/cloudposse/terraform-aws-ecs-atlantis/releases/tag/0.11.0
* https://github.com/cloudposse/terraform-aws-alb/pull/17
