### PR TITLE
[atlantis] Convert `ecs` project to terraform 0.12

### DIFF
--- a/aws/ecs/Makefile
+++ b/aws/ecs/Makefile
@@ -4,7 +4,7 @@ init:
 
 ## Clean up the project
 clean:
-	rm -rf .terraform *.tfstate*
+	rm -rf .terraform *.tfstate* $$TF_MODULE_CACHE
 
 ## Pass arguments through to terraform which require remote state
 apply console destroy graph plan output providers show: init

--- a/aws/ecs/acm.tf
+++ b/aws/ecs/acm.tf
@@ -1,24 +1,30 @@
 variable "subject_alternative_names" {
-  type        = "list"
+  type        = list(string)
   description = "A list of domains that should be SANs in the issued certificate"
   default     = []
 }
 
 variable "domain_name" {
-  type        = "string"
+  type        = string
   description = "Domain name (E.g. staging.cloudposse.co)"
   default     = ""
 }
 
 locals {
-  domain_name               = "${var.domain_name != "" ? var.domain_name : module.dns.zone_name}"
-  subject_alternative_names = "${distinct(concat(var.subject_alternative_names, formatlist("*.%s", list(local.domain_name))))}"
+  domain_name = var.domain_name != "" ? var.domain_name : module.dns.zone_name
+
+  subject_alternative_names = distinct(
+    concat(
+      var.subject_alternative_names,
+      formatlist("*.%s", [local.domain_name])
+    )
+  )
 }
 
 module "acm_request_certificate" {
-  source                    = "git::https://github.com/cloudposse/terraform-aws-acm-request-certificate.git?ref=tags/0.1.4"
-  domain_name               = "${local.domain_name}"
-  ttl                       = "300"
-  subject_alternative_names = "${local.subject_alternative_names}"
-  tags                      = "${var.tags}"
+  source                    = "git::https://github.com/cloudposse/terraform-aws-acm-request-certificate.git?ref=tags/0.4.0"
+  domain_name               = local.domain_name
+  ttl                       = 300
+  subject_alternative_names = local.subject_alternative_names
+  tags                      = var.tags
 }

--- a/aws/ecs/alb.tf
+++ b/aws/ecs/alb.tf
@@ -1,32 +1,32 @@
 variable "alb_ingress_cidr_blocks_http" {
-  type        = "list"
+  type        = list(string)
   default     = ["0.0.0.0/0"]
   description = "List of CIDR blocks allowed to access environment over HTTP"
 }
 
 variable "alb_ingress_cidr_blocks_https" {
-  type        = "list"
+  type        = list(string)
   default     = ["0.0.0.0/0"]
   description = "List of CIDR blocks allowed to access environment over HTTPS"
 }
 
 module "alb" {
-  source             = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.5.0"
-  name               = "${var.name}"
-  namespace          = "${var.namespace}"
-  stage              = "${var.stage}"
-  attributes         = "${var.attributes}"
-  vpc_id             = "${module.vpc.vpc_id}"
+  source             = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.7.0"
+  name               = var.name
+  namespace          = var.namespace
+  stage              = var.stage
+  attributes         = var.attributes
+  vpc_id             = module.vpc.vpc_id
   ip_address_type    = "ipv4"
-  subnet_ids         = ["${module.subnets.public_subnet_ids}"]
+  subnet_ids         = [module.subnets.public_subnet_ids]
   security_group_ids = []
-  access_logs_region = "${var.region}"
+  access_logs_region = var.region
 
-  https_enabled             = "true"
-  http_ingress_cidr_blocks  = "${var.alb_ingress_cidr_blocks_http}"
-  https_ingress_cidr_blocks = "${var.alb_ingress_cidr_blocks_https}"
-  certificate_arn           = "${module.acm_request_certificate.arn}"
-  health_check_interval     = "60"
+  https_enabled             = true
+  http_ingress_cidr_blocks  = var.alb_ingress_cidr_blocks_http
+  https_ingress_cidr_blocks = var.alb_ingress_cidr_blocks_https
+  certificate_arn           = module.acm_request_certificate.arn
+  health_check_interval     = 60
 
   alb_access_logs_s3_bucket_force_destroy = true
 }

