### PR TITLE
Add domain_name to outputs

### DIFF
--- a/aws/elasticsearch/main.tf
+++ b/aws/elasticsearch/main.tf
@@ -119,6 +119,11 @@ output "elasticsearch_domain_id" {
   value       = "${module.elasticsearch.domain_id}"
   description = "Unique identifier for the Elasticsearch domain"
 }
+  
+output "elasticsearch_domain_name" {
+  value       = "${module.elasticsearch.domain_name}"
+  description = "Name of the Elasticsearch domain"
+}
 
 output "elasticsearch_domain_endpoint" {
   value       = "${module.elasticsearch.domain_endpoint}"


### PR DESCRIPTION
## what
Add `domain_name` to outputs.

## why
* We are configuring monitoring alerts in Elasticsearch that require the `domain_name`.