### PR TITLE
[vpc] Allow for deploying the VPC into fewer than all the availability zones

### DIFF
--- a/aws/vpc/variables.tf
+++ b/aws/vpc/variables.tf
@@ -28,6 +28,32 @@ variable "region" {
   type = "string"
 }
 
+variable "max_subnet_count" {
+  default     = 0
+  description = "Sets the maximum amount of subnets to deploy.  0 will deploy a subnet for every provided availablility zone (in `availability_zones` variable) within the region"
+}
+
+variable "availability_zones" {
+  type        = "list"
+  default     = []
+  description = "List of Availability Zones where subnets will be created. If empty, all zones will be used"
+}
+
+variable "vpc_nat_gateway_enabled" {
+  description = "Flag to enable/disable NAT Gateways to allow servers in the private subnets to access the Internet"
+  default     = "true"
+}
+
+variable "vpc_nat_instance_enabled" {
+  description = "Flag to enable/disable NAT Instances to allow servers in the private subnets to access the Internet"
+  default     = "false"
+}
+
+variable "vpc_nat_instance_type" {
+  description = "NAT Instance type"
+  default     = "t3.micro"
+}
+
 variable "tags" {
   type        = "map"
   default     = {}
@@ -36,10 +62,6 @@ variable "tags" {
 
 variable "vpc_cidr_block" {
   default = "10.0.0.0/16"
-}
-
-variable "vpc_nat_gateway_enabled" {
-  default = "true"
 }
 
 variable "chamber_service" {


### PR DESCRIPTION
## what
Allow for deploying the VPC into fewer than all the availability zones
## why
We typically only want to deploy into 3 availability zones, but prior to this PR the VPC deployed into every available availability zone, and, for example, `us-east-1` has 6 availability zones