--- a/aws/ecs/atlantis-repo-config.yaml
+++ b/aws/ecs/atlantis-repo-config.yaml
@@ -11,7 +11,7 @@ repos:
   - id: /.*/
 
     # apply_requirements sets the Apply Requirements for all repos that match
-    apply_requirements: [approved, mergeable]
+    apply_requirements: [approved]
 
     # allowed_overrides specifies which keys can be overridden by this repo in
     # its atlantis.yaml file

--- a/aws/ecs/atlantis.auto.tfvars.example
+++ b/aws/ecs/atlantis.auto.tfvars.example
@@ -1,5 +1,8 @@
-# Write the github_oauth_token to SSM parameter store:
+# Write atlantis_gh_token to SSM parameter store:
 # chamber write atlantis atlantis_gh_token "....."
+
+# Write github_webhooks_token to SSM parameter store:
+# chamber write atlantis github_webhooks_token "....."
 
 # When using Cognito authentication (atlantis_authentication_type = COGNITO), write the following values to SSM parameter store:
 # chamber write atlantis atlantis_cognito_user_pool_arn "....."
@@ -10,7 +13,7 @@
 # chamber write atlantis atlantis_oidc_client_id "....."
 # chamber write atlantis atlantis_oidc_client_secret "....."
 
-atlantis_enabled = "true"
+atlantis_enabled = true
 
 atlantis_branch = "master"
 
@@ -40,10 +43,14 @@ atlantis_oidc_user_info_endpoint = "https://openidconnect.googleapis.com/v1/user
 
 atlantis_alb_ingress_unauthenticated_paths = ["/events"]
 
-atlantis_alb_ingress_listener_unauthenticated_priority = "50"
+atlantis_alb_ingress_listener_unauthenticated_priority = 50
 
 atlantis_alb_ingress_authenticated_paths = ["/*"]
 
-atlantis_alb_ingress_listener_authenticated_priority = "100"
+atlantis_alb_ingress_listener_authenticated_priority = 100
 
 availability_zones=["us-west-2a", "us-west-2b"]
+
+nat_instance_enabled = true
+
+nat_gateway_enabled = false

