### PR TITLE
avoid duplicate Security Group rule error

### DIFF
--- a/aws/sentry/rds.tf
+++ b/aws/sentry/rds.tf
@@ -47,13 +47,13 @@ variable "postgres_rds_instance_iam_database_authentication_enabled" {
 
 variable "postgres_rds_instance_cluster_dns_name" {
   type        = string
-  description = "Name of the cluster CNAME record to create in the parent DNS zone specified by `zone_name`. If left empty, the name will be auto-asigned using the format `master.var.postgres_name`"
+  description = "Name of the cluster CNAME record to create in the parent DNS zone specified by `zone_name`. If left empty, the name will be auto-asigned using the format `master.var.postgres_rds_instance_name`"
   default     = ""
 }
 
 variable "postgres_rds_instance_replicas_dns_name" {
   type        = string
-  description = "Name of the reader endpoint CNAME record to create in the parent DNS zone specified by `zone_name`. If left empty, the name will be auto-asigned using the format `replicas.var.postgres_name`"
+  description = "Name of the reader endpoint CNAME record to create in the parent DNS zone specified by `zone_name`. If left empty, the name will be auto-asigned using the format `replicas.var.postgres_rds_instance_name`"
   default     = ""
 }
 
@@ -102,7 +102,6 @@ module "rds_instance_postgres" {
   dns_zone_id          = local.zone_id
   vpc_id               = module.kops_metadata.vpc_id
   subnet_ids           = module.kops_metadata.private_subnet_ids
-  security_group_ids   = [module.kops_metadata.nodes_security_group_id]
   multi_az             = true
   storage_type         = "gp2"
   allocated_storage    = var.postgres_rds_instance_allocated_storage


### PR DESCRIPTION
## what
* unnecessary Security Group removed

## why
* to avoid duplicate Security Group rule error