### PR TITLE
[teleport] Add additional required permissions

### DIFF
--- a/aws/kops-aws-platform/autoscaler-role.tf
+++ b/aws/kops-aws-platform/autoscaler-role.tf
@@ -33,7 +33,7 @@ module "autoscaler_role" {
 }
 
 resource "aws_ssm_parameter" "kops_autoscaler_iam_role_name" {
-  name        = "/kops/kops_autoscaler_iam_role_name"
+  name        = "/kops/kubernetes_autoscaler_iam_role_name"
   value       = "${module.autoscaler_role.name}"
   description = "IAM role name for cluster autoscaler"
   type        = "String"

--- a/aws/teleport/main.tf
+++ b/aws/teleport/main.tf
@@ -86,24 +86,34 @@ resource "aws_iam_role" "teleport" {
 }
 
 data "aws_iam_policy_document" "teleport" {
+  // Teleport can use LetsEncrypt to get TLS certificates. For this  // it needs additional permissions which are not included here.
+
+  // Teleport can use SSM to publish "join tokens" and retreive the enterprise  // license, but that is not fully documented, so permissions to access SSM  // are not included at this time.
+
+  // S3 permissions are needed to save and replay SSH sessions
   statement {
+    sid       = "ListTeleportSessionData"
     effect    = "Allow"
-    actions   = ["s3:ListBucket"]
+    actions   = ["s3:ListBucket", "s3:ListBucketVersions"]
     resources = ["arn:aws:s3:::${module.teleport_backend.s3_bucket_id}"]
   }
 
   statement {
+    sid    = "GetTeleportSessionData"
     effect = "Allow"
 
     actions = [
       "s3:PutObject",
+      "s3:GetObjectVersion",
       "s3:GetObject",
     ]
 
     resources = ["arn:aws:s3:::${module.teleport_backend.s3_bucket_id}/*"]
   }
 
+  // DynamoDB permissions are needed to save configuration and event data
   statement {
+    sid     = "ReadWriteTeleportEventAndConfigData"
     effect  = "Allow"
     actions = ["dynamodb:*"]
 


### PR DESCRIPTION
## what
1. [teleport] Add additional required permissions
2. [autoscaler-role] Change SSM parameter name

## why
1. New permissions required in Teleport 4.0.5. See https://github.com/gravitational/teleport/issues/2963
2. Distinguish deployed auto-scaler from `kops` add-on