### PR TITLE
terraform-aws-elasticsearch version bump

### DIFF
--- a/aws/elasticsearch/main.tf
+++ b/aws/elasticsearch/main.tf
@@ -55,7 +55,7 @@ locals {
 }
 
 module "elasticsearch" {
-  source                          = "git::https://github.com/cloudposse/terraform-aws-elasticsearch.git?ref=tags/0.3.2"
+  source                          = "git::https://github.com/cloudposse/terraform-aws-elasticsearch.git?ref=tags/0.3.4"
   namespace                       = "${var.namespace}"
   stage                           = "${var.stage}"
   name                            = "${var.elasticsearch_name}"


### PR DESCRIPTION
## what
* terraform-aws-elasticsearch version bump

## why
* to support `elasticsearch_subdomain_name` variable