### PR TITLE
[sentry] Added optional SES module for sending emails

### DIFF
--- a/aws/sentry/aurora-postgres.tf
+++ b/aws/sentry/aurora-postgres.tf
@@ -55,16 +55,19 @@ variable "postgres_cluster_size" {
   default     = 2
   description = "Postgres cluster size"
 }
+
 variable "postgres_autoscaling_enabled" {
   type        = bool
   default     = false
   description = "Set true to enable the database cluster autoscaler"
 }
+
 variable "postgres_autoscaling_min_capacity" {
   type        = number
   default     = 1
   description = "Minimum number of Postgres instances to be maintained by the autoscaler"
 }
+
 variable "postgres_autoscaling_max_capacity" {
   type        = number
   default     = 6

--- a/aws/sentry/elasticache-redis.tf
+++ b/aws/sentry/elasticache-redis.tf
@@ -31,8 +31,6 @@ variable "redis_params" {
   description = "A list of Redis parameters to apply. Note that parameters may differ from a Redis family to another"
 }
 
-
-
 module "elasticache_redis" {
   source                       = "git::https://github.com/cloudposse/terraform-aws-elasticache-redis.git?ref=tags/0.13.0"
   enabled                      = var.redis_cluster_enabled
@@ -61,7 +59,6 @@ module "elasticache_redis" {
 
   parameter = var.redis_params
 }
-
 
 resource "aws_ssm_parameter" "elasticache_redis_host" {
   count       = local.postgres_cluster_enabled ? 1 : 0

--- a/aws/sentry/main.tf
+++ b/aws/sentry/main.tf
@@ -2,7 +2,6 @@ terraform {
   backend "s3" {}
 }
 
-
 data "aws_availability_zones" "available" {}
 
 data "aws_route53_zone" "default" {
@@ -22,7 +21,6 @@ locals {
   chamber_service    = var.chamber_service == "" ? basename(pathexpand(path.module)) : var.chamber_service
 
   chamber_parameter_format = "/%s/%s"
-
 }
 
 provider "aws" {
@@ -31,11 +29,11 @@ provider "aws" {
   }
 }
 
-
 resource "random_string" "sentry_secret_key" {
   length  = 48
   special = true
 }
+
 resource "random_string" "sentry_admin_user_password" {
   length  = 21
   special = false
@@ -56,4 +54,3 @@ resource "aws_ssm_parameter" "sentry_admin_user_password" {
   type        = "String"
   overwrite   = true
 }
-

--- a/aws/sentry/rds.tf
+++ b/aws/sentry/rds.tf
@@ -26,8 +26,8 @@ variable "postgres_rds_instance_db_name" {
   description = "Postgres database name"
 }
 
-# https://aws.amazon.com/rds/aurora/pricing
-variable "postgres_rds_instance_instance_class" {
+# https://aws.amazon.com/rds/pricing/
+variable "postgres_rds_instance_type" {
   type        = string
   default     = "db.t3.medium"
   description = "EC2 instance type for Postgres cluster"
@@ -94,7 +94,7 @@ module "rds_instance_postgres" {
   stage                = var.stage
   name                 = var.postgres_rds_instance_name
   engine               = "postgres"
-  instance_class       = var.postgres_rds_instance_instance_class
+  instance_class       = var.postgres_rds_instance_type
   database_user        = var.postgres_rds_instance_user
   database_password    = local.postgres_rds_instance_admin_password
   database_name        = var.postgres_rds_instance_db_name

--- a/aws/sentry/ses.tf
+++ b/aws/sentry/ses.tf
@@ -38,30 +38,28 @@ module "ses" {
   verify_dkim   = var.ses_verify_dkim
   verify_domain = var.ses_verify_domain
 }
-
-output "access_key_id" {
-  value       = module.ses.access_key_id
-  description = "The access key ID"
+output "smtp_password" {
+  sensitive   = true
+  value       = module.ses.smtp_password
+  description = "The SMTP password. This will be written to the state file in plain text."
 }
 
-output "secret_access_key" {
-  sensitive   = true
-  value       = module.ses.secret_access_key
-  description = "The secret access key. This will be written to the state file in plain-text"
+output "smtp_user" {
+  value       = module.ses.smtp_user
+  description = "The SMTP user which is access key ID."
 }
 
 output "user_name" {
   value       = module.ses.user_name
-  description = "Normalized IAM user name"
-}
-
-output "user_arn" {
-  value       = module.ses.user_arn
-  description = "The ARN assigned by AWS for this user"
+  description = "Normalized IAM user name."
 }
 
 output "user_unique_id" {
   value       = module.ses.user_unique_id
-  description = "The unique ID assigned by AWS"
+  description = "The unique ID assigned by AWS."
 }
 
+output "user_arn" {
+  value       = module.ses.user_arn
+  description = "The ARN assigned by AWS for this user."
+}

--- a/aws/sentry/ses.tf
+++ b/aws/sentry/ses.tf
@@ -28,7 +28,7 @@ variable "ses_verify_dkim" {
 }
 
 module "ses" {
-  source        = "git::https://github.com/cloudposse/terraform-aws-ses.git?ref=ses-module"
+  source        = "git::https://github.com/cloudposse/terraform-aws-ses.git?ref=tags/0.1.0"
   namespace     = var.namespace
   name          = "sentry-ses"
   stage         = var.stage

--- a/aws/sentry/ses.tf
+++ b/aws/sentry/ses.tf
@@ -1,0 +1,67 @@
+variable "ses_enabled" {
+  type        = bool
+  default     = false
+  description = "Set true to enable SES for sending emails."
+}
+
+variable "domain" {
+  description = "The domain to create the SES identity for."
+  type        = string
+}
+
+variable "zone_id" {
+  type        = string
+  description = "Route53 parent zone ID. If provided (not empty), the module will create Route53 DNS records used for verification"
+  default     = ""
+}
+
+variable "verify_domain" {
+  type        = bool
+  description = "If provided the module will create Route53 DNS records used for domain verification."
+  default     = null
+}
+
+variable "verify_dkim" {
+  type        = bool
+  description = "If provided the module will create Route53 DNS records used for DKIM verification."
+  default     = null
+}
+
+module "ses" {
+  source        = "git::https://github.com/cloudposse/terraform-aws-ses.git?ref=ses-module"
+  namespace     = var.namespace
+  name          = "sentry"
+  stage         = var.stage
+  enabled       = var.ses_enabled
+  domain        = var.domain
+  zone_id       = var.zone_id
+  verify_dkim   = var.verify_dkim
+  verify_domain = var.verify_domain
+}
+
+output "access_key_id" {
+  value       = module.ses.access_key_id
+  description = "The access key ID"
+}
+
+output "secret_access_key" {
+  sensitive   = true
+  value       = module.ses.secret_access_key
+  description = "The secret access key. This will be written to the state file in plain-text"
+}
+
+output "user_name" {
+  value       = module.ses.user_name
+  description = "Normalized IAM user name"
+}
+
+output "user_arn" {
+  value       = module.ses.user_arn
+  description = "The ARN assigned by AWS for this user"
+}
+
+output "user_unique_id" {
+  value       = module.ses.user_unique_id
+  description = "The unique ID assigned by AWS"
+}
+

--- a/aws/sentry/ses.tf
+++ b/aws/sentry/ses.tf
@@ -30,7 +30,7 @@ variable "ses_verify_dkim" {
 module "ses" {
   source        = "git::https://github.com/cloudposse/terraform-aws-ses.git?ref=ses-module"
   namespace     = var.namespace
-  name          = "sentry"
+  name          = "sentry-ses"
   stage         = var.stage
   enabled       = var.ses_enabled
   domain        = var.ses_domain

--- a/aws/sentry/ses.tf
+++ b/aws/sentry/ses.tf
@@ -4,24 +4,24 @@ variable "ses_enabled" {
   description = "Set true to enable SES for sending emails."
 }
 
-variable "domain" {
+variable "ses_domain" {
   description = "The domain to create the SES identity for."
   type        = string
 }
 
-variable "zone_id" {
+variable "ses_zone_id" {
   type        = string
   description = "Route53 parent zone ID. If provided (not empty), the module will create Route53 DNS records used for verification"
   default     = ""
 }
 
-variable "verify_domain" {
+variable "ses_verify_domain" {
   type        = bool
   description = "If provided the module will create Route53 DNS records used for domain verification."
   default     = null
 }
 
-variable "verify_dkim" {
+variable "ses_verify_dkim" {
   type        = bool
   description = "If provided the module will create Route53 DNS records used for DKIM verification."
   default     = null
@@ -33,10 +33,10 @@ module "ses" {
   name          = "sentry"
   stage         = var.stage
   enabled       = var.ses_enabled
-  domain        = var.domain
-  zone_id       = var.zone_id
-  verify_dkim   = var.verify_dkim
-  verify_domain = var.verify_domain
+  domain        = var.ses_domain
+  zone_id       = var.ses_zone_id
+  verify_dkim   = var.ses_verify_dkim
+  verify_domain = var.ses_verify_domain
 }
 
 output "access_key_id" {

--- a/aws/sentry/variables.tf
+++ b/aws/sentry/variables.tf
@@ -12,7 +12,6 @@ variable "stage" {
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
-
 variable "elasticache_availability_zones" {
   type        = list(string)
   description = "AWS region availability zones for elasticache (e.g.: ['us-west-2a', 'us-west-2b']). If empty will use all available zones"


### PR DESCRIPTION
# what
* Add SES module that creates `domain identity`, IAM user that can send emails and verification DNS records in Route53

# why
* To send emails via SES with sentry