--- a/aws/ecs/atlantis.tf
+++ b/aws/ecs/atlantis.tf
@@ -1,244 +1,245 @@
 variable "atlantis_enabled" {
-  type    = "string"
-  default = "true"
+  type    = bool
+  default = true
 }
 
 variable "atlantis_gh_team_whitelist" {
-  type        = "string"
+  type        = string
   description = "Atlantis GitHub team whitelist"
   default     = ""
 }
 
 variable "atlantis_gh_user" {
-  type        = "string"
+  type        = string
   description = "Atlantis GitHub user"
   default     = "undefined"
 }
 
 variable "atlantis_repo_config" {
-  type        = "string"
+  type        = string
   description = "Path to atlantis server-side repo config file (https://www.runatlantis.io/docs/server-side-repo-config.html)"
   default     = "atlantis-repo-config.yaml"
 }
 
 variable "atlantis_repo_whitelist" {
-  type        = "list"
+  type        = list(string)
   description = "Whitelist of repositories Atlantis will accept webhooks from"
   default     = []
 }
 
 variable "atlantis_branch" {
-  type        = "string"
+  type        = string
   default     = "master"
   description = "Atlantis branch Branch of the GitHub repository, _e.g._ `master`"
 }
 
 variable "atlantis_repo_name" {
-  type        = "string"
+  type        = string
   description = "GitHub repository name of the atlantis to be built and deployed to ECS."
 }
 
 variable "atlantis_repo_owner" {
-  type        = "string"
+  type        = string
   description = "GitHub organization containing the Atlantis repository"
   default     = "undefined"
 }
 
 variable "atlantis_container_cpu" {
-  type        = "string"
+  type        = number
   description = "The vCPU setting to control cpu limits of container. (If FARGATE launch type is used below, this must be a supported vCPU size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html)"
-  default     = "256"
+  default     = 256
 }
 
 variable "atlantis_container_memory" {
-  type        = "string"
+  type        = number
   description = "The amount of RAM to allow container to use in MB. (If FARGATE launch type is used below, this must be a supported Memory size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html)"
-  default     = "512"
+  default     = 512
 }
 
 variable "atlantis_authentication_type" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Authentication action type. Supported values are `COGNITO` and `OIDC`"
 }
 
 variable "atlantis_cognito_user_pool_arn" {
-  type        = "string"
+  type        = string
   description = "Cognito User Pool ARN"
   default     = ""
 }
 
 variable "atlantis_cognito_user_pool_arn_ssm_name" {
-  type        = "string"
+  type        = string
   description = "SSM param name to lookup `atlantis_cognito_user_pool_arn` if not provided"
   default     = ""
 }
 
 variable "atlantis_cognito_user_pool_client_id" {
-  type        = "string"
+  type        = string
   description = "Cognito User Pool Client ID"
   default     = ""
 }
 
 variable "atlantis_cognito_user_pool_client_id_ssm_name" {
-  type        = "string"
+  type        = string
   description = "SSM param name to lookup `atlantis_cognito_user_pool_client_id` if not provided"
   default     = ""
 }
 
 variable "atlantis_cognito_user_pool_domain" {
-  type        = "string"
+  type        = string
   description = "Cognito User Pool Domain. The User Pool Domain should be set to the domain prefix (`xxx`) instead of full domain (https://xxx.auth.us-west-2.amazoncognito.com)"
   default     = ""
 }
 
 variable "atlantis_cognito_user_pool_domain_ssm_name" {
-  type        = "string"
+  type        = string
   description = "SSM param name to lookup `atlantis_cognito_user_pool_domain` if not provided"
   default     = ""
 }
 
 variable "atlantis_oidc_client_id" {
-  type        = "string"
+  type        = string
   description = "OIDC Client ID"
   default     = ""
 }
 
 variable "atlantis_oidc_client_id_ssm_name" {
-  type        = "string"
+  type        = string
   description = "SSM param name to lookup `atlantis_oidc_client_id` if not provided"
   default     = ""
 }
 
 variable "atlantis_oidc_client_secret" {
-  type        = "string"
+  type        = string
   description = "OIDC Client Secret"
   default     = ""
 }
 
 variable "atlantis_oidc_client_secret_ssm_name" {
-  type        = "string"
+  type        = string
   description = "SSM param name to lookup `atlantis_oidc_client_secret` if not provided"
   default     = ""
 }
 
 variable "atlantis_oidc_issuer" {
-  type        = "string"
+  type        = string
   description = "OIDC Issuer"
   default     = ""
 }
 
 variable "atlantis_oidc_authorization_endpoint" {
-  type        = "string"
+  type        = string
   description = "OIDC Authorization Endpoint"
   default     = ""
 }
 
 variable "atlantis_oidc_token_endpoint" {
-  type        = "string"
+  type        = string
   description = "OIDC Token Endpoint"
   default     = ""
 }
 
 variable "atlantis_oidc_user_info_endpoint" {
-  type        = "string"
+  type        = string
   description = "OIDC User Info Endpoint"
   default     = ""
 }
 
 variable "atlantis_alb_ingress_listener_unauthenticated_priority" {
-  type        = "string"
-  default     = "50"
+  type        = number
+  default     = 50
   description = "The priority for the rules without authentication, between 1 and 50000 (1 being highest priority). Must be different from `alb_ingress_listener_authenticated_priority` since a listener can't have multiple rules with the same priority"
 }
 
 variable "atlantis_alb_ingress_listener_authenticated_priority" {
-  type        = "string"
-  default     = "100"
+  type        = number
+  default     = 100
   description = "The priority for the rules with authentication, between 1 and 50000 (1 being highest priority). Must be different from `alb_ingress_listener_unauthenticated_priority` since a listener can't have multiple rules with the same priority"
 }
 
 variable "atlantis_alb_ingress_unauthenticated_paths" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Unauthenticated path pattern to match (a maximum of 1 can be defined)"
 }
 
 variable "atlantis_alb_ingress_authenticated_paths" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Authenticated path pattern to match (a maximum of 1 can be defined)"
 }
 
 variable "atlantis_build_timeout" {
+  type        = number
   description = "Time (in minutes) to allow for Atlantis build to complete before declaring it a failure"
-  default     = "20"
+  default     = 20
 }
 
 module "atlantis" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-ecs-atlantis.git?ref=tags/0.13.0"
