### PR TITLE
[kops-aws-platform] Support cert-manager

### DIFF
--- a/aws/kops-aws-platform/external-dns.tf
+++ b/aws/kops-aws-platform/external-dns.tf
@@ -1,5 +1,5 @@
 module "kops_external_dns" {
-  source         = "git::https://github.com/cloudposse/terraform-aws-kops-external-dns.git?ref=tags/0.2.1"
+  source         = "git::https://github.com/cloudposse/terraform-aws-kops-external-dns.git?ref=tags/0.2.2"
   namespace      = "${var.namespace}"
   stage          = "${var.stage}"
   name           = "external-dns"


### PR DESCRIPTION
## what
[kops-aws-platform] Expand external-dns IAM role to cover [`cert-manager`](https://github.com/jetstack/cert-manager) as well
## why
Support `cert-manager` as replacement for obsolete `kube-lego`