### PR TITLE
[atlantis] Preliminary support for specifying a build timeout

### DIFF
--- a/aws/ecs/atlantis.tf
+++ b/aws/ecs/atlantis.tf
@@ -196,6 +196,7 @@ module "atlantis" {
   parent_zone_id     = "${module.dns.zone_id}"
   ecs_cluster_arn    = "${aws_ecs_cluster.default.arn}"
   ecs_cluster_name   = "${aws_ecs_cluster.default.name}"
+  build_timeout      = "${var.atlantis_build_timeout}"
   repo_name          = "${var.atlantis_repo_name}"
   repo_owner         = "${var.atlantis_repo_owner}"
   private_subnet_ids = ["${module.subnets.private_subnet_ids}"]

--- a/aws/ecs/flow-logs.tf
+++ b/aws/ecs/flow-logs.tf
@@ -4,7 +4,7 @@ variable "flow_logs_enabled" {
 }
 
 module "flow_logs" {
-  source = "git::https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket.git?ref=tags/0.1.0"
+  source = "git::https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket.git?ref=tags/0.1.1"
 
   name       = "${var.name}"
   namespace  = "${var.namespace}"

--- a/aws/ecs/main.tf
+++ b/aws/ecs/main.tf
@@ -9,3 +9,9 @@ provider "aws" {
     role_arn = "${var.aws_assume_role_arn}"
   }
 }
+
+# Change in 2.2.1 breaks
+# module.default_backend_web_app.module.ecs_codepipeline.module.github_webhooks.provider.github
+provider "github" {
+  version = "2.2.0"
+}

--- a/aws/ecs/variables.tf
+++ b/aws/ecs/variables.tf
@@ -46,3 +46,8 @@ variable "region" {
   description = "AWS Region the S3 bucket should reside in"
   default     = "us-west-2"
 }
+
+variable "atlantis_build_timeout" {
+  description = "Time (in minutes) to allow for Atlantis build to complete before declaring it a failure"
+  default     = "20"
+}


### PR DESCRIPTION
# Do Not Merge

## what
Add `build_timeout` option for Atlantis deploy

## why
Current timeout of 5 minutes is too short

## notes
Several issues with this currently, due to changes in the Terraform `git` provider and changes backwards incompatible changes made for CIS. Needs thoughtful improvement. 