-  enabled   = "${var.atlantis_enabled}"
-  name      = "${var.name}"
-  namespace = "${var.namespace}"
-  region    = "${var.region}"
-  stage     = "${var.stage}"
+  source    = "git::https://github.com/cloudposse/terraform-aws-ecs-atlantis.git?ref=tags/0.14.0"
+  enabled   = var.atlantis_enabled
+  name      = var.name
+  namespace = var.namespace
+  region    = var.region
+  stage     = var.stage
 
-  atlantis_gh_team_whitelist = "${var.atlantis_gh_team_whitelist}"
-  atlantis_gh_user           = "${var.atlantis_gh_user}"
-  atlantis_repo_whitelist    = ["${var.atlantis_repo_whitelist}"]
-  atlantis_repo_config       = "${var.atlantis_repo_config}"
+  atlantis_gh_team_whitelist = var.atlantis_gh_team_whitelist
+  atlantis_gh_user           = var.atlantis_gh_user
+  atlantis_repo_whitelist    = var.atlantis_repo_whitelist
+  atlantis_repo_config       = var.atlantis_repo_config
 
-  alb_arn_suffix     = "${module.alb.alb_arn_suffix}"
-  alb_dns_name       = "${module.alb.alb_dns_name}"
-  alb_name           = "${module.alb.alb_name}"
-  alb_zone_id        = "${module.alb.alb_zone_id}"
-  alb_security_group = "${module.alb.security_group_id}"
+  alb_arn_suffix     = module.alb.alb_arn_suffix
+  alb_dns_name       = module.alb.alb_dns_name
+  alb_name           = module.alb.alb_name
+  alb_zone_id        = module.alb.alb_zone_id
+  alb_security_group = module.alb.security_group_id
 
-  container_cpu    = "${var.atlantis_container_cpu}"
-  container_memory = "${var.atlantis_container_memory}"
+  container_cpu    = var.atlantis_container_cpu
+  container_memory = var.atlantis_container_memory
 
-  branch             = "${var.atlantis_branch}"
-  parent_zone_id     = "${module.dns.zone_id}"
-  ecs_cluster_arn    = "${aws_ecs_cluster.default.arn}"
-  ecs_cluster_name   = "${aws_ecs_cluster.default.name}"
-  repo_name          = "${var.atlantis_repo_name}"
-  repo_owner         = "${var.atlantis_repo_owner}"
-  private_subnet_ids = ["${module.subnets.private_subnet_ids}"]
-  vpc_id             = "${module.vpc.vpc_id}"
+  branch             = var.atlantis_branch
+  parent_zone_id     = module.dns.zone_id
+  ecs_cluster_arn    = aws_ecs_cluster.default.arn
+  ecs_cluster_name   = aws_ecs_cluster.default.name
+  repo_name          = var.atlantis_repo_name
+  repo_owner         = var.atlantis_repo_owner
+  private_subnet_ids = module.subnets.private_subnet_ids
+  vpc_id             = module.vpc.vpc_id
 
-  alb_ingress_authenticated_listener_arns       = ["${module.alb.https_listener_arn}"]
+  alb_ingress_authenticated_listener_arns       = [module.alb.https_listener_arn]
   alb_ingress_authenticated_listener_arns_count = 1
 
-  alb_ingress_unauthenticated_listener_arns       = ["${module.alb.listener_arns}"]
+  alb_ingress_unauthenticated_listener_arns       = module.alb.listener_arns
   alb_ingress_unauthenticated_listener_arns_count = 2
 
