### PR TITLE
[elasticsearch] Fix log cleanup module

### DIFF
--- a/aws/elasticsearch/main.tf
+++ b/aws/elasticsearch/main.tf
@@ -149,7 +149,7 @@ output "elasticsearch_user_iam_role_arn" {
 }
 
 module "elasticsearch_log_cleanup" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-lambda-elasticsearch-cleanup.git?ref=tags/0.3.0"
+  source    = "git::https://github.com/cloudposse/terraform-aws-lambda-elasticsearch-cleanup.git?ref=tags/0.4.2"
   enabled   = "${var.elasticsearch_enabled == "true" ? var.elasticsearch_log_cleanup_enabled : "false"}"
   namespace = "${var.namespace}"
   stage     = "${var.stage}"
@@ -163,4 +163,6 @@ module "elasticsearch_log_cleanup" {
 
   index        = "${var.elasticsearch_log_index_name}"
   delete_after = "${var.elasticsearch_log_retention_days}"
+
+  sns_arn = "${var.sns_arn}"
 }

--- a/aws/elasticsearch/variables.tf
+++ b/aws/elasticsearch/variables.tf
@@ -141,5 +141,11 @@ variable "elasticsearch_log_retention_days" {
 variable "elasticsearch_log_index_name" {
   type        = "string"
   default     = "all"
-  description = "Index/indices to process. Use a comma-separated list. Specify `all` to match every index except for `.kibana`"
+  description = "Index/indices to process. Use a comma-separated list. Specify `all` to match every index except for `.kibana` and `.kibana_1`"
+}
+
+variable "sns_arn" {
+  type        = "string"
+  default     = ""
+  description = "SNS ARN to publish alerts"
 }


### PR DESCRIPTION
## what
[elasticsearch] log cleanup lambda suddenly stopped working with error 
```
ValueError: You can only send PreparedRequests
```
apparently due to a change in AWS. This update installs an updated lambda function that work in the current AWS environment

## why
Restore functionality broken by external factors