### PR TITLE
EasyVPC peering inside a single AWS account.

### DIFF
--- a/aws/ecs/acm.tf
+++ b/aws/ecs/acm.tf
@@ -11,12 +11,12 @@ variable "domain_name" {
 }
 
 locals {
-  domain_name               = "${var.domain_name != "" ? var.domain_name : module.dns.zone_name }"
+  domain_name               = "${var.domain_name != "" ? var.domain_name : module.dns.zone_name}"
   subject_alternative_names = "${distinct(concat(var.subject_alternative_names, formatlist("*.%s", list(local.domain_name))))}"
 }
 
 module "acm_request_certificate" {
-  source                    = "git::https://github.com/cloudposse/terraform-aws-acm-request-certificate.git?ref=tags/0.1.1"
+  source                    = "git::https://github.com/cloudposse/terraform-aws-acm-request-certificate.git?ref=tags/0.1.4"
   domain_name               = "${local.domain_name}"
   ttl                       = "300"
   subject_alternative_names = "${local.subject_alternative_names}"

--- a/aws/vpc-peering-intra-account/Makefile
+++ b/aws/vpc-peering-intra-account/Makefile
@@ -1,0 +1,15 @@
+## Initialize terraform remote state
+init:
+	[ -f .terraform/terraform.tfstate ] || terraform $@
+
+## Clean up the project
+clean:
+	rm -rf .terraform *.tfstate*
+
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
+	terraform $@

--- a/aws/vpc-peering-intra-account/main.tf
+++ b/aws/vpc-peering-intra-account/main.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_version = "~> 0.11.0"
+
+  backend "s3" {}
+}
+
+provider "aws" {
+  assume_role {
+    role_arn = "${var.aws_assume_role_arn}"
+  }
+}
+
+module "vpc_peering" {
+  source = "git::https://github.com/cloudposse/terraform-aws-vpc-peering.git?ref=tags/0.2.0"
+
+  enabled = "${var.enabled}"
+
+  stage      = "${var.stage}"
+  namespace  = "${var.namespace}"
+  name       = "${var.name}"
+  delimiter  = "${var.delimiter}"
+  attributes = "${var.attributes}"
+  tags       = "${var.tags}"
+
+  requestor_vpc_id   = "${var.requestor_vpc_id}"
+  requestor_vpc_tags = "${var.requestor_vpc_tags}"
+  acceptor_vpc_id    = "${var.acceptor_vpc_id}"
+  acceptor_vpc_tags  = "${var.acceptor_vpc_tags}"
+  auto_accept        = "${var.auto_accept}"
+
+  acceptor_allow_remote_vpc_dns_resolution  = "${var.acceptor_allow_remote_vpc_dns_resolution}"
+  requestor_allow_remote_vpc_dns_resolution = "${var.requestor_allow_remote_vpc_dns_resolution}"
+}

--- a/aws/vpc-peering-intra-account/outputs.tf
+++ b/aws/vpc-peering-intra-account/outputs.tf
@@ -1,0 +1,9 @@
+output "connection_id" {
+  value       = "${module.vpc_peering.connection_id}"
+  description = "VPC peering connection ID"
+}
+
+output "accept_status" {
+  value       = "${module.vpc_peering.accept_status}"
+  description = "The status of the VPC peering connection request"
+}

--- a/aws/vpc-peering-intra-account/variables.tf
+++ b/aws/vpc-peering-intra-account/variables.tf
@@ -1,0 +1,80 @@
+variable "enabled" {
+  default     = "true"
+  description = "Set to false to prevent the module from creating or accessing any resources"
+}
+
+variable "aws_assume_role_arn" {
+  type = "string"
+}
+
+variable "requestor_vpc_id" {
+  type        = "string"
+  description = "Requestor VPC ID"
+  default     = ""
+}
+
+variable "requestor_vpc_tags" {
+  type        = "map"
+  description = "Requestor VPC tags"
+  default     = {}
+}
+
+variable "acceptor_vpc_id" {
+  type        = "string"
+  description = "Acceptor VPC ID"
+  default     = ""
+}
+
+variable "acceptor_vpc_tags" {
+  type        = "map"
+  description = "Acceptor VPC tags"
+  default     = {}
+}
+
+variable "auto_accept" {
+  default     = "true"
+  description = "Automatically accept the peering (both VPCs need to be in the same AWS account)"
+}
+
+variable "acceptor_allow_remote_vpc_dns_resolution" {
+  default     = "true"
+  description = "Allow acceptor VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requestor VPC"
+}
+
+variable "requestor_allow_remote_vpc_dns_resolution" {
+  default     = "true"
+  description = "Allow requestor VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the acceptor VPC"
+}
+
+variable "namespace" {
+  description = "Namespace (e.g. `cp` or `cloudposse`)"
+  type        = "string"
+}
+
+variable "stage" {
+  description = "Stage (e.g. `prod`, `dev`, `staging`)"
+  type        = "string"
+}
+
+variable "name" {
+  description = "Name  (e.g. `app` or `cluster`)"
+  type        = "string"
+}
+
+variable "delimiter" {
+  type        = "string"
+  default     = "-"
+  description = "Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`"
+}
+
+variable "attributes" {
+  type        = "list"
+  default     = []
+  description = "Additional attributes (e.g. `policy` or `role`)"
+}
+
+variable "tags" {
+  type        = "map"
+  default     = {}
+  description = "Additional tags (e.g. map('BusinessUnit`,`XYZ`)"
+}


### PR DESCRIPTION
## what
Create `vpc-peering-intra-account`

## why
Much easier-to-use than other VPC peering modules, because it requires both VPCs to be in the same account.