### PR TITLE
Bump terraform-aws-elasticsearch to 0.13.0

### DIFF
--- a/aws/elasticsearch/main.tf
+++ b/aws/elasticsearch/main.tf
@@ -54,7 +54,7 @@ locals {
 }
 
 module "elasticsearch" {
-  source                 = "git::https://github.com/cloudposse/terraform-aws-elasticsearch.git?ref=tags/0.12.0"
+  source                 = "git::https://github.com/cloudposse/terraform-aws-elasticsearch.git?ref=tags/0.13.0"
   namespace              = var.namespace
   stage                  = var.stage
   name                   = var.elasticsearch_name


### PR DESCRIPTION
## Why

A new version of `https://github.com/cloudposse/terraform-aws-elasticsearch` has been released and needs to be reflected here. 