### PR TITLE
[kops-aws-platofrm] Store EFS info in SSM for use by efs-provisioner

### DIFF
--- a/aws/kops-aws-platform/autoscaler-role.tf
+++ b/aws/kops-aws-platform/autoscaler-role.tf
@@ -33,7 +33,7 @@ module "autoscaler_role" {
 }
 
 resource "aws_ssm_parameter" "kops_autoscaler_iam_role_name" {
-  name        = "/kops/kubernetes_autoscaler_iam_role_name"
+  name        = "${format(local.chamber_parameter_format, var.chamber_service, "kubernetes_autoscaler_iam_role_name")}"
   value       = "${module.autoscaler_role.name}"
   description = "IAM role name for cluster autoscaler"
   type        = "String"

--- a/aws/kops-aws-platform/efs-provisioner.tf
+++ b/aws/kops-aws-platform/efs-provisioner.tf
@@ -24,7 +24,7 @@ locals {
 }
 
 module "kops_efs_provisioner" {
-  source             = "git::https://github.com/cloudposse/terraform-aws-kops-efs.git?ref=tags/0.3.0"
+  source             = "git::https://github.com/cloudposse/terraform-aws-kops-efs.git?ref=tags/0.4.0"
   enabled            = "${var.efs_enabled}"
   namespace          = "${var.namespace}"
   stage              = "${var.stage}"
@@ -37,6 +37,24 @@ module "kops_efs_provisioner" {
   tags = {
     Cluster = "${var.region}.${var.zone_name}"
   }
+}
+
+resource "aws_ssm_parameter" "kops_efs_provisioner_role_name" {
+  count       = "${var.efs_enabled == "true" ? 1 : 0}"
+  name        = "/kops/kops_efs_provisioner_role_name"
+  value       = "${module.kops_efs_provisioner.role_name}"
+  description = "IAM role name for EFS provisioner"
+  type        = "String"
+  overwrite   = "true"
+}
+
+resource "aws_ssm_parameter" "kops_efs_file_system_id" {
+  count       = "${var.efs_enabled == "true" ? 1 : 0}"
+  name        = "/kops/kops_efs_file_system_id"
+  value       = "${module.kops_efs_provisioner.efs_id}"
+  description = "ID for shared EFS file system"
+  type        = "String"
+  overwrite   = "true"
 }
 
 output "kops_efs_provisioner_role_name" {

--- a/aws/kops-aws-platform/efs-provisioner.tf
+++ b/aws/kops-aws-platform/efs-provisioner.tf
@@ -11,12 +11,12 @@ variable "kops_dns_zone_id" {
 }
 
 data "aws_ssm_parameter" "kops_availability_zones" {
-  name = "/kops/kops_availability_zones"
+  name  = "${format(local.chamber_parameter_format, var.chamber_service_kops, "kops_availability_zones")}"
 }
 
 data "aws_ssm_parameter" "kops_zone_id" {
   count = "${var.efs_enabled == "true" && var.kops_dns_zone_id == "" ? 1 : 0}"
-  name  = "/kops/kops_dns_zone_id"
+  name  = "${format(local.chamber_parameter_format, var.chamber_service_kops, "kops_dns_zone_id")}"
 }
 
 locals {
@@ -41,7 +41,7 @@ module "kops_efs_provisioner" {
 
 resource "aws_ssm_parameter" "kops_efs_provisioner_role_name" {
   count       = "${var.efs_enabled == "true" ? 1 : 0}"
-  name        = "/kops/kops_efs_provisioner_role_name"
+  name        = "${format(local.chamber_parameter_format, var.chamber_service, "kops_efs_provisioner_role_name")}"
   value       = "${module.kops_efs_provisioner.role_name}"
   description = "IAM role name for EFS provisioner"
   type        = "String"
@@ -50,7 +50,7 @@ resource "aws_ssm_parameter" "kops_efs_provisioner_role_name" {
 
 resource "aws_ssm_parameter" "kops_efs_file_system_id" {
   count       = "${var.efs_enabled == "true" ? 1 : 0}"
-  name        = "/kops/kops_efs_file_system_id"
+  name        = "${format(local.chamber_parameter_format, var.chamber_service, "kops_efs_file_system_id")}"
   value       = "${module.kops_efs_provisioner.efs_id}"
   description = "ID for shared EFS file system"
   type        = "String"

--- a/aws/kops-aws-platform/main.tf
+++ b/aws/kops-aws-platform/main.tf
@@ -33,3 +33,7 @@ resource "aws_default_security_group" "default" {
     Name = "Default Security Group"
   }
 }
+
+locals {
+  chamber_parameter_format = "/%s/%s"
+}

--- a/aws/kops-aws-platform/variables.tf
+++ b/aws/kops-aws-platform/variables.tf
@@ -45,3 +45,16 @@ variable "tags" {
   default     = {}
   description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`"
 }
+
+variable "chamber_service" {
+  type        = "string"
+  default     = "kops"
+  description = "Service under which to store SSM parameters"
+}
+
+variable "chamber_service_kops" {
+  type        = "string"
+  default     = "kops"
+  description = "Service where kops stores its configuration information"
+}
+


### PR DESCRIPTION
## what
[kops-aws-platofrm] Store EFS info in SSM for use by efs-provisioner

## why
Avoid the need to copy and paste output of Terraform into input of Helmfile