### PR TITLE
Update  `ecs/atlantis` version

### DIFF
--- a/aws/ecs/atlantis.tf
+++ b/aws/ecs/atlantis.tf
@@ -171,7 +171,7 @@ variable "atlantis_alb_ingress_authenticated_paths" {
 }
 
 module "atlantis" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-ecs-atlantis.git?ref=update-web-app"
+  source    = "git::https://github.com/cloudposse/terraform-aws-ecs-atlantis.git?ref=tags/0.12.0"
   enabled   = "${var.atlantis_enabled}"
   name      = "${var.name}"
   namespace = "${var.namespace}"

--- a/aws/ecs/atlantis.tf
+++ b/aws/ecs/atlantis.tf
@@ -171,7 +171,7 @@ variable "atlantis_alb_ingress_authenticated_paths" {
 }
 
 module "atlantis" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-ecs-atlantis.git?ref=tags/0.11.0"
+  source    = "git::https://github.com/cloudposse/terraform-aws-ecs-atlantis.git?ref=update-web-app"
   enabled   = "${var.atlantis_enabled}"
   name      = "${var.name}"
   namespace = "${var.namespace}"

--- a/aws/ecs/default-backend.tf
+++ b/aws/ecs/default-backend.tf
@@ -8,7 +8,7 @@ variable "default_backend_name" {
 
 # default backend app
 module "default_backend_web_app" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.21.0"
+  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.22.0"
   name       = "${var.name}"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"


### PR DESCRIPTION
## what
* Update  `ecs/atlantis` version

## why
* https://github.com/cloudposse/terraform-aws-ecs-atlantis/pull/12
* https://github.com/cloudposse/terraform-aws-ecs-web-app/pull/34
* https://github.com/cloudposse/terraform-aws-ecs-codepipeline/pull/25

