### PR TITLE
Expose domain type outputs from elasticsearch module

### DIFF
--- a/aws/elasticsearch/outputs.tf
+++ b/aws/elasticsearch/outputs.tf
@@ -1,0 +1,14 @@
+output "domain_arn" {
+  value       = "${module.elasticsearch.domain_arn}"
+  description = "ARN of the Elasticsearch domain"
+}
+
+output "domain_id" {
+  value       = "${module.elasticsearch.domain_id}"
+  description = "Unique identifier for the Elasticsearch domain"
+}
+
+output "domain_hostname" {
+  value       = "${module.elasticsearch.domain_hostname}"
+  description = "Elasticsearch domain hostname to submit index, search, and data upload requests"
+}


### PR DESCRIPTION
**Why?**

When doing the following:

```hcl-terraform
module "elasticsearch" {
  source  = "git::https://github.com/cloudposse/terraform-root-modules.git//aws/elasticsearch?ref=tags/0.123.0"
  aws_assume_role_arn = "${var.aws_assume_role_arn}"
  namespace = "${var.namespace}"
  stage = "${var.stage}"
  region = "${var.region}"
  zone_name = "${var.zone_name}"
  ....
```

There's no way to access the outputs from the `elasticsearch` module. This is because there's no `outputs.tf` defined (see https://github.com/cloudposse/terraform-root-modules/tree/master/aws/elasticsearch).

I specificially need some of the domain outputs from the elasticsearch module.