-  alb_ingress_unauthenticated_paths             = ["${var.atlantis_alb_ingress_unauthenticated_paths}"]
-  alb_ingress_listener_unauthenticated_priority = "${var.atlantis_alb_ingress_listener_unauthenticated_priority}"
-  alb_ingress_authenticated_paths               = ["${var.atlantis_alb_ingress_authenticated_paths}"]
-  alb_ingress_listener_authenticated_priority   = "${var.atlantis_alb_ingress_listener_authenticated_priority}"
+  alb_ingress_unauthenticated_paths             = var.atlantis_alb_ingress_unauthenticated_paths
+  alb_ingress_listener_unauthenticated_priority = var.atlantis_alb_ingress_listener_unauthenticated_priority
+  alb_ingress_authenticated_paths               = var.atlantis_alb_ingress_authenticated_paths
+  alb_ingress_listener_authenticated_priority   = var.atlantis_alb_ingress_listener_authenticated_priority
 
-  authentication_type                        = "${var.atlantis_authentication_type}"
-  authentication_cognito_user_pool_arn       = "${var.atlantis_cognito_user_pool_arn}"
-  authentication_cognito_user_pool_client_id = "${var.atlantis_cognito_user_pool_client_id}"
-  authentication_cognito_user_pool_domain    = "${var.atlantis_cognito_user_pool_domain}"
-  authentication_oidc_client_id              = "${var.atlantis_oidc_client_id}"
-  authentication_oidc_client_secret          = "${var.atlantis_oidc_client_secret}"
-  authentication_oidc_issuer                 = "${var.atlantis_oidc_issuer}"
-  authentication_oidc_authorization_endpoint = "${var.atlantis_oidc_authorization_endpoint}"
-  authentication_oidc_token_endpoint         = "${var.atlantis_oidc_token_endpoint}"
-  authentication_oidc_user_info_endpoint     = "${var.atlantis_oidc_user_info_endpoint}"
+  authentication_type                        = var.atlantis_authentication_type
+  authentication_cognito_user_pool_arn       = var.atlantis_cognito_user_pool_arn
+  authentication_cognito_user_pool_client_id = var.atlantis_cognito_user_pool_client_id
+  authentication_cognito_user_pool_domain    = var.atlantis_cognito_user_pool_domain
+  authentication_oidc_client_id              = var.atlantis_oidc_client_id
+  authentication_oidc_client_secret          = var.atlantis_oidc_client_secret
+  authentication_oidc_issuer                 = var.atlantis_oidc_issuer
+  authentication_oidc_authorization_endpoint = var.atlantis_oidc_authorization_endpoint
+  authentication_oidc_token_endpoint         = var.atlantis_oidc_token_endpoint
+  authentication_oidc_user_info_endpoint     = var.atlantis_oidc_user_info_endpoint
 
-  authentication_cognito_user_pool_arn_ssm_name       = "${var.atlantis_cognito_user_pool_arn_ssm_name}"
-  authentication_cognito_user_pool_client_id_ssm_name = "${var.atlantis_cognito_user_pool_client_id_ssm_name}"
-  authentication_cognito_user_pool_domain_ssm_name    = "${var.atlantis_cognito_user_pool_domain_ssm_name}"
-  authentication_oidc_client_id_ssm_name              = "${var.atlantis_oidc_client_id_ssm_name}"
-  authentication_oidc_client_secret_ssm_name          = "${var.atlantis_oidc_client_secret_ssm_name}"
+  authentication_cognito_user_pool_arn_ssm_name       = var.atlantis_cognito_user_pool_arn_ssm_name
+  authentication_cognito_user_pool_client_id_ssm_name = var.atlantis_cognito_user_pool_client_id_ssm_name
+  authentication_cognito_user_pool_domain_ssm_name    = var.atlantis_cognito_user_pool_domain_ssm_name
+  authentication_oidc_client_id_ssm_name              = var.atlantis_oidc_client_id_ssm_name
+  authentication_oidc_client_secret_ssm_name          = var.atlantis_oidc_client_secret_ssm_name
 
   codepipeline_s3_bucket_force_destroy = true
 
-  build_timeout = "${var.atlantis_build_timeout}"
+  build_timeout = var.atlantis_build_timeout
 }
 
 output "atlantis_url" {
-  value = "${module.atlantis.atlantis_url}"
+  value = module.atlantis.atlantis_url
 }

