### PR TITLE
terraform-aws-dynamic-subnets upgrade

### DIFF
--- a/aws/vpc/main.tf
+++ b/aws/vpc/main.tf
@@ -43,7 +43,7 @@ module "vpc" {
 }
 
 module "subnets" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.12.2"
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.12.3"
   availability_zones   = "${local.availability_zones}"
   max_subnet_count     = "${var.max_subnet_count}"
   namespace            = "${var.namespace}"


### PR DESCRIPTION
in new version:
## what
* gateway and instance now use same EIP module

## why
* to avoid reassigning IPs in case of switch between `gateway` and `instance` types
