### PR TITLE
 [kops-aws-platform] Create autoscaler role

### DIFF
--- a/aws/acm/main.tf
+++ b/aws/acm/main.tf
@@ -1,41 +1,44 @@
 terraform {
-  required_version = ">= 0.11.2"
-
   backend "s3" {}
 }
 
-variable "aws_assume_role_arn" {}
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
-variable "domain_name" {
-  description = "Domain name (E.g. staging.cloudposse.co)"
-}
+
 
 module "certificate" {
-  source                           = "git::https://github.com/cloudposse/terraform-aws-acm-request-certificate.git?ref=tags/0.1.1"
-  domain_name                      = "${var.domain_name}"
-  proces_domain_validation_options = "true"
-  ttl                              = "300"
-  subject_alternative_names        = ["*.${var.domain_name}"]
+  source                            = "git::https://github.com/cloudposse/terraform-aws-acm-request-certificate.git?ref=tags/0.4.0"
+  domain_name                       = var.domain_name
+  process_domain_validation_options = true
+  ttl                               = 300
+  subject_alternative_names         = ["*.${var.domain_name}"]
+}
+
+resource "aws_ssm_parameter" "certificate_arn_parameter" {
+  name        = format(var.chamber_parameter_name_format, var.chamber_service, var.certificate_arn_parameter_name)
+  value       = module.certificate.arn
+  description = "ACM-issued TLS Certificate ARN"
+  type        = "String"
+  overwrite   = true
 }
 
 output "certificate_domain_name" {
-  value = "${var.domain_name}"
+  value = var.domain_name
 }
 
 output "certificate_id" {
-  value = "${module.certificate.id}"
+  value = module.certificate.id
 }
 
 output "certificate_arn" {
-  value = "${module.certificate.arn}"
+  value = module.certificate.arn
 }
 
 output "certificate_domain_validation_options" {
-  value = "${module.certificate.domain_validation_options}"
+  value = module.certificate.domain_validation_options
 }

--- a/aws/acm/variables.tf
+++ b/aws/acm/variables.tf
@@ -1,0 +1,27 @@
+
+variable "aws_assume_role_arn" {}
+
+
+variable "domain_name" {
+  type        = string
+  description = "Domain name (E.g. staging.cloudposse.co)"
+}
+
+
+variable "chamber_service" {
+  description = "`chamber` service name to use for storing the certificate ARN"
+  default     = "kops"
+}
+
+# If certificate_arn_parameter_name is not set, no SSM parameter will be created/updated
+variable "certificate_arn_parameter_name" {
+  description = "Chamber parameter name in which to store the AWS ARN of the issued certificate"
+  default     = ""
+}
+
+variable "chamber_parameter_name_format" {
+  type        = string
+  description = "Format string for combining `chamber` service name and parameter name. It is rare to need to set this."
+  default     = "/%s/%s"
+}
+

--- a/aws/acm/versions.tf
+++ b/aws/acm/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~> 0.12.0"
+
+  required_providers {
+    aws = "~> 2.0"
+  }
+}

--- a/aws/kops-aws-platform/autoscaler-role.tf
+++ b/aws/kops-aws-platform/autoscaler-role.tf
@@ -1,0 +1,58 @@
+data "aws_iam_policy_document" "autoscaler" {
+  statement {
+    sid = "AutoScaler"
+
+    actions = [
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeTags",
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
+    ]
+
+    resources = ["*"]
+    effect    = "Allow"
+  }
+}
+
+
+module "autoscaler_role" {
+  source = "git::https://github.com/cloudposse/terraform-aws-iam-role.git?ref=tags/0.4.0"
+
+  enabled            = "true"
+  namespace          = "${var.namespace}"
+  stage              = "${var.stage}"
+  name               = "kubernetes"
+  attributes         = ["autoscaler", "role"]
+  role_description   = "Role for Cluster Auto-Scaler"
+  policy_description = "Permit auto-scaling operations on auto-scaling groups"
+  principals         = { AWS = ["${module.kops_metadata_iam.masters_role_arn}"] }
+
+  policy_documents = ["${data.aws_iam_policy_document.autoscaler.json}"]
+}
+
+resource "aws_ssm_parameter" "kops_autoscaler_iam_role_name" {
+  name        = "/kops/kops_autoscaler_iam_role_name"
+  value       = "${module.autoscaler_role.name}"
+  description = "IAM role name for cluster autoscaler"
+  type        = "String"
+  overwrite   = "true"
+}
+
+
+output "autoscaler_role_name" {
+  value       = "${module.autoscaler_role.name}"
+  description = "The name of the IAM role created"
+}
+
+output "autoscaler_role_id" {
+  value       = "${module.autoscaler_role.id}"
+  description = "The stable and unique string identifying the role"
+}
+
+output "autoscaler_role_arn" {
+  value       = "${module.autoscaler_role.arn}"
+  description = "The Amazon Resource Name (ARN) specifying the role"
+}
+

