### PR TITLE
Add missing log publishing options for Elasticsearch

### DIFF
--- a/aws/elasticsearch/main.tf
+++ b/aws/elasticsearch/main.tf
@@ -54,19 +54,25 @@ locals {
 }
 
 module "elasticsearch" {
-  source                  = "git::https://github.com/cloudposse/terraform-aws-elasticsearch.git?ref=tags/0.14.0"
-  namespace               = var.namespace
-  stage                   = var.stage
-  name                    = var.elasticsearch_name
-  dns_zone_id             = local.zone_id
-  security_groups         = local.security_groups[var.elasticsearch_network_permitted_nodes]
-  vpc_id                  = module.kops_vpc.vpc_id
-  subnet_ids              = module.kops_vpc.private_subnet_ids
-  zone_awareness_enabled  = length(module.kops_vpc.private_subnet_ids) > 1 ? true : false
-  elasticsearch_version   = var.elasticsearch_version
-  instance_type           = var.elasticsearch_instance_type
-  instance_count          = var.elasticsearch_instance_count
-  availability_zone_count = var.availability_zone_count
+  source                                              = "git::https://github.com/cloudposse/terraform-aws-elasticsearch.git?ref=tags/0.14.0"
+  namespace                                           = var.namespace
+  stage                                               = var.stage
+  name                                                = var.elasticsearch_name
+  dns_zone_id                                         = local.zone_id
+  security_groups                                     = local.security_groups[var.elasticsearch_network_permitted_nodes]
+  vpc_id                                              = module.kops_vpc.vpc_id
+  subnet_ids                                          = module.kops_vpc.private_subnet_ids
+  zone_awareness_enabled                              = length(module.kops_vpc.private_subnet_ids) > 1 ? true : false
+  elasticsearch_version                               = var.elasticsearch_version
+  instance_type                                       = var.elasticsearch_instance_type
+  instance_count                                      = var.elasticsearch_instance_count
+  log_publishing_index_enabled                        = var.elasticsearch_log_publishing_index_enabled
+  log_publishing_index_cloudwatch_log_group_arn       = var.elasticsearch_log_publishing_index_cloudwatch_log_group_arn
+  log_publishing_search_enabled                       = var.elasticsearch_log_publishing_search_enabled
+  log_publishing_search_cloudwatch_log_group_arn      = var.elasticsearch_log_publishing_search_cloudwatch_log_group_arn
+  log_publishing_application_enabled                  = var.elasticsearch_log_publishing_application_enabled
+  log_publishing_application_cloudwatch_log_group_arn = var.elasticsearch_log_publishing_application_cloudwatch_log_group_arn
+  availability_zone_count                             = var.availability_zone_count
 
   iam_role_arns = distinct(
     concat(

--- a/aws/elasticsearch/variables.tf
+++ b/aws/elasticsearch/variables.tf
@@ -198,3 +198,39 @@ variable "artifact_url" {
   description = "URL template for the remote artifact for elasticsearch cleanup lambda"
   default     = "https://artifacts.cloudposse.com/$$${module_name}/$$${git_ref}/$$${filename}"
 }
+
+variable "elasticsearch_log_publishing_index_enabled" {
+  type        = bool
+  default     = false
+  description = "Specifies whether log publishing option for INDEX_SLOW_LOGS is enabled or not"
+}
+
+variable "elasticsearch_log_publishing_search_enabled" {
+  type        = bool
+  default     = false
+  description = "Specifies whether log publishing option for SEARCH_SLOW_LOGS is enabled or not"
+}
+
+variable "elasticsearch_log_publishing_application_enabled" {
+  type        = bool
+  default     = false
+  description = "Specifies whether log publishing option for ES_APPLICATION_LOGS is enabled or not"
+}
+
+variable "elasticsearch_log_publishing_index_cloudwatch_log_group_arn" {
+  type        = string
+  default     = ""
+  description = "ARN of the CloudWatch log group to which log for INDEX_SLOW_LOGS needs to be published"
+}
+
+variable "elasticsearch_log_publishing_search_cloudwatch_log_group_arn" {
+  type        = string
+  default     = ""
+  description = "ARN of the CloudWatch log group to which log for SEARCH_SLOW_LOGS needs to be published"
+}
+
+variable "elasticsearch_log_publishing_application_cloudwatch_log_group_arn" {
+  type        = string
+  default     = ""
+  description = "ARN of the CloudWatch log group to which log for ES_APPLICATION_LOGS needs to be published"
+}


### PR DESCRIPTION
### Why?

It's not possible to override the log publishing options provided by the module https://github.com/cloudposse/terraform-aws-elasticsearch.