### PR TITLE
Update `terraform-aws-lambda-elasticsearch-cleanup` version

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,10 @@ We deliver 10x the value for a fraction of the cost of a full-time engineer. Our
 
 Join our [Open Source Community][slack] on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
 
+## Discourse Forums
+
+Participate in our [Discourse Forums][discourse]. Here you'll find answers to commonly asked questions. Most questions will be related to the enormous number of projects we support on our GitHub. Come here to collaborate on answers, find solutions, and get ideas about the products and services we value. It only takes a minute to get started! Just sign in with SSO using your GitHub account.
+
 ## Newsletter
 
 Sign up for [our newsletter][newsletter] that covers everything on our technology radar.  Receive updates on what we're up to on GitHub as well as awesome new projects we discover. 
@@ -273,7 +277,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2019 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2020 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 
@@ -353,6 +357,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [testimonial]: https://cpco.io/leave-testimonial?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-root-modules&utm_content=testimonial
   [office_hours]: https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-root-modules&utm_content=office_hours
   [newsletter]: https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-root-modules&utm_content=newsletter
+  [discourse]: https://ask.sweetops.com/?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-root-modules&utm_content=discourse
   [email]: https://cpco.io/email?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-root-modules&utm_content=email
   [commercial_support]: https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-root-modules&utm_content=commercial_support
   [we_love_open_source]: https://cpco.io/we-love-open-source?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-root-modules&utm_content=we_love_open_source

--- a/aws/elasticsearch/main.tf
+++ b/aws/elasticsearch/main.tf
@@ -133,8 +133,7 @@ resource "aws_ssm_parameter" "elasticsearch_kibana_endpoint" {
 }
 
 module "elasticsearch_log_cleanup" {
-  #source    = "git::https://github.com/cloudposse/terraform-aws-lambda-elasticsearch-cleanup.git?ref=tags/0.5.0"
-  source    = "git::https://github.com/cloudposse/terraform-aws-lambda-elasticsearch-cleanup.git?ref=update-terraform-external-module-artifact"
+  source    = "git::https://github.com/cloudposse/terraform-aws-lambda-elasticsearch-cleanup.git?ref=tags/0.6.0"
   enabled   = var.elasticsearch_enabled && var.elasticsearch_log_cleanup_enabled
   namespace = var.namespace
   stage     = var.stage

--- a/aws/elasticsearch/main.tf
+++ b/aws/elasticsearch/main.tf
@@ -133,7 +133,8 @@ resource "aws_ssm_parameter" "elasticsearch_kibana_endpoint" {
 }
 
 module "elasticsearch_log_cleanup" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-lambda-elasticsearch-cleanup.git?ref=tags/0.5.0"
+  #source    = "git::https://github.com/cloudposse/terraform-aws-lambda-elasticsearch-cleanup.git?ref=tags/0.5.0"
+  source    = "git::https://github.com/cloudposse/terraform-aws-lambda-elasticsearch-cleanup.git?ref=update-terraform-external-module-artifact"
   enabled   = var.elasticsearch_enabled && var.elasticsearch_log_cleanup_enabled
   namespace = var.namespace
   stage     = var.stage

--- a/aws/elasticsearch/main.tf
+++ b/aws/elasticsearch/main.tf
@@ -149,5 +149,6 @@ module "elasticsearch_log_cleanup" {
   index        = var.elasticsearch_log_index_name
   delete_after = var.elasticsearch_log_retention_days
 
-  sns_arn = var.sns_arn
+  sns_arn      = var.sns_arn
+  artifact_url = var.artifact_url
 }

--- a/aws/elasticsearch/variables.tf
+++ b/aws/elasticsearch/variables.tf
@@ -186,3 +186,9 @@ variable "create_iam_service_linked_role" {
   default     = true
   description = "Whether to create `AWSServiceRoleForAmazonElasticsearchService` service-linked role. Set it to `false` if you already have an ElasticSearch cluster created in the AWS account and AWSServiceRoleForAmazonElasticsearchService already exists. See https://github.com/terraform-providers/terraform-provider-aws/issues/5218 for more info"
 }
+
+variable "artifact_url" {
+  type        = string
+  description = "URL template for the remote artifact for elasticsearch cleanup lambda"
+  default     = "https://artifacts.cloudposse.com/$$${module_name}/$$${git_ref}/$$${filename}"
+}


### PR DESCRIPTION
## what
* Update `terraform-aws-lambda-elasticsearch-cleanup` version

## why
* Added `enabled` and `artifact_url ` variables to the module
* When the `terraform-external-module-artifact` module is used in this module with `enabled` variable set to `false`, `terraform-external-module-artifact` needs to be disabled as well (otherwise it throws errors that it can't download the artifact)
* Allow to override the `artifact_url ` URL template

## references
* https://github.com/cloudposse/terraform-aws-lambda-elasticsearch-cleanup/releases/tag/0.6.0
* https://github.com/cloudposse/terraform-external-module-artifact/releases/tag/0.3.0