--- a/aws/ecs/default-backend.tf
+++ b/aws/ecs/default-backend.tf
@@ -8,49 +8,51 @@ variable "default_backend_name" {
 
 # default backend app
 module "default_backend_web_app" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.23.0"
-  name       = "${var.name}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  attributes = ["${concat(var.attributes, list(var.default_backend_name))}"]
-  vpc_id     = "${module.vpc.vpc_id}"
+  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.24.0"
+  name       = var.name
+  namespace  = var.namespace
+  stage      = var.stage
+  attributes = concat(var.attributes, [var.default_backend_name])
 
-  container_image  = "${var.default_backend_image}"
-  container_cpu    = "256"
-  container_memory = "512"
-  container_port   = "80"
+  vpc_id = module.vpc.vpc_id
+  region = var.region
+
+  container_image  = var.default_backend_image
+  container_cpu    = 256
+  container_memory = 512
+  container_port   = 80
 
   #launch_type                 = "FARGATE"
-  aws_logs_region              = "${var.region}"
-  ecs_cluster_arn              = "${aws_ecs_cluster.default.arn}"
-  ecs_cluster_name             = "${aws_ecs_cluster.default.name}"
-  ecs_private_subnet_ids       = ["${module.subnets.private_subnet_ids}"]
+  aws_logs_region              = var.region
+  ecs_cluster_arn              = aws_ecs_cluster.default.arn
+  ecs_cluster_name             = aws_ecs_cluster.default.name
+  ecs_private_subnet_ids       = module.subnets.private_subnet_ids
   alb_ingress_healthcheck_path = "/healthz"
 
-  codepipeline_enabled = "false"
-  ecs_alarms_enabled   = "true"
-  autoscaling_enabled  = "false"
+  codepipeline_enabled = false
+  ecs_alarms_enabled   = true
+  autoscaling_enabled  = false
 
-  alb_name                                        = "${module.alb.alb_name}"
-  alb_arn_suffix                                  = "${module.alb.alb_arn_suffix}"
-  alb_security_group                              = "${module.alb.security_group_id}"
-  alb_target_group_alarms_enabled                 = "true"
-  alb_target_group_alarms_3xx_threshold           = "25"
-  alb_target_group_alarms_4xx_threshold           = "25"
-  alb_target_group_alarms_5xx_threshold           = "25"
-  alb_target_group_alarms_response_time_threshold = "0.5"
-  alb_target_group_alarms_period                  = "300"
-  alb_target_group_alarms_evaluation_periods      = "1"
+  alb_name                                        = module.alb.alb_name
+  alb_arn_suffix                                  = module.alb.alb_arn_suffix
+  alb_security_group                              = module.alb.security_group_id
+  alb_target_group_alarms_enabled                 = true
+  alb_target_group_alarms_3xx_threshold           = 25
+  alb_target_group_alarms_4xx_threshold           = 25
+  alb_target_group_alarms_5xx_threshold           = 25
+  alb_target_group_alarms_response_time_threshold = 0.5
+  alb_target_group_alarms_period                  = 300
+  alb_target_group_alarms_evaluation_periods      = 1
 
-  alb_ingress_unauthenticated_listener_arns       = ["${module.alb.listener_arns}"]
+  alb_ingress_unauthenticated_listener_arns       = module.alb.listener_arns
   alb_ingress_unauthenticated_listener_arns_count = 1
 
   alb_ingress_unauthenticated_paths = ["/*"]
   alb_ingress_authenticated_paths   = []
 
-  repo_owner = "${var.atlantis_repo_owner}"
+  repo_owner = var.atlantis_repo_owner
 
-  webhook_enabled       = "false"
+  webhook_enabled       = false
   github_oauth_token    = "NO_TOKEN"
   github_webhooks_token = "NO_TOKEN"
 }

