### PR TITLE
[teleport] Configure version and proxy domain

### DIFF
--- a/aws/grafana-backing-services/main.tf
+++ b/aws/grafana-backing-services/main.tf
@@ -26,11 +26,6 @@ variable "stage" {
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
-variable "region" {
-  type        = string
-  description = "AWS region"
-}
-
 variable "dns_zone_name" {
   type        = string
   default     = ""

--- a/aws/teleport/main.tf
+++ b/aws/teleport/main.tf
@@ -201,6 +201,22 @@ resource "aws_ssm_parameter" "teleport_tokens" {
   overwrite   = "true"
 }
 
+resource "aws_ssm_parameter" "teleport_proxy_domain_name" {
+  name        = "${format(var.chamber_parameter_name, local.chamber_service, "teleport_proxy_domain_name")}"
+  value       = "${var.teleport_proxy_domain_name}"
+  description = "Teleport Proxy domain name"
+  type        = "String"
+  overwrite   = "true"
+}
+
+resource "aws_ssm_parameter" "teleport_version" {
+  name        = "${format(var.chamber_parameter_name, local.chamber_service, "teleport_version")}"
+  value       = "${var.teleport_version}"
+  description = "Teleport version to install"
+  type        = "String"
+  overwrite   = "true"
+}
+
 resource "kubernetes_namespace" "default" {
   metadata {
     annotations {

--- a/aws/teleport/outputs.tf
+++ b/aws/teleport/outputs.tf
@@ -1,3 +1,11 @@
+output "teleport_version" {
+  value = "${var.teleport_version}"
+}
+
+output "teleport_proxy_domain_name" {
+  value = "${var.teleport_proxy_domain_name}"
+}
+
 output "parameter_store_prefix" {
   value = "${format(var.chamber_parameter_name, local.chamber_service, "")}"
 }

--- a/aws/teleport/variables.tf
+++ b/aws/teleport/variables.tf
@@ -50,6 +50,16 @@ variable "tags" {
   description = "Additional tags (e.g. map('BusinessUnit`,`XYZ`)"
 }
 
+variable "teleport_version" {
+  type        = "string"
+  description = "Version number of Teleport to install (e.g. \"4.0.9\")"
+}
+
+variable "teleport_proxy_domain_name" {
+  type        = "string"
+  description = "Domain name to use for Teleport Proxy"
+}
+
 variable "masters_name" {
   type        = "string"
   default     = "masters"


### PR DESCRIPTION
## what
- [teleport] Configure version and proxy domain
- [grafana-backing-services] Remove unused `region` variable

## why
- Previously configured by directly adding to SSM, this now supports changing the Teleport version using GitOps
- Unused variables are misleading at best