### PR TITLE
elasticsearch_subdomain_name variable added

### DIFF
--- a/aws/elasticsearch/main.tf
+++ b/aws/elasticsearch/main.tf
@@ -71,6 +71,7 @@ module "elasticsearch" {
   iam_authorizing_role_arns       = "${coalescelist(local.role_arns[lookup(local.option_keys, var.elasticsearch_iam_authorizing_role_arn, "none")], list(var.elasticsearch_iam_authorizing_role_arn))}"
   iam_actions                     = ["${var.elasticsearch_iam_actions}"]
   kibana_subdomain_name           = "${var.kibana_subdomain_name}"
+  elasticsearch_subdomain_name    = "${var.elasticsearch_subdomain_name}"
   ebs_volume_size                 = "${var.elasticsearch_ebs_volume_size}"
   encrypt_at_rest_enabled         = "${var.elasticsearch_encrypt_at_rest_enabled}"
   node_to_node_encryption_enabled = "${var.elasticsearch_node_to_node_encryption_enabled}"

--- a/aws/elasticsearch/variables.tf
+++ b/aws/elasticsearch/variables.tf
@@ -161,6 +161,12 @@ variable "kibana_subdomain_name" {
   description = "Kubana subdomain"
 }
 
+variable "elasticsearch_subdomain_name" {
+  type        = "string"
+  default     = ""
+  description = "The name of the subdomain for Elasticsearch endpoint in the DNS zone (_e.g._ `elasticsearch`). If empty then module name will be used."
+}
+
 variable "create_iam_service_linked_role" {
   type        = "string"
   default     = "true"


### PR DESCRIPTION
## what
* `elasticsearch_subdomain_name` variable added

## why
* to be able to override default value (var.name) with custom subdomain hostname