--- a/aws/ecs/dns.tf
+++ b/aws/ecs/dns.tf
@@ -3,24 +3,24 @@ variable "dns_parent_zone_name" {
 }
 
 variable "dns_enabled" {
-  default = "true"
+  default = true
 }
 
 variable "dns_zone_name" {
   description = "Zone name template"
-  default     = "$${region}-$${name}.$${parent_zone_name}"
+  default     = "$$${region}-$$${name}.$$${parent_zone_name}"
 }
 
 module "dns" {
-  source           = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-zone.git?ref=tags/0.3.1"
-  enabled          = "${var.dns_enabled}"
-  namespace        = "${var.namespace}"
-  stage            = "${var.stage}"
-  name             = "${var.name}"
-  parent_zone_name = "${var.dns_parent_zone_name}"
-  zone_name        = "${var.dns_zone_name}"
+  source           = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-zone.git?ref=tags/0.4.0"
+  enabled          = var.dns_enabled
+  namespace        = var.namespace
+  stage            = var.stage
+  name             = var.name
+  parent_zone_name = var.dns_parent_zone_name
+  zone_name        = var.dns_zone_name
 }
 
 output "dns_zone_name" {
-  value = "${module.dns.zone_name}"
+  value = module.dns.zone_name
 }

--- a/aws/ecs/ecs.tf
+++ b/aws/ecs/ecs.tf
@@ -1,14 +1,14 @@
 module "ecs_cluster_label" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
-  name       = "${var.name}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  tags       = "${var.tags}"
-  attributes = "${var.attributes}"
-  delimiter  = "${var.delimiter}"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
+  name       = var.name
+  namespace  = var.namespace
+  stage      = var.stage
+  tags       = var.tags
+  attributes = var.attributes
+  delimiter  = var.delimiter
 }
 
 # ECS Cluster (needed even if using FARGATE launch type)
 resource "aws_ecs_cluster" "default" {
-  name = "${module.ecs_cluster_label.id}"
+  name = module.ecs_cluster_label.id
 }

--- a/aws/ecs/flow-logs.tf
+++ b/aws/ecs/flow-logs.tf
@@ -1,66 +1,63 @@
 variable "flow_logs_enabled" {
-  type    = "string"
-  default = "true"
+  type    = string
+  default = true
 }
 
 module "flow_logs" {
-  source = "git::https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket.git?ref=tags/0.1.1"
+  source  = "git::https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket.git?ref=tags/0.2.0"
+  enabled = var.flow_logs_enabled
 
-  name       = "${var.name}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  tags       = "${var.tags}"
-  attributes = "${concat(var.attributes, list("flow-logs"))}"
-  delimiter  = "${var.delimiter}"
-
-  region = "${var.region}"
-
-  enabled = "${var.flow_logs_enabled}"
-
-  vpc_id = "${module.vpc.vpc_id}"
+  name       = var.name
+  namespace  = var.namespace
+  stage      = var.stage
+  tags       = var.tags
+  attributes = concat(var.attributes, ["flow-logs"])
+  delimiter  = var.delimiter
+  region     = var.region
+  vpc_id     = module.vpc.vpc_id
 }
 
 output "flow_logs_kms_key_arn" {
-  value       = "${module.flow_logs.kms_key_arn}"
+  value       = module.flow_logs.kms_key_arn
   description = "Flow logs KMS Key ARN"
 }
 
 output "flow_logs_kms_key_id" {
-  value       = "${module.flow_logs.kms_key_id}"
+  value       = module.flow_logs.kms_key_id
   description = "Flow logs KMS Key ID"
 }
 
 output "flow_logs_kms_alias_arn" {
-  value       = "${module.flow_logs.kms_alias_arn}"
+  value       = module.flow_logs.kms_alias_arn
   description = "Flow logs KMS Alias ARN"
 }
 
 output "flow_logs_kms_alias_name" {
-  value       = "${module.flow_logs.kms_alias_name}"
+  value       = module.flow_logs.kms_alias_name
   description = "Flow logs KMS Alias name"
 }
 
 output "flow_logs_bucket_domain_name" {
-  value       = "${module.flow_logs.bucket_domain_name}"
+  value       = module.flow_logs.bucket_domain_name
   description = "Flow logs FQDN of bucket"
 }
 
 output "flow_logs_bucket_id" {
-  value       = "${module.flow_logs.bucket_id}"
+  value       = module.flow_logs.bucket_id
   description = "Flow logs bucket Name (aka ID)"
 }
 
 output "flow_logs_bucket_arn" {
-  value       = "${module.flow_logs.bucket_arn}"
+  value       = module.flow_logs.bucket_arn
   description = "Flow logs bucket ARN"
 }
 
 output "flow_logs_bucket_prefix" {
-  value       = "${module.flow_logs.bucket_prefix}"
+  value       = module.flow_logs.bucket_prefix
   description = "Flow logs bucket prefix configured for lifecycle rules"
 }
 
 output "flow_logs_id" {
-  value       = "${module.flow_logs.id}"
+  value       = module.flow_logs.id
   description = "Flow logs ID"
 }

