### PR TITLE
[elasticsearch] Bump `terraform-aws-elasticsearch` version

### DIFF
--- a/aws/elasticsearch/main.tf
+++ b/aws/elasticsearch/main.tf
@@ -54,7 +54,7 @@ locals {
 }
 
 module "elasticsearch" {
-  source                 = "git::https://github.com/cloudposse/terraform-aws-elasticsearch.git?ref=tags/0.13.0"
+  source                 = "git::https://github.com/cloudposse/terraform-aws-elasticsearch.git?ref=tags/0.14.0"
   namespace              = var.namespace
   stage                  = var.stage
   name                   = var.elasticsearch_name


### PR DESCRIPTION
## what
* [elasticsearch] Bump `terraform-aws-elasticsearch` version

## why
* When an output from a data source is used in `counts`, in some cases Terraform can't compute the counts throwing the errors (it's working in the Terratest, but does not work for some customers):

```
Error: Invalid count argument
 on .terraform/modules/search_service_elasticsearch_master.elasticsearch/main.tf line 76, in resource "aws_iam_service_linked_role" "default":
 76:   count            = var.enabled && var.create_iam_service_linked_role && length(data.aws_iam_role.default.*.id) == 0 ? 1 : 0
The "count" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the count depends on.
```

* We have a bool variable `create_iam_service_linked_role` to control that without using data sources. If the AWS account (where the module is provisioned) already has the `AWSServiceRoleForAmazonElasticsearchService` service role, set the variable `create_iam_service_linked_role` to `false`. On a new account, set it to `true`

## references
* https://github.com/cloudposse/terraform-aws-elasticsearch/pull/52