--- a/aws/kops-aws-platform/efs-provisioner.tf
+++ b/aws/kops-aws-platform/efs-provisioner.tf
@@ -20,7 +20,7 @@ data "aws_ssm_parameter" "kops_zone_id" {
 }
 
 locals {
-  kops_zone_id = "${coalesce(var.kops_dns_zone_id, join("",data.aws_ssm_parameter.kops_zone_id.*.value))}"
+  kops_zone_id = "${coalesce(var.kops_dns_zone_id, join("", data.aws_ssm_parameter.kops_zone_id.*.value))}"
 }
 
 module "kops_efs_provisioner" {

--- a/aws/kops-aws-platform/flow-logs.tf
+++ b/aws/kops-aws-platform/flow-logs.tf
@@ -4,8 +4,7 @@ variable "flow_logs_enabled" {
 }
 
 module "flow_logs" {
-  source = "git::https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket.git?ref=tags/0.1.0"
-
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket.git?ref=tags/0.1.1"
   name       = "kops"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"

--- a/aws/kops-aws-platform/main.tf
+++ b/aws/kops-aws-platform/main.tf
@@ -16,7 +16,17 @@ module "kops_metadata" {
   cluster_name = "${var.region}.${var.zone_name}"
 }
 
+module "kops_metadata_iam" {
+  source       = "git::https://github.com/cloudposse/terraform-aws-kops-data-iam.git?ref=tags/0.1.0"
+  cluster_name = "${var.region}.${var.zone_name}"
+}
+
 resource "aws_default_security_group" "default" {
+  # If kops is using a shared VPC, then it is likely that the kops_metadata module will
+  # return an empty vpc_id, in which case we will leave it to the VPC owner to manage
+  # the default security group.
+  count = "${module.kops_metadata.vpc_id == "" ? 0 : 1}"
+
   vpc_id = "${module.kops_metadata.vpc_id}"
 
   tags = {

--- a/aws/kops/main.tf
+++ b/aws/kops/main.tf
@@ -19,7 +19,7 @@ locals {
 
   # If we are creating the VPC, concatenate the predefined AZs with the computed AZs and select the first N distinct AZs.
   # If we are using a shared VPC, use the availability zones dictated by the VPC
-  availability_zones = "${split(",", var.create_vpc == "true" ? join(",", slice(local.distinct_availability_zones, 0, var.availability_zone_count)) : join("",data.aws_ssm_parameter.availability_zones.*.value))}"
+  availability_zones = "${split(",", var.create_vpc == "true" ? join(",", slice(local.distinct_availability_zones, 0, var.availability_zone_count)) : join("", data.aws_ssm_parameter.availability_zones.*.value))}"
 
   availability_zone_count = "${length(local.availability_zones)}"
 }
@@ -59,7 +59,7 @@ module "private_subnets" {
   iprange      = "${local.vpc_network_cidr}"
   newbits      = "${var.private_subnets_newbits > 0 ? var.private_subnets_newbits : local.availability_zone_count}"
   netnum       = "${var.private_subnets_netnum}"
-  subnet_count = "${local.availability_zone_count+1}"
+  subnet_count = "${local.availability_zone_count + 1}"
 }
 
 # Divide up the first private subnet and use it for the utility subnet
@@ -127,9 +127,9 @@ data "aws_ssm_parameter" "public_subnet_ids" {
 ######
 
 locals {
-  vpc_network_cidr     = "${var.create_vpc == "true" ? var.network_cidr : join("",data.aws_ssm_parameter.vpc_cidr_block.*.value)}"
-  private_subnet_cidrs = "${var.create_vpc == "true" ? join(",", slice(module.private_subnets.cidrs, 1, local.availability_zone_count+1)) : join("",data.aws_ssm_parameter.private_subnet_cidrs.*.value)}"
-  utility_subnet_cidrs = "${var.create_vpc == "true" ? join(",", module.utility_subnets.cidrs): join("",data.aws_ssm_parameter.public_subnet_cidrs.*.value)}"
+  vpc_network_cidr     = "${var.create_vpc == "true" ? var.network_cidr : join("", data.aws_ssm_parameter.vpc_cidr_block.*.value)}"
+  private_subnet_cidrs = "${var.create_vpc == "true" ? join(",", slice(module.private_subnets.cidrs, 1, local.availability_zone_count + 1)) : join("", data.aws_ssm_parameter.private_subnet_cidrs.*.value)}"
+  utility_subnet_cidrs = "${var.create_vpc == "true" ? join(",", module.utility_subnets.cidrs) : join("", data.aws_ssm_parameter.public_subnet_cidrs.*.value)}"
 }
 
 # These parameters correspond to the kops manifest template:


### PR DESCRIPTION
## what
1. [kops-aws-platform] Create autoscaler role
1. [kops-aws-platform] Do not try to take over default security group of shared VPC
1. [acm] Optionally save certificate ARN in SSM
1. [acm] Upgrade to TF 0.12


## why
1. Enable autoscaler to get authorization via `kiam`
1. VPC owner should manage default security group
1. Prevent copy-paste between certificate creation and usage
1. Migration to TF 0.12 as time allows