--- a/aws/ecs/main.tf
+++ b/aws/ecs/main.tf
@@ -6,6 +6,6 @@ terraform {
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }

--- a/aws/ecs/variables.tf
+++ b/aws/ecs/variables.tf
@@ -1,48 +1,49 @@
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "default_backend" {
-  description = ""
+  type        = string
+  description = "Default backend image"
   default     = "cloudposse/default-backend:0.1.2"
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   description = "Application or solution name (e.g. `app`)"
   default     = "ecs"
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Additional attributes (e.g. `1`)"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
 }
 
 variable "region" {
-  type        = "string"
-  description = "AWS Region the S3 bucket should reside in"
+  type        = string
+  description = "AWS Region"
   default     = "us-west-2"
 }

--- a/aws/ecs/versions.tf
+++ b/aws/ecs/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 0.12.0"
+
+  required_providers {
+    aws      = "~> 2.0"
+    template = "~> 2.0"
+    null     = "~> 2.0"
+    local    = "~> 1.3"
+  }
+}

--- a/aws/ecs/vpc.tf
+++ b/aws/ecs/vpc.tf
@@ -1,49 +1,49 @@
 variable "availability_zones" {
-  type        = "list"
+  type        = list(string)
   description = "List of Availability Zones to provision all the resources in"
 }
 
 variable "nat_gateway_enabled" {
-  type        = "string"
+  type        = string
   description = "Flag to enable/disable NAT Gateways to allow servers in the private subnets to access the Internet"
-  default     = "true"
+  default     = false
 }
 
 variable "nat_instance_enabled" {
-  type        = "string"
+  type        = string
   description = "Flag to enable/disable NAT Instances to allow servers in the private subnets to access the Internet"
-  default     = "false"
+  default     = true
 }
 
 variable "nat_instance_type" {
-  type        = "string"
+  type        = string
   description = "NAT Instance type"
   default     = "t3.micro"
 }
 
 locals {
-  name = "${var.region}"
+  name = var.region
 }
 
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.4.2"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${local.name}"
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.8.1"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = local.name
   cidr_block = "172.16.0.0/16"
 }
 
 module "subnets" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.9.0"
-  availability_zones   = "${var.availability_zones}"
-  namespace            = "${var.namespace}"
-  stage                = "${var.stage}"
-  name                 = "${local.name}"
-  region               = "${var.region}"
-  vpc_id               = "${module.vpc.vpc_id}"
-  igw_id               = "${module.vpc.igw_id}"
-  cidr_block           = "${module.vpc.vpc_cidr_block}"
-  nat_gateway_enabled  = "${var.nat_gateway_enabled}"
-  nat_instance_enabled = "${var.nat_instance_enabled}"
-  nat_instance_type    = "${var.nat_instance_type}"
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.18.1"
+  availability_zones   = var.availability_zones
+  namespace            = var.namespace
+  stage                = var.stage
+  name                 = local.name
+  region               = var.region
+  vpc_id               = module.vpc.vpc_id
+  igw_id               = module.vpc.igw_id
+  cidr_block           = module.vpc.vpc_cidr_block
+  nat_gateway_enabled  = var.nat_gateway_enabled
+  nat_instance_enabled = var.nat_instance_enabled
+  nat_instance_type    = var.nat_instance_type
 }


### PR DESCRIPTION
## what
* [atlantis] Convert `ecs` project to terraform 0.12

## why
* Keep up to date
* Update to latest TF version
* Use TF modules converted to 0.12
