### PR TITLE
Add availability_zone_count variable

### DIFF
--- a/aws/elasticsearch/main.tf
+++ b/aws/elasticsearch/main.tf
@@ -54,18 +54,19 @@ locals {
 }
 
 module "elasticsearch" {
-  source                 = "git::https://github.com/cloudposse/terraform-aws-elasticsearch.git?ref=tags/0.14.0"
-  namespace              = var.namespace
-  stage                  = var.stage
-  name                   = var.elasticsearch_name
-  dns_zone_id            = local.zone_id
-  security_groups        = local.security_groups[var.elasticsearch_network_permitted_nodes]
-  vpc_id                 = module.kops_vpc.vpc_id
-  subnet_ids             = module.kops_vpc.private_subnet_ids
-  zone_awareness_enabled = length(module.kops_vpc.private_subnet_ids) > 1 ? true : false
-  elasticsearch_version  = var.elasticsearch_version
-  instance_type          = var.elasticsearch_instance_type
-  instance_count         = var.elasticsearch_instance_count
+  source                  = "git::https://github.com/cloudposse/terraform-aws-elasticsearch.git?ref=tags/0.14.0"
+  namespace               = var.namespace
+  stage                   = var.stage
+  name                    = var.elasticsearch_name
+  dns_zone_id             = local.zone_id
+  security_groups         = local.security_groups[var.elasticsearch_network_permitted_nodes]
+  vpc_id                  = module.kops_vpc.vpc_id
+  subnet_ids              = module.kops_vpc.private_subnet_ids
+  zone_awareness_enabled  = length(module.kops_vpc.private_subnet_ids) > 1 ? true : false
+  elasticsearch_version   = var.elasticsearch_version
+  instance_type           = var.elasticsearch_instance_type
+  instance_count          = var.elasticsearch_instance_count
+  availability_zone_count = var.availability_zone_count
 
   iam_role_arns = distinct(
     concat(

--- a/aws/elasticsearch/variables.tf
+++ b/aws/elasticsearch/variables.tf
@@ -102,6 +102,12 @@ variable "elasticsearch_instance_count" {
   default     = 4
 }
 
+variable "availability_zone_count" {
+  type        = number
+  default     = 2
+  description = "Number of Availability Zones for the domain to use."
+}
+
 # https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-ac.html
 variable "elasticsearch_iam_actions" {
   type        = list(string)


### PR DESCRIPTION
## Why

The default value is 2 in https://github.com/cloudposse/terraform-aws-elasticsearch/blob/master/variables.tf which is not suitable for accounts that have 3 AZ's. It needs to exposed so it can be overridden.