### PR TITLE
Add `iam_role_arns` variable to specify additional IAM roles to allow access to the Elasticsearch domain

### DIFF
--- a/aws/elasticsearch/main.tf
+++ b/aws/elasticsearch/main.tf
@@ -66,7 +66,7 @@ module "elasticsearch" {
   elasticsearch_version           = "${var.elasticsearch_version}"
   instance_type                   = "${var.elasticsearch_instance_type}"
   instance_count                  = "${var.elasticsearch_instance_count}"
-  iam_role_arns                   = ["${local.role_arns[var.elasticsearch_iam_permitted_nodes]}"]
+  iam_role_arns                   = ["${concat(local.role_arns[var.elasticsearch_iam_permitted_nodes], var.iam_role_arns)}"]
   iam_authorizing_role_arns       = "${coalescelist(local.role_arns[lookup(local.option_keys, var.elasticsearch_iam_authorizing_role_arn, "none")], list(var.elasticsearch_iam_authorizing_role_arn))}"
   iam_actions                     = ["${var.elasticsearch_iam_actions}"]
   kibana_subdomain_name           = "${var.kibana_subdomain_name}"

--- a/aws/elasticsearch/main.tf
+++ b/aws/elasticsearch/main.tf
@@ -66,7 +66,7 @@ module "elasticsearch" {
   elasticsearch_version           = "${var.elasticsearch_version}"
   instance_type                   = "${var.elasticsearch_instance_type}"
   instance_count                  = "${var.elasticsearch_instance_count}"
-  iam_role_arns                   = ["${concat(local.role_arns[var.elasticsearch_iam_permitted_nodes], var.iam_role_arns)}"]
+  iam_role_arns                   = ["${distinct(concat(local.role_arns[var.elasticsearch_iam_permitted_nodes], var.iam_role_arns))}"]
   iam_authorizing_role_arns       = "${coalescelist(local.role_arns[lookup(local.option_keys, var.elasticsearch_iam_authorizing_role_arn, "none")], list(var.elasticsearch_iam_authorizing_role_arn))}"
   iam_actions                     = ["${var.elasticsearch_iam_actions}"]
   kibana_subdomain_name           = "${var.kibana_subdomain_name}"

--- a/aws/elasticsearch/variables.tf
+++ b/aws/elasticsearch/variables.tf
@@ -123,8 +123,14 @@ variable "elasticsearch_iam_permitted_nodes" {
 
 variable "elasticsearch_iam_authorizing_role_arn" {
   type        = "string"
-  description = "IAM role allowed to assume the elasticsearch user role. Typically the role that `kiam` runs as. Full ARN, or 'nodes' or 'masters')"
+  description = "IAM role allowed to assume the Elasticsearch user role. Typically the role that `kiam` runs as. Full ARN, or 'nodes' or 'masters')"
   default     = "masters"
+}
+
+variable "iam_role_arns" {
+  type        = "list"
+  default     = []
+  description = "List of additional IAM role ARNs to permit access to the Elasticsearch domain"
 }
 
 variable "elasticsearch_log_cleanup_enabled" {


### PR DESCRIPTION
## what
* Add `iam_role_arns` variable to specify additional IAM roles to allow access to the Elasticsearch domain

## why
* When Elasticsearch is accessed from applications running on a Kubernetes cluster, the applications are usually running by assuming an IAM role using `kiam` or EKS Service Account IAM Roles. We need to be able to give the application's role permissions to access the ES domain without forcing the application code to assume another IAM role
