### PR TITLE
[atlantis] Fix `ecs` project for `atlantis`. Add `ecs-atlantis` project for `atlantis` TF 0.12

### DIFF
--- a/aws/ecs-atlantis/Makefile
+++ b/aws/ecs-atlantis/Makefile
@@ -1,0 +1,15 @@
+## Initialize terraform remote state
+init:
+	[ -f .terraform/terraform.tfstate ] || terraform $@
+
+## Clean up the project
+clean:
+	rm -rf .terraform *.tfstate* $$TF_MODULE_CACHE
+
+## Pass arguments through to terraform which require remote state
+apply console destroy graph plan output providers show: init
+	terraform $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt validate version:
+	terraform $@

--- a/aws/ecs-atlantis/README.md
+++ b/aws/ecs-atlantis/README.md
@@ -1,0 +1,88 @@
+## CodePipeline Setup
+
+For GitHub, your personal access token must have the following scopes.
+
+* `repo`: Grants full control of private repositories.
+* `repo:status`: Grants access to commit statuses.
+* `admin:repo_hook`: Grants full control of repository hooks. This scope is not required if your token has the repo scope.
+
+We recommend creating the tokens from a "bot" account that has limited access to the repos you are using.
+
+Read more: <https://docs.aws.amazon.com/codebuild/latest/userguide/sample-access-tokens.html#sample-access-tokens>
+
+
+## Example Build Manifest
+
+Add the following `buildspec.yml` to the root of the GitHub repo's project.
+
+<details>
+<summary>View Example `buildspec.yml`</summary>
+
+```
+version: 0.2
+phases:
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR...
+      - aws --version
+      - eval $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)
+      - REPOSITORY_URI=$AWS_ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com/$IMAGE_REPO_NAME
+      - IMAGE_TAG=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+  build:
+    commands:
+      - echo Build started on `date`
+      - echo Building the Docker image...
+      - REPO_URI=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$IMAGE_REPO_NAME
+      - docker pull $REPO_URI:latest || true
+      - docker build --cache-from $REPO_URI:latest --tag $REPO_URI:latest --tag $REPO_URI:$IMAGE_TAG .
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker images...
+      - REPO_URI=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$IMAGE_REPO_NAME
+      - docker push $REPO_URI:latest
+      - docker push $REPO_URI:$IMAGE_TAG
+      - echo Writing image definitions file...
+      - printf '[{"name":"%s","imageUri":"%s"}]' "$CONTAINER_NAME" "$REPO_URI:$IMAGE_TAG" | tee imagedefinitions.json
+artifacts:
+  files: imagedefinitions.json
+```
+
+</details>
+
+## Troubleshooting
+
+
+### InvalidParameterException: Long arn format must be used for tagging operations
+
+```sh
+aws_ecs_service.default: error tagging ECS Cluster (arn:aws:ecs:us-west-2:223452713953:service/eg-example-fargate-atlantis): InvalidParameterException: Long arn format must be used for tagging operations
+```
+
+See: <https://stackoverflow.com/questions/53605033/adding-tags-to-ecs-service-invalidparameterexception/53625568#53625568>
+
+After enabling the Long ARNs, the cluster needs to be rebuilt from scratch.
+
+### InvalidParameterException: The target group with targetGroupArn ... does not have an associated load balancer.
+
+```sh
+InvalidParameterException: The target group with targetGroupArn arn:aws:elasticloadbalancing:us-west-2:223452713953:targetgroup/eg-example-backend/5f7241cb041d9356 does not have an associated load balancer.
+```
+
+This is a race condition. Rerun `terraform apply`.
+
+### ObjectNotFoundException: No scalable target registered for service namespace
+
+```sh
+Error putting scaling policy: ObjectNotFoundException: No scalable target registered for service namespace: ecs, resource ID: service/cpco-testing-fargate/eg-exapmle-fargate-atlantis, scalable dimension: ecs:service:DesiredCount
+````
+
+This is a race condition. Rerun `terraform apply`.
+
+### Webhooks Do Not Trigger Builds
+
+This could happen if the secrets between CodePipeline and GitHub do not match. Unfortunately, terraform cannot detect when the secrets change, so your best bet is to `taint` and reapply.
+
+```sh
+make taint/webhook
+```

--- a/aws/ecs-atlantis/acm.auto.tfvars.example
+++ b/aws/ecs-atlantis/acm.auto.tfvars.example
@@ -1,0 +1,1 @@
+#subject_alternative_names = [ "example.us-west-2-ecs.testing.example.co" ]

--- a/aws/ecs-atlantis/acm.tf
+++ b/aws/ecs-atlantis/acm.tf
@@ -1,0 +1,30 @@
+variable "subject_alternative_names" {
+  type        = list(string)
+  description = "A list of domains that should be SANs in the issued certificate"
+  default     = []
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Domain name (E.g. staging.cloudposse.co)"
+  default     = ""
+}
+
+locals {
+  domain_name = var.domain_name != "" ? var.domain_name : module.dns.zone_name
+
+  subject_alternative_names = distinct(
+    concat(
+      var.subject_alternative_names,
+      formatlist("*.%s", [local.domain_name])
+    )
+  )
+}
+
+module "acm_request_certificate" {
+  source                    = "git::https://github.com/cloudposse/terraform-aws-acm-request-certificate.git?ref=tags/0.4.0"
+  domain_name               = local.domain_name
+  ttl                       = 300
+  subject_alternative_names = local.subject_alternative_names
+  tags                      = var.tags
+}

--- a/aws/ecs-atlantis/alb.tf
+++ b/aws/ecs-atlantis/alb.tf
@@ -1,0 +1,32 @@
+variable "alb_ingress_cidr_blocks_http" {
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+  description = "List of CIDR blocks allowed to access environment over HTTP"
+}
+
+variable "alb_ingress_cidr_blocks_https" {
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+  description = "List of CIDR blocks allowed to access environment over HTTPS"
+}
+
+module "alb" {
+  source             = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.7.0"
+  name               = var.name
+  namespace          = var.namespace
+  stage              = var.stage
+  attributes         = var.attributes
+  vpc_id             = module.vpc.vpc_id
+  ip_address_type    = "ipv4"
+  subnet_ids         = [module.subnets.public_subnet_ids]
+  security_group_ids = []
+  access_logs_region = var.region
+
+  https_enabled             = true
+  http_ingress_cidr_blocks  = var.alb_ingress_cidr_blocks_http
+  https_ingress_cidr_blocks = var.alb_ingress_cidr_blocks_https
+  certificate_arn           = module.acm_request_certificate.arn
+  health_check_interval     = 60
+
+  alb_access_logs_s3_bucket_force_destroy = true
+}

--- a/aws/ecs-atlantis/atlantis-repo-config.yaml
+++ b/aws/ecs-atlantis/atlantis-repo-config.yaml
@@ -1,0 +1,22 @@
+# https://www.runatlantis.io/docs/configuring-atlantis.html
+# https://www.runatlantis.io/docs/server-configuration.html
+# https://www.runatlantis.io/docs/server-side-repo-config.html
+# https://www.runatlantis.io/docs/repo-level-atlantis-yaml.html
+
+# repos lists the config for specific repos
+repos:
+  # id can either be an exact repo ID or a regex.
+  # If using a regex, it must start and end with a slash
+  # Repo ID's are of the form {VCS hostname}/{org}/{repo name}
+  - id: /.*/
+
+    # apply_requirements sets the Apply Requirements for all repos that match
+    apply_requirements: [approved, mergeable]
+
+    # allowed_overrides specifies which keys can be overridden by this repo in
+    # its atlantis.yaml file
+    allowed_overrides: [apply_requirements, workflow]
+
+    # allow_custom_workflows defines whether this repo can define its own
+    # workflows. If false (default), the repo can only use server-side defined workflows
+    allow_custom_workflows: true

--- a/aws/ecs-atlantis/atlantis.auto.tfvars.example
+++ b/aws/ecs-atlantis/atlantis.auto.tfvars.example
@@ -1,0 +1,52 @@
+# Write atlantis_gh_token to SSM parameter store:
+# chamber write atlantis atlantis_gh_token "....."
+
+# Write github_webhooks_token to SSM parameter store:
+# chamber write atlantis github_webhooks_token "....."
+
+# When using Cognito authentication (atlantis_authentication_type = COGNITO), write the following values to SSM parameter store:
+# chamber write atlantis atlantis_cognito_user_pool_arn "....."
+# chamber write atlantis atlantis_cognito_user_pool_client_id "....."
+# chamber write atlantis atlantis_cognito_user_pool_domain "....."
+
+# When using OIDC authentication (atlantis_authentication_type = OIDC), write the following values to SSM parameter store:
+# chamber write atlantis atlantis_oidc_client_id "....."
+# chamber write atlantis atlantis_oidc_client_secret "....."
+
+atlantis_enabled = true
+
+atlantis_branch = "master"
+
+atlantis_repo_name = "testing.example.co"
+
+atlantis_repo_owner = "example"
+
+atlantis_repo_whitelist = ["github.com/example/*"]
+
+atlantis_repo_config = "/conf/ecs/atlantis-repo-config.yaml"
+
+atlantis_gh_user = "examplebot"
+
+atlantis_gh_team_whitelist = "engineering:plan,devops:*"
+
+atlantis_wake_word = "atlantis"
+
+atlantis_authentication_type = "OIDC"
+
+atlantis_oidc_issuer = "https://accounts.google.com"
+
+atlantis_oidc_authorization_endpoint = "https://accounts.google.com/o/oauth2/v2/auth"
+
+atlantis_oidc_token_endpoint = "https://oauth2.googleapis.com/token"
+
+atlantis_oidc_user_info_endpoint = "https://openidconnect.googleapis.com/v1/userinfo"
+
+atlantis_alb_ingress_unauthenticated_paths = ["/events"]
+
+atlantis_alb_ingress_listener_unauthenticated_priority = 50
+
+atlantis_alb_ingress_authenticated_paths = ["/*"]
+
+atlantis_alb_ingress_listener_authenticated_priority = 100
+
+availability_zones=["us-west-2a", "us-west-2b"]

--- a/aws/ecs-atlantis/atlantis.tf
+++ b/aws/ecs-atlantis/atlantis.tf
@@ -170,6 +170,11 @@ variable "atlantis_alb_ingress_authenticated_paths" {
   description = "Authenticated path pattern to match (a maximum of 1 can be defined)"
 }
 
+variable "atlantis_build_timeout" {
+  description = "Time (in minutes) to allow for Atlantis build to complete before declaring it a failure"
+  default     = 20
+}
+
 module "atlantis" {
   source    = "git::https://github.com/cloudposse/terraform-aws-ecs-atlantis.git?ref=tags/0.14.0"
   enabled   = var.atlantis_enabled
@@ -230,6 +235,8 @@ module "atlantis" {
   authentication_oidc_client_secret_ssm_name          = var.atlantis_oidc_client_secret_ssm_name
 
   codepipeline_s3_bucket_force_destroy = true
+
+  build_timeout = var.atlantis_build_timeout
 }
 
 output "atlantis_url" {

--- a/aws/ecs-atlantis/atlantis.tf
+++ b/aws/ecs-atlantis/atlantis.tf
@@ -1,0 +1,237 @@
+variable "atlantis_enabled" {
+  type    = bool
+  default = true
+}
+
+variable "atlantis_gh_team_whitelist" {
+  type        = string
+  description = "Atlantis GitHub team whitelist"
+  default     = ""
+}
+
+variable "atlantis_gh_user" {
+  type        = string
+  description = "Atlantis GitHub user"
+  default     = "undefined"
+}
+
+variable "atlantis_repo_config" {
+  type        = string
+  description = "Path to atlantis server-side repo config file (https://www.runatlantis.io/docs/server-side-repo-config.html)"
+  default     = "atlantis-repo-config.yaml"
+}
+
+variable "atlantis_repo_whitelist" {
+  type        = list(string)
+  description = "Whitelist of repositories Atlantis will accept webhooks from"
+  default     = []
+}
+
+variable "atlantis_branch" {
+  type        = string
+  default     = "master"
+  description = "Atlantis branch Branch of the GitHub repository, _e.g._ `master`"
+}
+
+variable "atlantis_repo_name" {
+  type        = string
+  description = "GitHub repository name of the atlantis to be built and deployed to ECS."
+}
+
+variable "atlantis_repo_owner" {
+  type        = string
+  description = "GitHub organization containing the Atlantis repository"
+  default     = "undefined"
+}
+
+variable "atlantis_container_cpu" {
+  type        = number
+  description = "The vCPU setting to control cpu limits of container. (If FARGATE launch type is used below, this must be a supported vCPU size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html)"
+  default     = 256
+}
+
+variable "atlantis_container_memory" {
+  type        = number
+  description = "The amount of RAM to allow container to use in MB. (If FARGATE launch type is used below, this must be a supported Memory size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html)"
+  default     = 512
+}
+
+variable "atlantis_authentication_type" {
+  type        = string
+  default     = ""
+  description = "Authentication action type. Supported values are `COGNITO` and `OIDC`"
+}
+
+variable "atlantis_cognito_user_pool_arn" {
+  type        = string
+  description = "Cognito User Pool ARN"
+  default     = ""
+}
+
+variable "atlantis_cognito_user_pool_arn_ssm_name" {
+  type        = string
+  description = "SSM param name to lookup `atlantis_cognito_user_pool_arn` if not provided"
+  default     = ""
+}
+
+variable "atlantis_cognito_user_pool_client_id" {
+  type        = string
+  description = "Cognito User Pool Client ID"
+  default     = ""
+}
+
+variable "atlantis_cognito_user_pool_client_id_ssm_name" {
+  type        = string
+  description = "SSM param name to lookup `atlantis_cognito_user_pool_client_id` if not provided"
+  default     = ""
+}
+
+variable "atlantis_cognito_user_pool_domain" {
+  type        = string
+  description = "Cognito User Pool Domain. The User Pool Domain should be set to the domain prefix (`xxx`) instead of full domain (https://xxx.auth.us-west-2.amazoncognito.com)"
+  default     = ""
+}
+
+variable "atlantis_cognito_user_pool_domain_ssm_name" {
+  type        = string
+  description = "SSM param name to lookup `atlantis_cognito_user_pool_domain` if not provided"
+  default     = ""
+}
+
+variable "atlantis_oidc_client_id" {
+  type        = string
+  description = "OIDC Client ID"
+  default     = ""
+}
+
+variable "atlantis_oidc_client_id_ssm_name" {
+  type        = string
+  description = "SSM param name to lookup `atlantis_oidc_client_id` if not provided"
+  default     = ""
+}
+
+variable "atlantis_oidc_client_secret" {
+  type        = string
+  description = "OIDC Client Secret"
+  default     = ""
+}
+
+variable "atlantis_oidc_client_secret_ssm_name" {
+  type        = string
+  description = "SSM param name to lookup `atlantis_oidc_client_secret` if not provided"
+  default     = ""
+}
+
+variable "atlantis_oidc_issuer" {
+  type        = string
+  description = "OIDC Issuer"
+  default     = ""
+}
+
+variable "atlantis_oidc_authorization_endpoint" {
+  type        = string
+  description = "OIDC Authorization Endpoint"
+  default     = ""
+}
+
+variable "atlantis_oidc_token_endpoint" {
+  type        = string
+  description = "OIDC Token Endpoint"
+  default     = ""
+}
+
+variable "atlantis_oidc_user_info_endpoint" {
+  type        = string
+  description = "OIDC User Info Endpoint"
+  default     = ""
+}
+
+variable "atlantis_alb_ingress_listener_unauthenticated_priority" {
+  type        = number
+  default     = 50
+  description = "The priority for the rules without authentication, between 1 and 50000 (1 being highest priority). Must be different from `alb_ingress_listener_authenticated_priority` since a listener can't have multiple rules with the same priority"
+}
+
+variable "atlantis_alb_ingress_listener_authenticated_priority" {
+  type        = number
+  default     = 100
+  description = "The priority for the rules with authentication, between 1 and 50000 (1 being highest priority). Must be different from `alb_ingress_listener_unauthenticated_priority` since a listener can't have multiple rules with the same priority"
+}
+
+variable "atlantis_alb_ingress_unauthenticated_paths" {
+  type        = list(string)
+  default     = []
+  description = "Unauthenticated path pattern to match (a maximum of 1 can be defined)"
+}
+
+variable "atlantis_alb_ingress_authenticated_paths" {
+  type        = list(string)
+  default     = []
+  description = "Authenticated path pattern to match (a maximum of 1 can be defined)"
+}
+
+module "atlantis" {
+  source    = "git::https://github.com/cloudposse/terraform-aws-ecs-atlantis.git?ref=tags/0.14.0"
+  enabled   = var.atlantis_enabled
+  name      = var.name
+  namespace = var.namespace
+  region    = var.region
+  stage     = var.stage
+
+  atlantis_gh_team_whitelist = var.atlantis_gh_team_whitelist
+  atlantis_gh_user           = var.atlantis_gh_user
+  atlantis_repo_whitelist    = [var.atlantis_repo_whitelist]
+  atlantis_repo_config       = var.atlantis_repo_config
+
+  alb_arn_suffix     = module.alb.alb_arn_suffix
+  alb_dns_name       = module.alb.alb_dns_name
+  alb_name           = module.alb.alb_name
+  alb_zone_id        = module.alb.alb_zone_id
+  alb_security_group = module.alb.security_group_id
+
+  container_cpu    = var.atlantis_container_cpu
+  container_memory = var.atlantis_container_memory
+
+  branch             = var.atlantis_branch
+  parent_zone_id     = module.dns.zone_id
+  ecs_cluster_arn    = aws_ecs_cluster.default.arn
+  ecs_cluster_name   = aws_ecs_cluster.default.name
+  repo_name          = var.atlantis_repo_name
+  repo_owner         = var.atlantis_repo_owner
+  private_subnet_ids = [module.subnets.private_subnet_ids]
+  vpc_id             = module.vpc.vpc_id
+
+  alb_ingress_authenticated_listener_arns       = [module.alb.https_listener_arn]
+  alb_ingress_authenticated_listener_arns_count = 1
+
+  alb_ingress_unauthenticated_listener_arns       = [module.alb.listener_arns]
+  alb_ingress_unauthenticated_listener_arns_count = 2
+
+  alb_ingress_unauthenticated_paths             = [var.atlantis_alb_ingress_unauthenticated_paths]
+  alb_ingress_listener_unauthenticated_priority = var.atlantis_alb_ingress_listener_unauthenticated_priority
+  alb_ingress_authenticated_paths               = [var.atlantis_alb_ingress_authenticated_paths]
+  alb_ingress_listener_authenticated_priority   = var.atlantis_alb_ingress_listener_authenticated_priority
+
+  authentication_type                        = var.atlantis_authentication_type
+  authentication_cognito_user_pool_arn       = var.atlantis_cognito_user_pool_arn
+  authentication_cognito_user_pool_client_id = var.atlantis_cognito_user_pool_client_id
+  authentication_cognito_user_pool_domain    = var.atlantis_cognito_user_pool_domain
+  authentication_oidc_client_id              = var.atlantis_oidc_client_id
+  authentication_oidc_client_secret          = var.atlantis_oidc_client_secret
+  authentication_oidc_issuer                 = var.atlantis_oidc_issuer
+  authentication_oidc_authorization_endpoint = var.atlantis_oidc_authorization_endpoint
+  authentication_oidc_token_endpoint         = var.atlantis_oidc_token_endpoint
+  authentication_oidc_user_info_endpoint     = var.atlantis_oidc_user_info_endpoint
+
+  authentication_cognito_user_pool_arn_ssm_name       = var.atlantis_cognito_user_pool_arn_ssm_name
+  authentication_cognito_user_pool_client_id_ssm_name = var.atlantis_cognito_user_pool_client_id_ssm_name
+  authentication_cognito_user_pool_domain_ssm_name    = var.atlantis_cognito_user_pool_domain_ssm_name
+  authentication_oidc_client_id_ssm_name              = var.atlantis_oidc_client_id_ssm_name
+  authentication_oidc_client_secret_ssm_name          = var.atlantis_oidc_client_secret_ssm_name
+
+  codepipeline_s3_bucket_force_destroy = true
+}
+
+output "atlantis_url" {
+  value = module.atlantis.atlantis_url
+}

--- a/aws/ecs-atlantis/default-backend.tf
+++ b/aws/ecs-atlantis/default-backend.tf
@@ -1,0 +1,55 @@
+variable "default_backend_image" {
+  default = "cloudposse/default-backend:0.1.2"
+}
+
+variable "default_backend_name" {
+  default = "404"
+}
+
+# default backend app
+module "default_backend_web_app" {
+  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.24.0"
+  name       = var.name
+  namespace  = var.namespace
+  stage      = var.stage
+  attributes = [concat(var.attributes, [var.default_backend_name])]
+
+  vpc_id = module.vpc.vpc_id
+  region = var.region
+
+  container_image  = var.default_backend_image
+  container_cpu    = 256
+  container_memory = 512
+  container_port   = 80
+
+  #launch_type                 = "FARGATE"
+  aws_logs_region              = var.region
+  ecs_cluster_arn              = aws_ecs_cluster.default.arn
+  ecs_cluster_name             = aws_ecs_cluster.default.name
+  ecs_private_subnet_ids       = [module.subnets.private_subnet_ids]
+  alb_ingress_healthcheck_path = "/healthz"
+
+  codepipeline_enabled = false
+  ecs_alarms_enabled   = true
+  autoscaling_enabled  = false
+
+  alb_name                                        = module.alb.alb_name
+  alb_arn_suffix                                  = module.alb.alb_arn_suffix
+  alb_security_group                              = module.alb.security_group_id
+  alb_target_group_alarms_enabled                 = true
+  alb_target_group_alarms_3xx_threshold           = 25
+  alb_target_group_alarms_4xx_threshold           = 25
+  alb_target_group_alarms_5xx_threshold           = 25
+  alb_target_group_alarms_response_time_threshold = 0.5
+  alb_target_group_alarms_period                  = 300
+  alb_target_group_alarms_evaluation_periods      = 1
+
+  alb_ingress_unauthenticated_listener_arns       = [module.alb.listener_arns]
+  alb_ingress_unauthenticated_listener_arns_count = 1
+
+  alb_ingress_unauthenticated_paths = ["/*"]
+  alb_ingress_authenticated_paths   = []
+
+  repo_owner = var.atlantis_repo_owner
+}
+

--- a/aws/ecs-atlantis/default-backend.tf
+++ b/aws/ecs-atlantis/default-backend.tf
@@ -51,5 +51,9 @@ module "default_backend_web_app" {
   alb_ingress_authenticated_paths   = []
 
   repo_owner = var.atlantis_repo_owner
+
+  webhook_enabled       = false
+  github_oauth_token    = "NO_TOKEN"
+  github_webhooks_token = "NO_TOKEN"
 }
 

--- a/aws/ecs-atlantis/dns.auto.tfvars.example
+++ b/aws/ecs-atlantis/dns.auto.tfvars.example
@@ -1,0 +1,1 @@
+dns_parent_zone_name = "testing.example.co"

--- a/aws/ecs-atlantis/dns.tf
+++ b/aws/ecs-atlantis/dns.tf
@@ -1,0 +1,26 @@
+variable "dns_parent_zone_name" {
+  description = "DNS zone of parent domain that will delegate NS records to this cluster zone (e.g. `prod.example.co`)"
+}
+
+variable "dns_enabled" {
+  default = true
+}
+
+variable "dns_zone_name" {
+  description = "Zone name template"
+  default     = "$$${region}-$$${name}.$$${parent_zone_name}"
+}
+
+module "dns" {
+  source           = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-zone.git?ref=tags/0.4.0"
+  enabled          = var.dns_enabled
+  namespace        = var.namespace
+  stage            = var.stage
+  name             = var.name
+  parent_zone_name = var.dns_parent_zone_name
+  zone_name        = var.dns_zone_name
+}
+
+output "dns_zone_name" {
+  value = module.dns.zone_name
+}

--- a/aws/ecs-atlantis/ecs.tf
+++ b/aws/ecs-atlantis/ecs.tf
@@ -1,0 +1,14 @@
+module "ecs_cluster_label" {
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
+  name       = var.name
+  namespace  = var.namespace
+  stage      = var.stage
+  tags       = var.tags
+  attributes = var.attributes
+  delimiter  = var.delimiter
+}
+
+# ECS Cluster (needed even if using FARGATE launch type)
+resource "aws_ecs_cluster" "default" {
+  name = module.ecs_cluster_label.id
+}

--- a/aws/ecs-atlantis/flow-logs.tf
+++ b/aws/ecs-atlantis/flow-logs.tf
@@ -1,0 +1,66 @@
+variable "flow_logs_enabled" {
+  type    = string
+  default = true
+}
+
+module "flow_logs" {
+  source = "git::https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket.git?ref=tags/0.1.0"
+
+  name       = var.name
+  namespace  = var.namespace
+  stage      = var.stage
+  tags       = var.tags
+  attributes = concat(var.attributes, ["flow-logs"])
+  delimiter  = var.delimiter
+
+  region = var.region
+
+  enabled = var.flow_logs_enabled
+
+  vpc_id = module.vpc.vpc_id
+}
+
+output "flow_logs_kms_key_arn" {
+  value       = module.flow_logs.kms_key_arn
+  description = "Flow logs KMS Key ARN"
+}
+
+output "flow_logs_kms_key_id" {
+  value       = module.flow_logs.kms_key_id
+  description = "Flow logs KMS Key ID"
+}
+
+output "flow_logs_kms_alias_arn" {
+  value       = module.flow_logs.kms_alias_arn
+  description = "Flow logs KMS Alias ARN"
+}
+
+output "flow_logs_kms_alias_name" {
+  value       = module.flow_logs.kms_alias_name
+  description = "Flow logs KMS Alias name"
+}
+
+output "flow_logs_bucket_domain_name" {
+  value       = module.flow_logs.bucket_domain_name
+  description = "Flow logs FQDN of bucket"
+}
+
+output "flow_logs_bucket_id" {
+  value       = module.flow_logs.bucket_id
+  description = "Flow logs bucket Name (aka ID)"
+}
+
+output "flow_logs_bucket_arn" {
+  value       = module.flow_logs.bucket_arn
+  description = "Flow logs bucket ARN"
+}
+
+output "flow_logs_bucket_prefix" {
+  value       = module.flow_logs.bucket_prefix
+  description = "Flow logs bucket prefix configured for lifecycle rules"
+}
+
+output "flow_logs_id" {
+  value       = module.flow_logs.id
+  description = "Flow logs ID"
+}

--- a/aws/ecs-atlantis/flow-logs.tf
+++ b/aws/ecs-atlantis/flow-logs.tf
@@ -4,7 +4,7 @@ variable "flow_logs_enabled" {
 }
 
 module "flow_logs" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket.git?ref=tags/0.1.0"
+  source  = "git::https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket.git?ref=tags/0.2.0"
   enabled = var.flow_logs_enabled
 
   name       = var.name

--- a/aws/ecs-atlantis/flow-logs.tf
+++ b/aws/ecs-atlantis/flow-logs.tf
@@ -4,7 +4,8 @@ variable "flow_logs_enabled" {
 }
 
 module "flow_logs" {
-  source = "git::https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket.git?ref=tags/0.1.0"
+  source  = "git::https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket.git?ref=tags/0.1.0"
+  enabled = var.flow_logs_enabled
 
   name       = var.name
   namespace  = var.namespace
@@ -12,12 +13,8 @@ module "flow_logs" {
   tags       = var.tags
   attributes = concat(var.attributes, ["flow-logs"])
   delimiter  = var.delimiter
-
-  region = var.region
-
-  enabled = var.flow_logs_enabled
-
-  vpc_id = module.vpc.vpc_id
+  region     = var.region
+  vpc_id     = module.vpc.vpc_id
 }
 
 output "flow_logs_kms_key_arn" {

--- a/aws/ecs-atlantis/main.tf
+++ b/aws/ecs-atlantis/main.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 0.11.2"
+
+  backend "s3" {}
+}
+
+provider "aws" {
+  assume_role {
+    role_arn = var.aws_assume_role_arn
+  }
+}

--- a/aws/ecs-atlantis/sns.tf
+++ b/aws/ecs-atlantis/sns.tf
@@ -1,0 +1,92 @@
+variable "slack_webhook_url" {
+  type        = string
+  description = "Slack webhook URL"
+}
+
+variable "slack_channel" {
+  type        = string
+  description = "Slack channel"
+}
+
+variable "slack_username" {
+  type        = string
+  description = "Slack username"
+}
+
+module "sns_topic_label" {
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
+  name       = "sns"
+  namespace  = var.namespace
+  stage      = var.stage
+  attributes = compact(concat(var.attributes, ["alarms"]))
+}
+
+# Create an SNS topic
+resource "aws_sns_topic" "default" {
+  name_prefix = module.sns_topic_label.id
+}
+
+resource "aws_sns_topic_policy" "default" {
+  arn    = aws_sns_topic.default.arn
+  policy = data.aws_iam_policy_document.sns_topic.json
+}
+
+data "aws_caller_identity" "default" {
+}
+
+data "aws_iam_policy_document" "sns_topic" {
+  statement {
+    actions = [
+      "SNS:Subscribe",
+      "SNS:SetTopicAttributes",
+      "SNS:RemovePermission",
+      "SNS:Receive",
+      "SNS:Publish",
+      "SNS:ListSubscriptionsByTopic",
+      "SNS:GetTopicAttributes",
+      "SNS:DeleteTopic",
+      "SNS:AddPermission"
+    ]
+
+    effect    = "Allow"
+    resources = [aws_sns_topic.default.arn]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceOwner"
+
+      values = [
+        data.aws_caller_identity.default.account_id,
+      ]
+    }
+  }
+
+  statement {
+    sid       = "Allow CloudwatchEvents"
+    actions   = ["sns:Publish"]
+    resources = [aws_sns_topic.default.arn]
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+  }
+}
+
+module "notify_slack" {
+  source            = "git::https://github.com/cloudposse/terraform-aws-sns-lambda-notify-slack?ref=tags/0.2.3"
+  name              = "slack"
+  namespace         = var.namespace
+  stage             = var.stage
+  create_sns_topic  = false
+  sns_topic_name    = aws_sns_topic.default.name
+  slack_webhook_url = var.slack_webhook_url
+  slack_channel     = var.slack_channel
+  slack_username    = var.slack_username
+}
+

--- a/aws/ecs-atlantis/sns.tf
+++ b/aws/ecs-atlantis/sns.tf
@@ -79,7 +79,7 @@ data "aws_iam_policy_document" "sns_topic" {
 }
 
 module "notify_slack" {
-  source            = "git::https://github.com/cloudposse/terraform-aws-sns-lambda-notify-slack?ref=tags/0.2.3"
+  source            = "git::https://github.com/cloudposse/terraform-aws-sns-lambda-notify-slack?ref=tags/0.3.0"
   name              = "slack"
   namespace         = var.namespace
   stage             = var.stage
@@ -89,4 +89,3 @@ module "notify_slack" {
   slack_channel     = var.slack_channel
   slack_username    = var.slack_username
 }
-

--- a/aws/ecs-atlantis/variables.tf
+++ b/aws/ecs-atlantis/variables.tf
@@ -1,0 +1,49 @@
+variable "aws_assume_role_arn" {
+  type = string
+}
+
+variable "default_backend" {
+  type        = string
+  description = "Default backend image"
+  default     = "cloudposse/default-backend:0.1.2"
+}
+
+variable "namespace" {
+  type        = string
+  description = "Namespace (e.g. `cp` or `cloudposse`)"
+}
+
+variable "stage" {
+  type        = string
+  description = "Stage (e.g. `prod`, `dev`, `staging`)"
+}
+
+variable "name" {
+  type        = string
+  description = "Application or solution name (e.g. `app`)"
+  default     = "ecs"
+}
+
+variable "delimiter" {
+  type        = string
+  default     = "-"
+  description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = "Additional attributes (e.g. `1`)"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS Region"
+  default     = "us-west-2"
+}

--- a/aws/ecs-atlantis/versions.tf
+++ b/aws/ecs-atlantis/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 0.12.0"
+
+  required_providers {
+    aws      = "~> 2.0"
+    template = "~> 2.0"
+    null     = "~> 2.0"
+    local    = "~> 1.3"
+  }
+}

--- a/aws/ecs-atlantis/vpc.tf
+++ b/aws/ecs-atlantis/vpc.tf
@@ -1,0 +1,49 @@
+variable "availability_zones" {
+  type        = list(string)
+  description = "List of Availability Zones to provision all the resources in"
+}
+
+variable "nat_gateway_enabled" {
+  type        = string
+  description = "Flag to enable/disable NAT Gateways to allow servers in the private subnets to access the Internet"
+  default     = false
+}
+
+variable "nat_instance_enabled" {
+  type        = string
+  description = "Flag to enable/disable NAT Instances to allow servers in the private subnets to access the Internet"
+  default     = true
+}
+
+variable "nat_instance_type" {
+  type        = string
+  description = "NAT Instance type"
+  default     = "t3.micro"
+}
+
+locals {
+  name = var.region
+}
+
+module "vpc" {
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.8.1"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = local.name
+  cidr_block = "172.16.0.0/16"
+}
+
+module "subnets" {
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.18.1"
+  availability_zones   = var.availability_zones
+  namespace            = var.namespace
+  stage                = var.stage
+  name                 = local.name
+  region               = var.region
+  vpc_id               = module.vpc.vpc_id
+  igw_id               = module.vpc.igw_id
+  cidr_block           = module.vpc.vpc_cidr_block
+  nat_gateway_enabled  = var.nat_gateway_enabled
+  nat_instance_enabled = var.nat_instance_enabled
+  nat_instance_type    = var.nat_instance_type
+}

--- a/aws/ecs/atlantis.tf
+++ b/aws/ecs/atlantis.tf
@@ -170,6 +170,11 @@ variable "atlantis_alb_ingress_authenticated_paths" {
   description = "Authenticated path pattern to match (a maximum of 1 can be defined)"
 }
 
+variable "atlantis_build_timeout" {
+  description = "Time (in minutes) to allow for Atlantis build to complete before declaring it a failure"
+  default     = "20"
+}
+
 module "atlantis" {
   source    = "git::https://github.com/cloudposse/terraform-aws-ecs-atlantis.git?ref=tags/0.13.0"
   enabled   = "${var.atlantis_enabled}"
@@ -230,6 +235,8 @@ module "atlantis" {
   authentication_oidc_client_secret_ssm_name          = "${var.atlantis_oidc_client_secret_ssm_name}"
 
   codepipeline_s3_bucket_force_destroy = true
+
+  build_timeout = "${var.atlantis_build_timeout}"
 }
 
 output "atlantis_url" {

--- a/aws/ecs/default-backend.tf
+++ b/aws/ecs/default-backend.tf
@@ -28,6 +28,7 @@ module "default_backend_web_app" {
   alb_ingress_healthcheck_path = "/healthz"
 
   codepipeline_enabled = "false"
+  webhook_enabled      = "false"
   ecs_alarms_enabled   = "true"
   autoscaling_enabled  = "false"
 

--- a/aws/ecs/default-backend.tf
+++ b/aws/ecs/default-backend.tf
@@ -28,7 +28,6 @@ module "default_backend_web_app" {
   alb_ingress_healthcheck_path = "/healthz"
 
   codepipeline_enabled = "false"
-  webhook_enabled      = "false"
   ecs_alarms_enabled   = "true"
   autoscaling_enabled  = "false"
 
@@ -50,4 +49,9 @@ module "default_backend_web_app" {
   alb_ingress_authenticated_paths   = []
 
   repo_owner = "${var.atlantis_repo_owner}"
+
+  webhook_enabled       = "false"
+  github_oauth_token    = "NO_TOKEN"
+  github_webhooks_token = "NO_TOKEN"
 }
+

--- a/aws/ecs/flow-logs.tf
+++ b/aws/ecs/flow-logs.tf
@@ -4,7 +4,7 @@ variable "flow_logs_enabled" {
 }
 
 module "flow_logs" {
-  source = "git::https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket.git?ref=tags/0.1.0"
+  source = "git::https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket.git?ref=tags/0.1.1"
 
   name       = "${var.name}"
   namespace  = "${var.namespace}"


### PR DESCRIPTION
## what
* Fix `ecs` project for `atlantis` (TF 0.11 version)
* Add `ecs-atlantis` project for `atlantis` (TF 0.12 version)

## why 
* In 0.11 version, recent changes to `github` provider made GitHub token required even if the modules that use `github` provider are disabled (`github-repository-webhook` for `default-backend` in this case)
* Added build timeout to CodePipeline - in some cases the default timeout of 5 mins was not enough and CodePipeline failed
* New  project `ecs-atlantis` has the same functionality as the `ecs` project, but uses TF 0.12 for all modules

## related
* Closes #207 

