### PR TITLE
create_iam_service_linked_role variable added

### DIFF
--- a/aws/elasticsearch/main.tf
+++ b/aws/elasticsearch/main.tf
@@ -76,6 +76,7 @@ module "elasticsearch" {
   node_to_node_encryption_enabled = "${var.elasticsearch_node_to_node_encryption_enabled}"
   enabled                         = "${var.elasticsearch_enabled}"
   iam_role_max_session_duration   = "${var.elasticsearch_iam_role_max_session_duration}"
+  create_iam_service_linked_role  = "${var.create_iam_service_linked_role}"
 
   advanced_options {
     "rest.action.multi.allow_explicit_index" = "true"

--- a/aws/elasticsearch/variables.tf
+++ b/aws/elasticsearch/variables.tf
@@ -154,8 +154,15 @@ variable "elasticsearch_iam_role_max_session_duration" {
   default     = 3600
   description = "The maximum session duration (in seconds) for the role. Can have a value from 1 hour to 12 hours"
 }
+
 variable "kibana_subdomain_name" {
   type        = "string"
   default     = "kibana-elasticsearch"
   description = "Kubana subdomain"
+}
+
+variable "create_iam_service_linked_role" {
+  type        = "string"
+  default     = "true"
+  description = "Whether to create `AWSServiceRoleForAmazonElasticsearchService` service-linked role. Set it to `false` if you already have an ElasticSearch cluster created in the AWS account and AWSServiceRoleForAmazonElasticsearchService already exists. See https://github.com/terraform-providers/terraform-provider-aws/issues/5218 for more info"
 }


### PR DESCRIPTION
## what
* create_iam_service_linked_role variables added to pass to elasticsearch module

## why
* to be able to disable creating `AWSServiceRoleForAmazonElasticsearchService`. For example in case it is already there