### PR TITLE
ElasticSearch pin right version

### DIFF
--- a/aws/elasticsearch/main.tf
+++ b/aws/elasticsearch/main.tf
@@ -55,7 +55,7 @@ locals {
 }
 
 module "elasticsearch" {
-  source                          = "git::https://github.com/cloudposse/terraform-aws-elasticsearch.git?ref=tags/0.3.1"
+  source                          = "git::https://github.com/cloudposse/terraform-aws-elasticsearch.git?ref=tags/0.3.2"
   namespace                       = "${var.namespace}"
   stage                           = "${var.stage}"
   name                            = "${var.elasticsearch_name}"


### PR DESCRIPTION
## What
* Pin right version for elastic search

## Why
* The release `0.3.1` point to terraform 12 code, but we need terraform 11 so use `0.3.2`