### PR TITLE
[kops] Support multi-region kops clusters.[ecr] Fix TF "count" problem in ecr.

### DIFF
--- a/aws/ecr/kops_ecr_app.tf
+++ b/aws/ecr/kops_ecr_app.tf
@@ -9,7 +9,7 @@ variable "kops_ecr_app_enabled" {
 }
 
 module "kops_ecr_app" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-ecr.git?ref=tags/0.4.0"
+  source    = "git::https://github.com/cloudposse/terraform-aws-ecr.git?ref=tags/0.6.1"
   namespace = "${var.namespace}"
   stage     = "${var.stage}"
   name      = "${var.kops_ecr_app_repository_name}"

--- a/aws/kops/main.tf
+++ b/aws/kops/main.tf
@@ -25,17 +25,18 @@ locals {
 }
 
 module "kops_state_backend" {
-  source           = "git::https://github.com/cloudposse/terraform-aws-kops-state-backend.git?ref=tags/0.1.7"
+  source           = "git::https://github.com/cloudposse/terraform-aws-kops-state-backend.git?ref=tags/0.3.0"
   namespace        = "${var.namespace}"
   stage            = "${var.stage}"
   name             = "${var.name}"
   attributes       = ["${var.kops_attribute}"]
-  cluster_name     = "${var.region}"
+  cluster_name     = "${coalesce(var.cluster_name_prefix, var.resource_region, var.region)}"
   parent_zone_name = "${var.zone_name}"
   zone_name        = "${var.complete_zone_name}"
   domain_enabled   = "${var.domain_enabled}"
   force_destroy    = "${var.force_destroy}"
-  region           = "${var.region}"
+  region           = "${coalesce(var.state_store_region, var.region)}"
+  create_bucket    = "${var.create_state_store_bucket}"
 }
 
 module "ssh_key_pair" {
@@ -43,7 +44,7 @@ module "ssh_key_pair" {
   namespace            = "${var.namespace}"
   stage                = "${var.stage}"
   name                 = "${var.name}"
-  attributes           = ["${var.region}"]
+  attributes           = ["${coalesce(var.resource_region, var.region)}"]
   ssm_path_prefix      = "${local.chamber_service}"
   rsa_bits             = "${var.ssh_key_rsa_bits}"
   ssh_key_algorithm    = "${var.ssh_key_algorithm}"

--- a/aws/kops/variables.tf
+++ b/aws/kops/variables.tf
@@ -20,7 +20,32 @@ variable "name" {
 
 variable "region" {
   type        = "string"
-  description = "AWS region"
+  default     = ""
+  description = "AWS region for resources. Can be overriden by `resource_region` and `state_store_region`"
+}
+
+variable "state_store_region" {
+  type        = "string"
+  default     = ""
+  description = "Region where to create the S3 bucket for the kops state store. Defaults to `var.region`"
+}
+
+variable "resource_region" {
+  type        = "string"
+  default     = ""
+  description = "Region where to create region-specific resources. Defaults to `var.region`"
+}
+
+variable "create_state_store_bucket" {
+  type        = "string"
+  default     = "true"
+  description = "Set to `false` to use existing S3 bucket (e.g. from another region)"
+}
+
+variable "cluster_name_prefix" {
+  type        = "string"
+  default     = ""
+  description = "Prefix to add before parent DNS zone name to identify this cluster, e.g. `us-east-1`. Defaults to `var.resource_region`"
 }
 
 variable "availability_zones" {


### PR DESCRIPTION
## what
- [kops] Support multi-region clusters by allowing `kops` to use an existing S3 bucket in a different region for its state storage. Data is stored under cluster name, so it is no operational problem for multiple clusters to use the same S3 bucket. 
- [ecr] Fix an issue with Terraform "count"

## why
- [kops] Some people want to run clusters in more than one AWS region within the same AWS account.
- [ecr] ECR module failed when setting both read-only and full-access principals. This updates the backend module to one that has that issue fixed.