### PR TITLE
Making existing components pre-commit check compliant

### DIFF
--- a/deprecated/aws/account-dns/main.tf
+++ b/deprecated/aws/account-dns/main.tf
@@ -5,28 +5,28 @@ terraform {
 }
 
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "domain_name" {
-  type        = "string"
+  type        = string
   description = "Domain name"
 }
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
 resource "aws_route53_zone" "dns_zone" {
-  name = "${var.domain_name}"
+  name = var.domain_name
 }
 
 resource "aws_route53_record" "dns_zone_soa" {
   allow_overwrite = true
-  zone_id         = "${aws_route53_zone.dns_zone.id}"
-  name            = "${aws_route53_zone.dns_zone.name}"
+  zone_id         = aws_route53_zone.dns_zone.id
+  name            = aws_route53_zone.dns_zone.name
   type            = "SOA"
   ttl             = "60"
 
@@ -36,9 +36,9 @@ resource "aws_route53_record" "dns_zone_soa" {
 }
 
 output "zone_id" {
-  value = "${aws_route53_zone.dns_zone.zone_id}"
+  value = aws_route53_zone.dns_zone.zone_id
 }
 
 output "name_servers" {
-  value = "${aws_route53_zone.dns_zone.name_servers}"
+  value = aws_route53_zone.dns_zone.name_servers
 }

--- a/deprecated/aws/account-settings/main.tf
+++ b/deprecated/aws/account-settings/main.tf
@@ -6,16 +6,16 @@ terraform {
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
 module "account_settings" {
   source    = "git::https://github.com/cloudposse/terraform-aws-iam-account-settings.git?ref=tags/0.1.0"
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
-  name      = "${var.name}"
-  enabled   = "${var.enabled}"
+  namespace = var.namespace
+  stage     = var.stage
+  name      = var.name
+  enabled   = var.enabled
 
-  minimum_password_length = "${var.minimum_password_length}"
+  minimum_password_length = var.minimum_password_length
 }

--- a/deprecated/aws/account-settings/outputs.tf
+++ b/deprecated/aws/account-settings/outputs.tf
@@ -1,11 +1,11 @@
 output "account_alias" {
-  value = "${module.account_settings.account_alias}"
+  value = module.account_settings.account_alias
 }
 
 output "minimum_password_length" {
-  value = "${module.account_settings.minimum_password_length}"
+  value = module.account_settings.minimum_password_length
 }
 
 output "signin_url" {
-  value = "${module.account_settings.signin_url}"
+  value = module.account_settings.signin_url
 }

--- a/deprecated/aws/account-settings/variables.tf
+++ b/deprecated/aws/account-settings/variables.tf
@@ -1,5 +1,5 @@
 variable "minimum_password_length" {
-  type        = "string"
+  type        = string
   description = "Minimum number of characters allowed in an IAM user password.  Integer between 6 and 128, per https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_account-policy.html"
 
   ## Same default as https://github.com/cloudposse/terraform-aws-iam-account-settings:
@@ -7,21 +7,21 @@ variable "minimum_password_length" {
 }
 
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   description = "Application or solution name (e.g. `app`)"
   default     = "account"
 }

--- a/deprecated/aws/accounts/audit.tf
+++ b/deprecated/aws/accounts/audit.tf
@@ -1,21 +1,21 @@
 module "audit" {
   source                             = "stage"
-  namespace                          = "${var.namespace}"
+  namespace                          = var.namespace
   stage                              = "audit"
-  accounts_enabled                   = "${var.accounts_enabled}"
-  account_email                      = "${var.account_email}"
-  account_iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
-  account_role_name                  = "${var.account_role_name}"
+  accounts_enabled                   = var.accounts_enabled
+  account_email                      = var.account_email
+  account_iam_user_access_to_billing = var.account_iam_user_access_to_billing
+  account_role_name                  = var.account_role_name
 }
 
 output "audit_account_arn" {
-  value = "${module.audit.account_arn}"
+  value = module.audit.account_arn
 }
 
 output "audit_account_id" {
-  value = "${module.audit.account_id}"
+  value = module.audit.account_id
 }
 
 output "audit_organization_account_access_role" {
-  value = "${module.audit.organization_account_access_role}"
+  value = module.audit.organization_account_access_role
 }

--- a/deprecated/aws/accounts/corp.tf
+++ b/deprecated/aws/accounts/corp.tf
@@ -1,21 +1,21 @@
 module "corp" {
   source                             = "stage"
-  namespace                          = "${var.namespace}"
+  namespace                          = var.namespace
   stage                              = "corp"
-  accounts_enabled                   = "${var.accounts_enabled}"
-  account_email                      = "${var.account_email}"
-  account_iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
-  account_role_name                  = "${var.account_role_name}"
+  accounts_enabled                   = var.accounts_enabled
+  account_email                      = var.account_email
+  account_iam_user_access_to_billing = var.account_iam_user_access_to_billing
+  account_role_name                  = var.account_role_name
 }
 
 output "corp_account_arn" {
-  value = "${module.corp.account_arn}"
+  value = module.corp.account_arn
 }
 
 output "corp_account_id" {
-  value = "${module.corp.account_id}"
+  value = module.corp.account_id
 }
 
 output "corp_organization_account_access_role" {
-  value = "${module.corp.organization_account_access_role}"
+  value = module.corp.organization_account_access_role
 }

--- a/deprecated/aws/accounts/data.tf
+++ b/deprecated/aws/accounts/data.tf
@@ -1,21 +1,21 @@
 module "data" {
   source                             = "stage"
-  namespace                          = "${var.namespace}"
+  namespace                          = var.namespace
   stage                              = "data"
-  accounts_enabled                   = "${var.accounts_enabled}"
-  account_email                      = "${var.account_email}"
-  account_iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
-  account_role_name                  = "${var.account_role_name}"
+  accounts_enabled                   = var.accounts_enabled
+  account_email                      = var.account_email
+  account_iam_user_access_to_billing = var.account_iam_user_access_to_billing
+  account_role_name                  = var.account_role_name
 }
 
 output "data_account_arn" {
-  value = "${module.data.account_arn}"
+  value = module.data.account_arn
 }
 
 output "data_account_id" {
-  value = "${module.data.account_id}"
+  value = module.data.account_id
 }
 
 output "data_organization_account_access_role" {
-  value = "${module.data.organization_account_access_role}"
+  value = module.data.organization_account_access_role
 }

--- a/deprecated/aws/accounts/dev.tf
+++ b/deprecated/aws/accounts/dev.tf
@@ -1,21 +1,21 @@
 module "dev" {
   source                             = "stage"
-  namespace                          = "${var.namespace}"
+  namespace                          = var.namespace
   stage                              = "dev"
-  accounts_enabled                   = "${var.accounts_enabled}"
-  account_email                      = "${var.account_email}"
-  account_iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
-  account_role_name                  = "${var.account_role_name}"
+  accounts_enabled                   = var.accounts_enabled
+  account_email                      = var.account_email
+  account_iam_user_access_to_billing = var.account_iam_user_access_to_billing
+  account_role_name                  = var.account_role_name
 }
 
 output "dev_account_arn" {
-  value = "${module.dev.account_arn}"
+  value = module.dev.account_arn
 }
 
 output "dev_account_id" {
-  value = "${module.dev.account_id}"
+  value = module.dev.account_id
 }
 
 output "dev_organization_account_access_role" {
-  value = "${module.dev.organization_account_access_role}"
+  value = module.dev.organization_account_access_role
 }

--- a/deprecated/aws/accounts/identity.tf
+++ b/deprecated/aws/accounts/identity.tf
@@ -1,21 +1,21 @@
 module "identity" {
   source                             = "stage"
-  namespace                          = "${var.namespace}"
+  namespace                          = var.namespace
   stage                              = "identity"
-  accounts_enabled                   = "${var.accounts_enabled}"
-  account_email                      = "${var.account_email}"
-  account_iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
-  account_role_name                  = "${var.account_role_name}"
+  accounts_enabled                   = var.accounts_enabled
+  account_email                      = var.account_email
+  account_iam_user_access_to_billing = var.account_iam_user_access_to_billing
+  account_role_name                  = var.account_role_name
 }
 
 output "identity_account_arn" {
-  value = "${module.identity.account_arn}"
+  value = module.identity.account_arn
 }
 
 output "identity_account_id" {
-  value = "${module.identity.account_id}"
+  value = module.identity.account_id
 }
 
 output "identity_organization_account_access_role" {
-  value = "${module.identity.organization_account_access_role}"
+  value = module.identity.organization_account_access_role
 }

--- a/deprecated/aws/accounts/main.tf
+++ b/deprecated/aws/accounts/main.tf
@@ -5,39 +5,39 @@ terraform {
 }
 
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "account_role_name" {
-  type        = "string"
+  type        = string
   description = "IAM role that Organization automatically preconfigures in the new member account"
   default     = "OrganizationAccountAccessRole"
 }
 
 variable "account_email" {
-  type        = "string"
+  type        = string
   description = "Email address format for accounts (e.g. `%s@cloudposse.co`)"
 }
 
 variable "account_iam_user_access_to_billing" {
-  type        = "string"
+  type        = string
   description = "If set to `ALLOW`, the new account enables IAM users to access account billing information if they have the required permissions. If set to `DENY`, then only the root user of the new account can access account billing information"
   default     = "DENY"
 }
 
 variable "accounts_enabled" {
-  type        = "list"
+  type        = list(string)
   description = "Accounts to enable"
   default     = ["dev", "staging", "prod", "testing", "audit"]
 }
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }

--- a/deprecated/aws/accounts/prod.tf
+++ b/deprecated/aws/accounts/prod.tf
@@ -1,21 +1,21 @@
 module "prod" {
   source                             = "stage"
-  namespace                          = "${var.namespace}"
+  namespace                          = var.namespace
   stage                              = "prod"
-  accounts_enabled                   = "${var.accounts_enabled}"
-  account_email                      = "${var.account_email}"
-  account_iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
-  account_role_name                  = "${var.account_role_name}"
+  accounts_enabled                   = var.accounts_enabled
+  account_email                      = var.account_email
+  account_iam_user_access_to_billing = var.account_iam_user_access_to_billing
+  account_role_name                  = var.account_role_name
 }
 
 output "prod_account_arn" {
-  value = "${module.prod.account_arn}"
+  value = module.prod.account_arn
 }
 
 output "prod_account_id" {
-  value = "${module.prod.account_id}"
+  value = module.prod.account_id
 }
 
 output "prod_organization_account_access_role" {
-  value = "${module.prod.organization_account_access_role}"
+  value = module.prod.organization_account_access_role
 }

--- a/deprecated/aws/accounts/security.tf
+++ b/deprecated/aws/accounts/security.tf
@@ -1,21 +1,21 @@
 module "security" {
   source                             = "stage"
-  namespace                          = "${var.namespace}"
+  namespace                          = var.namespace
   stage                              = "security"
-  accounts_enabled                   = "${var.accounts_enabled}"
-  account_email                      = "${var.account_email}"
-  account_iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
-  account_role_name                  = "${var.account_role_name}"
+  accounts_enabled                   = var.accounts_enabled
+  account_email                      = var.account_email
+  account_iam_user_access_to_billing = var.account_iam_user_access_to_billing
+  account_role_name                  = var.account_role_name
 }
 
 output "security_account_arn" {
-  value = "${module.security.account_arn}"
+  value = module.security.account_arn
 }
 
 output "security_account_id" {
-  value = "${module.security.account_id}"
+  value = module.security.account_id
 }
 
 output "security_organization_account_access_role" {
-  value = "${module.security.organization_account_access_role}"
+  value = module.security.organization_account_access_role
 }

--- a/deprecated/aws/accounts/stage/main.tf
+++ b/deprecated/aws/accounts/stage/main.tf
@@ -1,41 +1,41 @@
 resource "aws_organizations_account" "default" {
-  count                      = "${local.count}"
-  name                       = "${var.stage}"
-  email                      = "${format(var.account_email, var.stage)}"
-  iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
-  role_name                  = "${var.account_role_name}"
+  count                      = local.count
+  name                       = var.stage
+  email                      = format(var.account_email, var.stage)
+  iam_user_access_to_billing = var.account_iam_user_access_to_billing
+  role_name                  = var.account_role_name
 }
 
 locals {
-  count                            = "${contains(var.accounts_enabled, var.stage) == true ? 1 : 0}"
-  account_arn                      = "${join("", aws_organizations_account.default.*.arn)}"
-  account_id                       = "${join("", aws_organizations_account.default.*.id)}"
+  count                            = contains(var.accounts_enabled, var.stage) == true ? 1 : 0
+  account_arn                      = join("", aws_organizations_account.default.*.arn)
+  account_id                       = join("", aws_organizations_account.default.*.id)
   organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.default.*.id)}:role/OrganizationAccountAccessRole"
 }
 
 resource "aws_ssm_parameter" "account_id" {
-  count       = "${local.count}"
+  count       = local.count
   name        = "/${var.namespace}/${var.stage}/account_id"
   description = "AWS Account ID"
   type        = "String"
-  value       = "${local.account_id}"
+  value       = local.account_id
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "account_arn" {
-  count       = "${local.count}"
+  count       = local.count
   name        = "/${var.namespace}/${var.stage}/account_arn"
   description = "AWS Account ARN"
   type        = "String"
-  value       = "${local.account_arn}"
+  value       = local.account_arn
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "organization_account_access_role" {
-  count       = "${local.count}"
+  count       = local.count
   name        = "/${var.namespace}/${var.stage}/organization_account_access_role"
   description = "AWS Organization Account Access Role"
   type        = "String"
-  value       = "${local.organization_account_access_role}"
+  value       = local.organization_account_access_role
   overwrite   = "true"
 }

--- a/deprecated/aws/accounts/stage/outputs.tf
+++ b/deprecated/aws/accounts/stage/outputs.tf
@@ -1,11 +1,11 @@
 output "account_arn" {
-  value = "${local.account_arn}"
+  value = local.account_arn
 }
 
 output "account_id" {
-  value = "${local.account_id}"
+  value = local.account_id
 }
 
 output "organization_account_access_role" {
-  value = "${local.organization_account_access_role}"
+  value = local.organization_account_access_role
 }

--- a/deprecated/aws/accounts/stage/variables.tf
+++ b/deprecated/aws/accounts/stage/variables.tf
@@ -1,29 +1,29 @@
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `audit`)"
 }
 
 variable "account_role_name" {
-  type        = "string"
+  type        = string
   description = "IAM role that Organization automatically preconfigures in the new member account"
 }
 
 variable "account_email" {
-  type        = "string"
+  type        = string
   description = "Email address format for accounts (e.g. `%s@cloudposse.co`)"
 }
 
 variable "account_iam_user_access_to_billing" {
-  type        = "string"
+  type        = string
   description = "If set to `ALLOW`, the new account enables IAM users to access account billing information if they have the required permissions. If set to `DENY`, then only the root user of the new account can access account billing information"
 }
 
 variable "accounts_enabled" {
-  type        = "list"
+  type        = list(string)
   description = "Accounts to enable"
 }

--- a/deprecated/aws/accounts/staging.tf
+++ b/deprecated/aws/accounts/staging.tf
@@ -1,21 +1,21 @@
 module "staging" {
   source                             = "stage"
-  namespace                          = "${var.namespace}"
+  namespace                          = var.namespace
   stage                              = "staging"
-  accounts_enabled                   = "${var.accounts_enabled}"
-  account_email                      = "${var.account_email}"
-  account_iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
-  account_role_name                  = "${var.account_role_name}"
+  accounts_enabled                   = var.accounts_enabled
+  account_email                      = var.account_email
+  account_iam_user_access_to_billing = var.account_iam_user_access_to_billing
+  account_role_name                  = var.account_role_name
 }
 
 output "staging_account_arn" {
-  value = "${module.staging.account_arn}"
+  value = module.staging.account_arn
 }
 
 output "staging_account_id" {
-  value = "${module.staging.account_id}"
+  value = module.staging.account_id
 }
 
 output "staging_organization_account_access_role" {
-  value = "${module.staging.organization_account_access_role}"
+  value = module.staging.organization_account_access_role
 }

--- a/deprecated/aws/accounts/testing.tf
+++ b/deprecated/aws/accounts/testing.tf
@@ -1,21 +1,21 @@
 module "testing" {
   source                             = "stage"
-  namespace                          = "${var.namespace}"
+  namespace                          = var.namespace
   stage                              = "testing"
-  accounts_enabled                   = "${var.accounts_enabled}"
-  account_email                      = "${var.account_email}"
-  account_iam_user_access_to_billing = "${var.account_iam_user_access_to_billing}"
-  account_role_name                  = "${var.account_role_name}"
+  accounts_enabled                   = var.accounts_enabled
+  account_email                      = var.account_email
+  account_iam_user_access_to_billing = var.account_iam_user_access_to_billing
+  account_role_name                  = var.account_role_name
 }
 
 output "testing_account_arn" {
-  value = "${module.testing.account_arn}"
+  value = module.testing.account_arn
 }
 
 output "testing_account_id" {
-  value = "${module.testing.account_id}"
+  value = module.testing.account_id
 }
 
 output "testing_organization_account_access_role" {
-  value = "${module.testing.organization_account_access_role}"
+  value = module.testing.organization_account_access_role
 }

--- a/deprecated/aws/acm-cloudfront/main.tf
+++ b/deprecated/aws/acm-cloudfront/main.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 provider "aws" {
@@ -17,7 +17,7 @@ provider "aws" {
   region = "us-east-1"
 
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
@@ -27,24 +27,24 @@ variable "domain_name" {
 
 module "certificate" {
   source                           = "git::https://github.com/cloudposse/terraform-aws-acm-request-certificate.git?ref=tags/0.1.1"
-  domain_name                      = "${var.domain_name}"
+  domain_name                      = var.domain_name
   proces_domain_validation_options = "true"
   ttl                              = "300"
   subject_alternative_names        = ["*.${var.domain_name}"]
 }
 
 output "certificate_domain_name" {
-  value = "${var.domain_name}"
+  value = var.domain_name
 }
 
 output "certificate_id" {
-  value = "${module.certificate.id}"
+  value = module.certificate.id
 }
 
 output "certificate_arn" {
-  value = "${module.certificate.arn}"
+  value = module.certificate.arn
 }
 
 output "certificate_domain_validation_options" {
-  value = "${module.certificate.domain_validation_options}"
+  value = module.certificate.domain_validation_options
 }

--- a/deprecated/aws/acm-teleport/main.tf
+++ b/deprecated/aws/acm-teleport/main.tf
@@ -8,21 +8,21 @@ variable "aws_assume_role_arn" {}
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
 module "certificate" {
   source                           = "git::https://github.com/cloudposse/terraform-aws-acm-request-certificate.git?ref=tags/0.1.1"
-  domain_name                      = "${var.domain_name}"
+  domain_name                      = var.domain_name
   proces_domain_validation_options = "true"
   ttl                              = "300"
   subject_alternative_names        = ["*.${var.domain_name}"]
 }
 
 resource "aws_ssm_parameter" "certificate_arn_parameter" {
-  name        = "${format(var.chamber_parameter_name, var.chamber_service, var.certificate_arn_parameter_name)}"
-  value       = "${module.certificate.arn}"
+  name        = format(var.chamber_parameter_name, var.chamber_service, var.certificate_arn_parameter_name)
+  value       = module.certificate.arn
   description = "Teleport ACM-issued TLS Certificate AWS ARN"
   type        = "String"
   overwrite   = "true"

--- a/deprecated/aws/acm-teleport/outputs.tf
+++ b/deprecated/aws/acm-teleport/outputs.tf
@@ -1,15 +1,15 @@
 output "certificate_domain_name" {
-  value = "${var.domain_name}"
+  value = var.domain_name
 }
 
 output "certificate_id" {
-  value = "${module.certificate.id}"
+  value = module.certificate.id
 }
 
 output "certificate_arn" {
-  value = "${module.certificate.arn}"
+  value = module.certificate.arn
 }
 
 output "certificate_domain_validation_options" {
-  value = "${module.certificate.domain_validation_options}"
+  value = module.certificate.domain_validation_options
 }

--- a/deprecated/aws/artifacts/main.tf
+++ b/deprecated/aws/artifacts/main.tf
@@ -9,14 +9,14 @@ provider "aws" {
   region = "us-east-1"
 
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
 # https://www.terraform.io/artifacts/providers/aws/d/acm_certificate.html
 data "aws_acm_certificate" "acm_cloudfront_certificate" {
   provider = "aws.virginia"
-  domain   = "${var.domain_name}"
+  domain   = var.domain_name
   statuses = ["ISSUED"]
   types    = ["AMAZON_ISSUED"]
 }
@@ -29,19 +29,19 @@ locals {
 
 module "artifacts_user" {
   source    = "git::https://github.com/cloudposse/terraform-aws-iam-system-user.git?ref=tags/0.2.2"
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
-  name      = "${local.name}"
+  namespace = var.namespace
+  stage     = var.stage
+  name      = local.name
 }
 
 module "origin" {
   source               = "git::https://github.com/cloudposse/terraform-aws-s3-website.git?ref=tags/0.5.2"
-  namespace            = "${var.namespace}"
-  stage                = "${var.stage}"
-  name                 = "${local.name}"
-  hostname             = "${local.cdn_domain}"
-  parent_zone_name     = "${var.domain_name}"
-  region               = "${var.region}"
+  namespace            = var.namespace
+  stage                = var.stage
+  name                 = local.name
+  hostname             = local.cdn_domain
+  parent_zone_name     = var.domain_name
+  region               = var.region
   cors_allowed_headers = ["*"]
   cors_allowed_methods = ["GET"]
   cors_allowed_origins = ["*"]
@@ -66,14 +66,14 @@ module "origin" {
 # CloudFront CDN fronting origin
 module "cdn" {
   source                 = "git::https://github.com/cloudposse/terraform-aws-cloudfront-cdn.git?ref=tags/0.5.7"
-  namespace              = "${var.namespace}"
-  stage                  = "${var.stage}"
-  name                   = "${local.name}"
+  namespace              = var.namespace
+  stage                  = var.stage
+  name                   = local.name
   aliases                = ["${local.cdn_domain}", "artifacts.cloudposse.com"]
-  origin_domain_name     = "${module.origin.s3_bucket_website_endpoint}"
+  origin_domain_name     = module.origin.s3_bucket_website_endpoint
   origin_protocol_policy = "http-only"
   viewer_protocol_policy = "redirect-to-https"
-  parent_zone_name       = "${var.domain_name}"
+  parent_zone_name       = var.domain_name
   forward_cookies        = "none"
   forward_headers        = ["Origin", "Access-Control-Request-Headers", "Access-Control-Request-Method"]
   default_ttl            = 60
@@ -84,5 +84,5 @@ module "cdn" {
   allowed_methods        = ["GET", "HEAD", "OPTIONS"]
   price_class            = "PriceClass_All"
   default_root_object    = "index.html"
-  acm_certificate_arn    = "${data.aws_acm_certificate.acm_cloudfront_certificate.arn}"
+  acm_certificate_arn    = data.aws_acm_certificate.acm_cloudfront_certificate.arn
 }

--- a/deprecated/aws/artifacts/outputs.tf
+++ b/deprecated/aws/artifacts/outputs.tf
@@ -1,94 +1,94 @@
 output "artifacts_user_name" {
-  value       = "${module.artifacts_user.user_name}"
+  value       = module.artifacts_user.user_name
   description = "Normalized IAM user name"
 }
 
 output "artifacts_user_arn" {
-  value       = "${module.artifacts_user.user_arn}"
+  value       = module.artifacts_user.user_arn
   description = "The ARN assigned by AWS for the user"
 }
 
 output "artifacts_user_unique_id" {
-  value       = "${module.artifacts_user.user_unique_id}"
+  value       = module.artifacts_user.user_unique_id
   description = "The user unique ID assigned by AWS"
 }
 
 output "artifacts_user_access_key_id" {
-  value       = "${module.artifacts_user.access_key_id}"
+  value       = module.artifacts_user.access_key_id
   description = "The access key ID"
 }
 
 output "artifacts_user_secret_access_key" {
-  value       = "${module.artifacts_user.secret_access_key}"
+  value       = module.artifacts_user.secret_access_key
   description = "The secret access key. This will be written to the state file in plain-text"
 }
 
 output "artifacts_s3_bucket_name" {
-  value       = "${module.origin.s3_bucket_name}"
+  value       = module.origin.s3_bucket_name
   description = "The S3 bucket which serves as the origin for the CDN and S3 website"
 }
 
 output "artifacts_s3_bucket_domain_name" {
-  value       = "${module.origin.s3_bucket_domain_name}"
+  value       = module.origin.s3_bucket_domain_name
   description = "The bucket domain name. Will be of format bucketname.s3.amazonaws.com."
 }
 
 output "artifacts_s3_bucket_arn" {
-  value       = "${module.origin.s3_bucket_arn}"
+  value       = module.origin.s3_bucket_arn
   description = "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname."
 }
 
 output "artifacts_s3_bucket_website_endpoint" {
-  value       = "${module.origin.s3_bucket_website_endpoint}"
+  value       = module.origin.s3_bucket_website_endpoint
   description = "The website endpoint, if the bucket is configured with a website. If not, this will be an empty string."
 }
 
 output "artifacts_s3_bucket_website_domain" {
-  value       = "${module.origin.s3_bucket_website_domain}"
+  value       = module.origin.s3_bucket_website_domain
   description = "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records."
 }
 
 output "artifacts_s3_bucket_hosted_zone_id" {
-  value       = "${module.origin.s3_bucket_hosted_zone_id}"
+  value       = module.origin.s3_bucket_hosted_zone_id
   description = "The Route 53 Hosted Zone ID for this bucket's region."
 }
 
 output "artifacts_cloudfront_id" {
-  value       = "${module.cdn.cf_id}"
+  value       = module.cdn.cf_id
   description = "The identifier for the distribution. For example: EDFDVBD632BHDS5."
 }
 
 output "artifacts_cloudfront_arn" {
-  value       = "${module.cdn.cf_arn}"
+  value       = module.cdn.cf_arn
   description = "The ARN (Amazon Resource Name) for the distribution. For example: arn:aws:cloudfront::123456789012:distribution/EDFDVBD632BHDS5, where 123456789012 is your AWS account ID."
 }
 
 output "artifacts_cloudfront_aliases" {
-  value       = "${module.cdn.cf_aliases}"
+  value       = module.cdn.cf_aliases
   description = "Extra CNAMEs (alternate domain names), if any, for this distribution."
 }
 
 output "artifacts_cloudfront_status" {
-  value       = "${module.cdn.cf_status}"
+  value       = module.cdn.cf_status
   description = "The current status of the distribution. Deployed if the distribution's information is fully propagated throughout the Amazon CloudFront system."
 }
 
 output "artifacts_cloudfront_domain_name" {
-  value       = "${module.cdn.cf_domain_name}"
+  value       = module.cdn.cf_domain_name
   description = "The domain name corresponding to the distribution. For example: d604721fxaaqy9.cloudfront.net."
 }
 
 output "artifacts_cloudfront_etag" {
-  value       = "${module.cdn.cf_etag}"
+  value       = module.cdn.cf_etag
   description = "The current version of the distribution's information. For example: E2QWRUHAPOMQZL."
 }
 
 output "artifacts_cloudfront_hosted_zone_id" {
-  value       = "${module.cdn.cf_hosted_zone_id}"
+  value       = module.cdn.cf_hosted_zone_id
   description = "The CloudFront Route 53 zone ID that can be used to route an Alias Resource Record Set to. This attribute is simply an alias for the zone ID Z2FDTNDATAQYW2."
 }
 
 output "artifacts_cloudfront_origin_access_identity_path" {
-  value       = "${module.cdn.cf_origin_access_identity}"
+  value       = module.cdn.cf_origin_access_identity
   description = "The CloudFront origin access identity to associate with the origin."
 }

--- a/deprecated/aws/artifacts/variables.tf
+++ b/deprecated/aws/artifacts/variables.tf
@@ -1,28 +1,28 @@
 variable "aws_assume_role_arn" {
-  type        = "string"
+  type        = string
   description = "The ARN of the role to assume"
 }
 
 variable "domain_name" {
-  type = "string"
+  type = string
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "region" {
-  type        = "string"
+  type        = string
   description = "AWS region"
 }
 
 variable "aws_account_id" {
-  type        = "string"
+  type        = string
   description = "AWS account ID"
 }

--- a/deprecated/aws/audit-cloudtrail/cloudwatch_logs.tf
+++ b/deprecated/aws/audit-cloudtrail/cloudwatch_logs.tf
@@ -1,11 +1,11 @@
 module "logs" {
   source     = "git::https://github.com/cloudposse/terraform-aws-cloudwatch-logs.git?ref=tags/0.3.0"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
   attributes = ["cloudwatch", "logs"]
 
-  retention_in_days = "${var.cloudwatch_logs_retention_in_days}"
+  retention_in_days = var.cloudwatch_logs_retention_in_days
 
   principals = {
     Service = ["cloudtrail.amazonaws.com"]
@@ -18,16 +18,16 @@ module "logs" {
 
 module "kms_key_logs" {
   source     = "git::https://github.com/cloudposse/terraform-aws-kms-key.git?ref=tags/0.1.3"
-  namespace  = "${var.namespace}"
-  name       = "${var.name}"
-  stage      = "${var.stage}"
+  namespace  = var.namespace
+  name       = var.name
+  stage      = var.stage
   attributes = ["cloudwatch", "logs"]
 
   description             = "KMS key for CloudWatch"
   deletion_window_in_days = 10
   enable_key_rotation     = "true"
 
-  policy = "${data.aws_iam_policy_document.kms_key_logs.json}"
+  policy = data.aws_iam_policy_document.kms_key_logs.json
 }
 
 data "aws_iam_policy_document" "kms_key_logs" {

--- a/deprecated/aws/audit-cloudtrail/main.tf
+++ b/deprecated/aws/audit-cloudtrail/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
@@ -15,35 +15,35 @@ data "aws_caller_identity" "default" {}
 data "aws_region" "default" {}
 
 locals {
-  region = "${length(var.region) > 0 ? var.region : data.aws_region.default.name}"
+  region = length(var.region) > 0 ? var.region : data.aws_region.default.name
 }
 
 module "cloudtrail" {
   source                        = "git::https://github.com/cloudposse/terraform-aws-cloudtrail.git?ref=tags/0.7.1"
-  namespace                     = "${var.namespace}"
-  stage                         = "${var.stage}"
-  name                          = "${var.name}"
+  namespace                     = var.namespace
+  stage                         = var.stage
+  name                          = var.name
   enable_logging                = "true"
   enable_log_file_validation    = "true"
   include_global_service_events = "true"
   is_multi_region_trail         = "true"
-  s3_bucket_name                = "${module.cloudtrail_s3_bucket.bucket_id}"
-  kms_key_arn                   = "${module.kms_key_cloudtrail.alias_arn}"
-  cloud_watch_logs_group_arn    = "${module.logs.log_group_arn}"
-  cloud_watch_logs_role_arn     = "${module.logs.role_arn}"
+  s3_bucket_name                = module.cloudtrail_s3_bucket.bucket_id
+  kms_key_arn                   = module.kms_key_cloudtrail.alias_arn
+  cloud_watch_logs_group_arn    = module.logs.log_group_arn
+  cloud_watch_logs_role_arn     = module.logs.role_arn
 }
 
 module "kms_key_cloudtrail" {
   source    = "git::https://github.com/cloudposse/terraform-aws-kms-key.git?ref=tags/0.1.3"
-  namespace = "${var.namespace}"
-  name      = "${var.name}"
-  stage     = "${var.stage}"
+  namespace = var.namespace
+  name      = var.name
+  stage     = var.stage
 
   description             = "KMS key for CloudTrail"
   deletion_window_in_days = 10
   enable_key_rotation     = "true"
 
-  policy = "${data.aws_iam_policy_document.kms_key_cloudtrail.json}"
+  policy = data.aws_iam_policy_document.kms_key_cloudtrail.json
 }
 
 data "aws_iam_policy_document" "kms_key_cloudtrail" {

--- a/deprecated/aws/audit-cloudtrail/output.tf
+++ b/deprecated/aws/audit-cloudtrail/output.tf
@@ -1,15 +1,15 @@
 output "cloudtrail_kms_key_arn" {
-  value = "${module.kms_key_cloudtrail.alias_arn}"
+  value = module.kms_key_cloudtrail.alias_arn
 }
 
 output "cloudtrail_bucket_domain_name" {
-  value = "${module.cloudtrail_s3_bucket.bucket_domain_name}"
+  value = module.cloudtrail_s3_bucket.bucket_domain_name
 }
 
 output "cloudtrail_bucket_id" {
-  value = "${module.cloudtrail_s3_bucket.bucket_id}"
+  value = module.cloudtrail_s3_bucket.bucket_id
 }
 
 output "cloudtrail_bucket_arn" {
-  value = "${module.cloudtrail_s3_bucket.bucket_arn}"
+  value = module.cloudtrail_s3_bucket.bucket_arn
 }

--- a/deprecated/aws/audit-cloudtrail/s3_bucket.tf
+++ b/deprecated/aws/audit-cloudtrail/s3_bucket.tf
@@ -1,21 +1,21 @@
 module "cloudtrail_s3_bucket" {
   source             = "git::https://github.com/cloudposse/terraform-aws-cloudtrail-s3-bucket.git?ref=tags/0.3.2"
-  namespace          = "${var.namespace}"
-  stage              = "${var.stage}"
-  name               = "${var.name}"
-  region             = "${local.region}"
+  namespace          = var.namespace
+  stage              = var.stage
+  name               = var.name
+  region             = local.region
   sse_algorithm      = "aws:kms"
-  kms_master_key_arn = "${module.kms_key_s3_bucket.alias_arn}"
+  kms_master_key_arn = module.kms_key_s3_bucket.alias_arn
 
   access_logs_sse_algorithm      = "aws:kms"
-  access_logs_kms_master_key_arn = "${module.kms_key_s3_bucket_logs.alias_arn}"
+  access_logs_kms_master_key_arn = module.kms_key_s3_bucket_logs.alias_arn
 }
 
 module "kms_key_s3_bucket" {
   source    = "git::https://github.com/cloudposse/terraform-aws-kms-key.git?ref=tags/0.1.3"
-  namespace = "${var.namespace}"
-  name      = "${var.name}"
-  stage     = "${var.stage}"
+  namespace = var.namespace
+  name      = var.name
+  stage     = var.stage
 
   attributes = ["cloudtrail", "s3", "bucket"]
 
@@ -26,9 +26,9 @@ module "kms_key_s3_bucket" {
 
 module "kms_key_s3_bucket_logs" {
   source    = "git::https://github.com/cloudposse/terraform-aws-kms-key.git?ref=tags/0.1.3"
-  namespace = "${var.namespace}"
-  name      = "${var.name}"
-  stage     = "${var.stage}"
+  namespace = var.namespace
+  name      = var.name
+  stage     = var.stage
 
   attributes = ["cloudtrail", "s3", "bucket", "logs"]
 

--- a/deprecated/aws/audit-cloudtrail/varaibles.tf
+++ b/deprecated/aws/audit-cloudtrail/varaibles.tf
@@ -1,26 +1,26 @@
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `audit`)"
   default     = "audit"
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   description = "Name (e.g. `account`)"
   default     = "account"
 }
 
 variable "region" {
-  type        = "string"
+  type        = string
   description = "AWS region"
   default     = ""
 }

--- a/deprecated/aws/aws-metrics-role/main.tf
+++ b/deprecated/aws/aws-metrics-role/main.tf
@@ -57,8 +57,8 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "default" {
-  role       = "${aws_iam_role.default.name}"
-  policy_arn = "${aws_iam_policy.default.arn}"
+  role       = aws_iam_role.default.name
+  policy_arn = aws_iam_policy.default.arn
 
   lifecycle {
     create_before_destroy = true
@@ -66,9 +66,9 @@ resource "aws_iam_role_policy_attachment" "default" {
 }
 
 resource "aws_iam_policy" "default" {
-  name        = "${module.label.id}"
+  name        = module.label.id
   description = "Grant permissions for external-dns"
-  policy      = "${data.aws_iam_policy_document.default.json}"
+  policy      = data.aws_iam_policy_document.default.json
 }
 
 data "aws_iam_policy_document" "default" {

--- a/deprecated/aws/aws-metrics-role/variables.tf
+++ b/deprecated/aws/aws-metrics-role/variables.tf
@@ -43,7 +43,7 @@ variable "kops_cluster_name" {
 }
 
 variable "assume_role_permitted_roles" {
-  type        = "string"
+  type        = string
   description = "Roles that are permitted to assume thie role. One of 'kiam', 'nodes', 'masters', or 'both' (nodes + masters)."
   default     = "kiam"
 }

--- a/deprecated/aws/backing-services/aurora-mysql.tf
+++ b/deprecated/aws/backing-services/aurora-mysql.tf
@@ -1,44 +1,44 @@
 # https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html
 
 variable "mysql_name" {
-  type        = "string"
+  type        = string
   description = "Name of the application, e.g. `app` or `analytics`"
   default     = "mysql"
 }
 
 variable "mysql_admin_user" {
-  type        = "string"
+  type        = string
   description = "MySQL admin user name"
   default     = ""
 }
 
 variable "mysql_admin_password" {
-  type        = "string"
+  type        = string
   description = "MySQL password for the admin user"
   default     = ""
 }
 
 variable "mysql_db_name" {
-  type        = "string"
+  type        = string
   description = "MySQL database name"
   default     = ""
 }
 
 # https://aws.amazon.com/rds/aurora/pricing
 variable "mysql_instance_type" {
-  type        = "string"
+  type        = string
   default     = "db.t2.small"
   description = "EC2 instance type for Aurora MySQL cluster"
 }
 
 variable "mysql_cluster_size" {
-  type        = "string"
+  type        = string
   default     = "2"
   description = "MySQL cluster size"
 }
 
 variable "mysql_cluster_enabled" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Set to false to prevent the module from creating any resources"
 }
@@ -49,134 +49,134 @@ variable "mysql_cluster_publicly_accessible" {
 }
 
 variable "mysql_cluster_allowed_cidr_blocks" {
-  type        = "list"
+  type        = list(string)
   default     = ["0.0.0.0/0"]
   description = "List of CIDR blocks allowed to access the cluster"
 }
 
 resource "random_pet" "mysql_db_name" {
-  count     = "${local.mysql_cluster_enabled ? 1 : 0}"
+  count     = local.mysql_cluster_enabled ? 1 : 0
   separator = "_"
 }
 
 resource "random_string" "mysql_admin_user" {
-  count   = "${local.mysql_cluster_enabled ? 1 : 0}"
+  count   = local.mysql_cluster_enabled ? 1 : 0
   length  = 8
   number  = false
   special = false
 }
 
 resource "random_string" "mysql_admin_password" {
-  count   = "${local.mysql_cluster_enabled ? 1 : 0}"
+  count   = local.mysql_cluster_enabled ? 1 : 0
   length  = 16
   special = true
 }
 
 locals {
-  mysql_cluster_enabled = "${var.mysql_cluster_enabled == "true"}"
-  mysql_admin_user      = "${length(var.mysql_admin_user) > 0 ? var.mysql_admin_user : join("", random_string.mysql_admin_user.*.result)}"
-  mysql_admin_password  = "${length(var.mysql_admin_password) > 0 ? var.mysql_admin_password : join("", random_string.mysql_admin_password.*.result)}"
-  mysql_db_name         = "${join("", random_pet.mysql_db_name.*.id)}"
+  mysql_cluster_enabled = var.mysql_cluster_enabled == "true"
+  mysql_admin_user      = length(var.mysql_admin_user) > 0 ? var.mysql_admin_user : join("", random_string.mysql_admin_user.*.result)
+  mysql_admin_password  = length(var.mysql_admin_password) > 0 ? var.mysql_admin_password : join("", random_string.mysql_admin_password.*.result)
+  mysql_db_name         = join("", random_pet.mysql_db_name.*.id)
 }
 
 module "aurora_mysql" {
   source         = "git::https://github.com/cloudposse/terraform-aws-rds-cluster.git?ref=tags/0.8.0"
-  namespace      = "${var.namespace}"
-  stage          = "${var.stage}"
-  name           = "${var.mysql_name}"
+  namespace      = var.namespace
+  stage          = var.stage
+  name           = var.mysql_name
   engine         = "aurora-mysql"
   cluster_family = "aurora-mysql5.7"
-  instance_type  = "${var.mysql_instance_type}"
-  cluster_size   = "${var.mysql_cluster_size}"
-  admin_user     = "${local.mysql_admin_user}"
-  admin_password = "${local.mysql_admin_password}"
-  db_name        = "${local.mysql_db_name}"
+  instance_type  = var.mysql_instance_type
+  cluster_size   = var.mysql_cluster_size
+  admin_user     = local.mysql_admin_user
+  admin_password = local.mysql_admin_password
+  db_name        = local.mysql_db_name
   db_port        = "3306"
-  vpc_id         = "${module.vpc.vpc_id}"
+  vpc_id         = module.vpc.vpc_id
 
   # Use module.subnets.private_subnet_ids if the cluster does not need to be publicly accessible
   subnets             = ["${module.subnets.public_subnet_ids}"]
-  zone_id             = "${local.zone_id}"
-  enabled             = "${var.mysql_cluster_enabled}"
-  publicly_accessible = "${var.mysql_cluster_publicly_accessible}"
-  allowed_cidr_blocks = "${var.mysql_cluster_allowed_cidr_blocks}"
+  zone_id             = local.zone_id
+  enabled             = var.mysql_cluster_enabled
+  publicly_accessible = var.mysql_cluster_publicly_accessible
+  allowed_cidr_blocks = var.mysql_cluster_allowed_cidr_blocks
 }
 
 resource "aws_ssm_parameter" "aurora_mysql_database_name" {
-  count       = "${local.mysql_cluster_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "aurora_mysql_database_name")}"
-  value       = "${module.aurora_mysql.name}"
+  count       = local.mysql_cluster_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, "aurora_mysql_database_name")
+  value       = module.aurora_mysql.name
   description = "Aurora MySQL Database Name"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "aurora_mysql_master_username" {
-  count       = "${local.mysql_cluster_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "aurora_mysql_master_username")}"
-  value       = "${module.aurora_mysql.user}"
+  count       = local.mysql_cluster_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, "aurora_mysql_master_username")
+  value       = module.aurora_mysql.user
   description = "Aurora MySQL Username for the master DB user"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "aurora_mysql_master_password" {
-  count       = "${local.mysql_cluster_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "aurora_mysql_master_password")}"
-  value       = "${module.aurora_mysql.password}"
+  count       = local.mysql_cluster_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, "aurora_mysql_master_password")
+  value       = module.aurora_mysql.password
   description = "Aurora MySQL Password for the master DB user"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "aurora_mysql_master_hostname" {
-  count       = "${local.mysql_cluster_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "aurora_mysql_master_hostname")}"
-  value       = "${module.aurora_mysql.master_host}"
+  count       = local.mysql_cluster_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, "aurora_mysql_master_hostname")
+  value       = module.aurora_mysql.master_host
   description = "Aurora MySQL DB Master hostname"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "aurora_mysql_replicas_hostname" {
-  count       = "${local.mysql_cluster_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "aurora_mysql_replicas_hostname")}"
-  value       = "${module.aurora_mysql.replicas_host}"
+  count       = local.mysql_cluster_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, "aurora_mysql_replicas_hostname")
+  value       = module.aurora_mysql.replicas_host
   description = "Aurora MySQL DB Replicas hostname"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "aurora_mysql_cluster_name" {
-  count       = "${local.mysql_cluster_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "aurora_mysql_cluster_name")}"
-  value       = "${module.aurora_mysql.cluster_name}"
+  count       = local.mysql_cluster_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, "aurora_mysql_cluster_name")
+  value       = module.aurora_mysql.cluster_name
   description = "Aurora MySQL DB Cluster Identifier"
   type        = "String"
   overwrite   = "true"
 }
 
 output "aurora_mysql_database_name" {
-  value       = "${module.aurora_mysql.name}"
+  value       = module.aurora_mysql.name
   description = "Aurora MySQL Database name"
 }
 
 output "aurora_mysql_master_username" {
-  value       = "${module.aurora_mysql.user}"
+  value       = module.aurora_mysql.user
   description = "Aurora MySQL Username for the master DB user"
 }
 
 output "aurora_mysql_master_hostname" {
-  value       = "${module.aurora_mysql.master_host}"
+  value       = module.aurora_mysql.master_host
   description = "Aurora MySQL DB Master hostname"
 }
 
 output "aurora_mysql_replicas_hostname" {
-  value       = "${module.aurora_mysql.replicas_host}"
+  value       = module.aurora_mysql.replicas_host
   description = "Aurora MySQL Replicas hostname"
 }
 
 output "aurora_mysql_cluster_name" {
-  value       = "${module.aurora_mysql.cluster_name}"
+  value       = module.aurora_mysql.cluster_name
   description = "Aurora MySQL Cluster Identifier"
 }

--- a/deprecated/aws/backing-services/aurora-postgres-replica.tf
+++ b/deprecated/aws/backing-services/aurora-postgres-replica.tf
@@ -1,5 +1,5 @@
 variable "postgres_replica_name" {
-  type        = "string"
+  type        = string
   description = "Name of the replica, e.g. `postgres` or `reporting`"
   default     = "postgres"
 }
@@ -7,75 +7,75 @@ variable "postgres_replica_name" {
 # db.r4.large is the smallest instance type supported by Aurora Postgres
 # https://aws.amazon.com/rds/aurora/pricing
 variable "postgres_replica_instance_type" {
-  type        = "string"
+  type        = string
   default     = "db.r4.large"
   description = "EC2 instance type for Postgres cluster"
 }
 
 variable "postgres_replica_cluster_size" {
-  type        = "string"
+  type        = string
   default     = "2"
   description = "Postgres cluster size"
 }
 
 variable "postgres_replica_enabled" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Set to false to prevent the module from creating any resources"
 }
 
 variable "postgres_replica_cluster_identifier" {
-  type        = "string"
+  type        = string
   description = "The cluster identifier"
   default     = ""
 }
 
 locals {
-  postgres_replica_enabled = "${var.postgres_replica_enabled == "true"}"
+  postgres_replica_enabled = var.postgres_replica_enabled == "true"
 }
 
 module "postgres_replica" {
   source             = "git::https://github.com/cloudposse/terraform-aws-rds-cluster-instance-group.git?ref=tags/0.1.0"
-  enabled            = "${var.postgres_replica_enabled}"
-  namespace          = "${var.namespace}"
-  stage              = "${var.stage}"
-  name               = "${var.postgres_replica_name}"
-  cluster_identifier = "${var.postgres_replica_cluster_identifier}"
+  enabled            = var.postgres_replica_enabled
+  namespace          = var.namespace
+  stage              = var.stage
+  name               = var.postgres_replica_name
+  cluster_identifier = var.postgres_replica_cluster_identifier
   cluster_family     = "aurora-postgresql9.6"
   engine             = "aurora-postgresql"
-  instance_type      = "${var.postgres_replica_instance_type}"
-  cluster_size       = "${var.postgres_replica_cluster_size}"
+  instance_type      = var.postgres_replica_instance_type
+  cluster_size       = var.postgres_replica_cluster_size
   db_port            = "5432"
-  vpc_id             = "${module.vpc.vpc_id}"
+  vpc_id             = module.vpc.vpc_id
   subnets            = ["${module.subnets.private_subnet_ids}"]
-  zone_id            = "${local.zone_id}"
+  zone_id            = local.zone_id
   security_groups    = ["${module.kops_metadata.nodes_security_group_id}"]
 }
 
 resource "aws_ssm_parameter" "postgres_replica_hostname" {
-  count       = "${local.postgres_replica_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "postgres_replica_hostname")}"
-  value       = "${module.postgres_replica.hostname}"
+  count       = local.postgres_replica_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, "postgres_replica_hostname")
+  value       = module.postgres_replica.hostname
   description = "RDS Cluster replica hostname"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "postgres_replica_endpoint" {
-  count       = "${local.postgres_replica_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "postgres_replica_endpoint")}"
-  value       = "${module.postgres_replica.endpoint}"
+  count       = local.postgres_replica_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, "postgres_replica_endpoint")
+  value       = module.postgres_replica.endpoint
   description = "RDS Cluster Replicas hostname"
   type        = "String"
   overwrite   = "true"
 }
 
 output "postgres_replica_hostname" {
-  value       = "${module.postgres_replica.hostname}"
+  value       = module.postgres_replica.hostname
   description = "RDS Cluster replica hostname"
 }
 
 output "postgres_replica_endpoint" {
-  value       = "${module.postgres_replica.endpoint}"
+  value       = module.postgres_replica.endpoint
   description = "RDS Cluster replica endpoint"
 }

--- a/deprecated/aws/backing-services/aurora-postgres.tf
+++ b/deprecated/aws/backing-services/aurora-postgres.tf
@@ -1,5 +1,5 @@
 variable "postgres_name" {
-  type        = "string"
+  type        = string
   description = "Name of the application, e.g. `app` or `analytics`"
   default     = "postgres"
 }
@@ -8,7 +8,7 @@ variable "postgres_name" {
 # Read more: <https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html>
 # ("MasterUsername admin cannot be used as it is a reserved word used by the engine")
 variable "postgres_admin_user" {
-  type        = "string"
+  type        = string
   description = "Postgres admin user name"
   default     = ""
 }
@@ -17,13 +17,13 @@ variable "postgres_admin_user" {
 # Read more: <https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html>
 # ("The parameter MasterUserPassword is not a valid password because it is shorter than 8 characters")
 variable "postgres_admin_password" {
-  type        = "string"
+  type        = string
   description = "Postgres password for the admin user"
   default     = ""
 }
 
 variable "postgres_db_name" {
-  type        = "string"
+  type        = string
   description = "Postgres database name"
   default     = ""
 }
@@ -31,151 +31,151 @@ variable "postgres_db_name" {
 # db.r4.large is the smallest instance type supported by Aurora Postgres
 # https://aws.amazon.com/rds/aurora/pricing
 variable "postgres_instance_type" {
-  type        = "string"
+  type        = string
   default     = "db.r4.large"
   description = "EC2 instance type for Postgres cluster"
 }
 
 variable "postgres_cluster_size" {
-  type        = "string"
+  type        = string
   default     = "2"
   description = "Postgres cluster size"
 }
 
 variable "postgres_cluster_enabled" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Set to false to prevent the module from creating any resources"
 }
 
 variable "postgres_iam_database_authentication_enabled" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled."
 }
 
 resource "random_pet" "postgres_db_name" {
-  count     = "${local.postgres_cluster_enabled ? 1 : 0}"
+  count     = local.postgres_cluster_enabled ? 1 : 0
   separator = "_"
 }
 
 resource "random_string" "postgres_admin_user" {
-  count   = "${local.postgres_cluster_enabled ? 1 : 0}"
+  count   = local.postgres_cluster_enabled ? 1 : 0
   length  = 8
   special = false
   number  = false
 }
 
 resource "random_string" "postgres_admin_password" {
-  count   = "${local.postgres_cluster_enabled ? 1 : 0}"
+  count   = local.postgres_cluster_enabled ? 1 : 0
   length  = 16
   special = true
 }
 
 locals {
-  postgres_cluster_enabled = "${var.postgres_cluster_enabled == "true"}"
-  postgres_admin_user      = "${length(var.postgres_admin_user) > 0 ? var.postgres_admin_user : join("", random_string.postgres_admin_user.*.result)}"
-  postgres_admin_password  = "${length(var.postgres_admin_password) > 0 ? var.postgres_admin_password : join("", random_string.postgres_admin_password.*.result)}"
-  postgres_db_name         = "${join("", random_pet.postgres_db_name.*.id)}"
+  postgres_cluster_enabled = var.postgres_cluster_enabled == "true"
+  postgres_admin_user      = length(var.postgres_admin_user) > 0 ? var.postgres_admin_user : join("", random_string.postgres_admin_user.*.result)
+  postgres_admin_password  = length(var.postgres_admin_password) > 0 ? var.postgres_admin_password : join("", random_string.postgres_admin_password.*.result)
+  postgres_db_name         = join("", random_pet.postgres_db_name.*.id)
 }
 
 module "aurora_postgres" {
   source          = "git::https://github.com/cloudposse/terraform-aws-rds-cluster.git?ref=tags/0.8.0"
-  namespace       = "${var.namespace}"
-  stage           = "${var.stage}"
-  name            = "${var.postgres_name}"
+  namespace       = var.namespace
+  stage           = var.stage
+  name            = var.postgres_name
   engine          = "aurora-postgresql"
   cluster_family  = "aurora-postgresql9.6"
-  instance_type   = "${var.postgres_instance_type}"
-  cluster_size    = "${var.postgres_cluster_size}"
-  admin_user      = "${local.postgres_admin_user}"
-  admin_password  = "${local.postgres_admin_password}"
-  db_name         = "${local.postgres_db_name}"
+  instance_type   = var.postgres_instance_type
+  cluster_size    = var.postgres_cluster_size
+  admin_user      = local.postgres_admin_user
+  admin_password  = local.postgres_admin_password
+  db_name         = local.postgres_db_name
   db_port         = "5432"
-  vpc_id          = "${module.vpc.vpc_id}"
+  vpc_id          = module.vpc.vpc_id
   subnets         = ["${module.subnets.private_subnet_ids}"]
-  zone_id         = "${local.zone_id}"
+  zone_id         = local.zone_id
   security_groups = ["${module.kops_metadata.nodes_security_group_id}"]
-  enabled         = "${var.postgres_cluster_enabled}"
+  enabled         = var.postgres_cluster_enabled
 
-  iam_database_authentication_enabled = "${var.postgres_iam_database_authentication_enabled}"
+  iam_database_authentication_enabled = var.postgres_iam_database_authentication_enabled
 }
 
 resource "aws_ssm_parameter" "aurora_postgres_database_name" {
-  count       = "${local.postgres_cluster_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "aurora_postgres_database_name")}"
-  value       = "${module.aurora_postgres.name}"
+  count       = local.postgres_cluster_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, "aurora_postgres_database_name")
+  value       = module.aurora_postgres.name
   description = "Aurora Postgres Database Name"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "aurora_postgres_master_username" {
-  count       = "${local.postgres_cluster_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "aurora_postgres_master_username")}"
-  value       = "${module.aurora_postgres.user}"
+  count       = local.postgres_cluster_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, "aurora_postgres_master_username")
+  value       = module.aurora_postgres.user
   description = "Aurora Postgres Username for the master DB user"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "aurora_postgres_master_password" {
-  count       = "${local.postgres_cluster_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "aurora_postgres_master_password")}"
-  value       = "${module.aurora_postgres.password}"
+  count       = local.postgres_cluster_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, "aurora_postgres_master_password")
+  value       = module.aurora_postgres.password
   description = "Aurora Postgres Password for the master DB user"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "aurora_postgres_master_hostname" {
-  count       = "${local.postgres_cluster_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "aurora_postgres_master_hostname")}"
-  value       = "${module.aurora_postgres.master_host}"
+  count       = local.postgres_cluster_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, "aurora_postgres_master_hostname")
+  value       = module.aurora_postgres.master_host
   description = "Aurora Postgres DB Master hostname"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "aurora_postgres_replicas_hostname" {
-  count       = "${local.postgres_cluster_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "aurora_postgres_replicas_hostname")}"
-  value       = "${module.aurora_postgres.replicas_host}"
+  count       = local.postgres_cluster_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, "aurora_postgres_replicas_hostname")
+  value       = module.aurora_postgres.replicas_host
   description = "Aurora Postgres DB Replicas hostname"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "aurora_postgres_cluster_name" {
-  count       = "${local.postgres_cluster_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "aurora_postgres_cluster_name")}"
-  value       = "${module.aurora_postgres.cluster_name}"
+  count       = local.postgres_cluster_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, "aurora_postgres_cluster_name")
+  value       = module.aurora_postgres.cluster_name
   description = "Aurora Postgres DB Cluster Identifier"
   type        = "String"
   overwrite   = "true"
 }
 
 output "aurora_postgres_database_name" {
-  value       = "${module.aurora_postgres.name}"
+  value       = module.aurora_postgres.name
   description = "Aurora Postgres Database name"
 }
 
 output "aurora_postgres_master_username" {
-  value       = "${module.aurora_postgres.user}"
+  value       = module.aurora_postgres.user
   description = "Aurora Postgres Username for the master DB user"
 }
 
 output "aurora_postgres_master_hostname" {
-  value       = "${module.aurora_postgres.master_host}"
+  value       = module.aurora_postgres.master_host
   description = "Aurora Postgres DB Master hostname"
 }
 
 output "aurora_postgres_replicas_hostname" {
-  value       = "${module.aurora_postgres.replicas_host}"
+  value       = module.aurora_postgres.replicas_host
   description = "Aurora Postgres Replicas hostname"
 }
 
 output "aurora_postgres_cluster_name" {
-  value       = "${module.aurora_postgres.cluster_name}"
+  value       = module.aurora_postgres.cluster_name
   description = "Aurora Postgres Cluster Identifier"
 }

--- a/deprecated/aws/backing-services/elasticache-redis.tf
+++ b/deprecated/aws/backing-services/elasticache-redis.tf
@@ -1,58 +1,58 @@
 variable "redis_name" {
-  type        = "string"
+  type        = string
   default     = "redis"
   description = "Redis name"
 }
 
 variable "redis_instance_type" {
-  type        = "string"
+  type        = string
   default     = "cache.t2.medium"
   description = "EC2 instance type for Redis cluster"
 }
 
 variable "redis_cluster_size" {
-  type        = "string"
+  type        = string
   default     = "2"
   description = "Redis cluster size"
 }
 
 variable "redis_cluster_enabled" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Set to false to prevent the module from creating any resources"
 }
 
 variable "redis_auth_token" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Auth token for password protecting redis, transit_encryption_enabled must be set to 'true'! Password must be longer than 16 chars"
 }
 
 variable "redis_transit_encryption_enabled" {
-  type        = "string"
+  type        = string
   default     = "true"
   description = "Enable TLS"
 }
 
 variable "redis_params" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "A list of Redis parameters to apply. Note that parameters may differ from a Redis family to another"
 }
 
 module "elasticache_redis" {
   source                       = "git::https://github.com/cloudposse/terraform-aws-elasticache-redis.git?ref=tags/0.7.1"
-  namespace                    = "${var.namespace}"
-  stage                        = "${var.stage}"
-  name                         = "${var.redis_name}"
-  zone_id                      = "${local.zone_id}"
+  namespace                    = var.namespace
+  stage                        = var.stage
+  name                         = var.redis_name
+  zone_id                      = local.zone_id
   security_groups              = ["${module.kops_metadata.nodes_security_group_id}"]
-  vpc_id                       = "${module.vpc.vpc_id}"
+  vpc_id                       = module.vpc.vpc_id
   subnets                      = ["${module.subnets.private_subnet_ids}"]
   maintenance_window           = "sun:03:00-sun:04:00"
-  cluster_size                 = "${var.redis_cluster_size}"
-  instance_type                = "${var.redis_instance_type}"
-  transit_encryption_enabled   = "${var.redis_transit_encryption_enabled}"
+  cluster_size                 = var.redis_cluster_size
+  instance_type                = var.redis_instance_type
+  transit_encryption_enabled   = var.redis_transit_encryption_enabled
   engine_version               = "3.2.6"
   family                       = "redis3.2"
   port                         = "6379"
@@ -61,20 +61,20 @@ module "elasticache_redis" {
   apply_immediately            = "true"
   availability_zones           = ["${local.availability_zones}"]
   automatic_failover           = "false"
-  enabled                      = "${var.redis_cluster_enabled}"
-  auth_token                   = "${var.redis_auth_token}"
+  enabled                      = var.redis_cluster_enabled
+  auth_token                   = var.redis_auth_token
 
-  parameter = "${var.redis_params}"
+  parameter = var.redis_params
 }
 
 output "elasticache_redis_id" {
-  value = "${module.elasticache_redis.id}"
+  value = module.elasticache_redis.id
 }
 
 output "elasticache_redis_security_group_id" {
-  value = "${module.elasticache_redis.security_group_id}"
+  value = module.elasticache_redis.security_group_id
 }
 
 output "elasticache_redis_host" {
-  value = "${module.elasticache_redis.host}"
+  value = module.elasticache_redis.host
 }

--- a/deprecated/aws/backing-services/elasticsearch.tf
+++ b/deprecated/aws/backing-services/elasticsearch.tf
@@ -1,18 +1,18 @@
 variable "elasticsearch_name" {
-  type        = "string"
+  type        = string
   default     = "elasticsearch"
   description = "Elasticsearch cluster name"
 }
 
 variable "elasticsearch_version" {
-  type        = "string"
+  type        = string
   default     = "6.2"
   description = "Version of Elasticsearch to deploy"
 }
 
 # Encryption at rest is not supported with t2.small.elasticsearch instances
 variable "elasticsearch_encrypt_at_rest_enabled" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Whether to enable encryption at rest"
 }
@@ -24,7 +24,7 @@ variable "elasticsearch_ebs_volume_size" {
 }
 
 variable "elasticsearch_instance_type" {
-  type        = "string"
+  type        = string
   default     = "t2.small.elasticsearch"
   description = "Elasticsearch instance type for data nodes in the cluster"
 }
@@ -36,19 +36,19 @@ variable "elasticsearch_instance_count" {
 
 # https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-ac.html
 variable "elasticsearch_iam_actions" {
-  type        = "list"
+  type        = list(string)
   default     = ["es:ESHttpGet", "es:ESHttpPut", "es:ESHttpPost", "es:ESHttpHead", "es:Describe*", "es:List*"]
   description = "List of actions to allow for the IAM roles, _e.g._ `es:ESHttpGet`, `es:ESHttpPut`, `es:ESHttpPost`"
 }
 
 variable "elasticsearch_enabled" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Set to false to prevent the module from creating any resources"
 }
 
 variable "elasticsearch_permitted_nodes" {
-  type        = "string"
+  type        = string
   description = "Kops kubernetes nodes that are permitted to access elastic search (e.g. 'nodes', 'masters', 'both' or 'any')"
   default     = "nodes"
 }
@@ -71,23 +71,23 @@ locals {
 
 module "elasticsearch" {
   source                  = "git::https://github.com/cloudposse/terraform-aws-elasticsearch.git?ref=tags/0.1.5"
-  namespace               = "${var.namespace}"
-  stage                   = "${var.stage}"
-  name                    = "${var.elasticsearch_name}"
-  dns_zone_id             = "${local.zone_id}"
+  namespace               = var.namespace
+  stage                   = var.stage
+  name                    = var.elasticsearch_name
+  dns_zone_id             = local.zone_id
   security_groups         = ["${local.security_groups[var.elasticsearch_permitted_nodes]}"]
-  vpc_id                  = "${module.vpc.vpc_id}"
+  vpc_id                  = module.vpc.vpc_id
   subnet_ids              = ["${slice(module.subnets.private_subnet_ids, 0, min(2, length(module.subnets.private_subnet_ids)))}"]
-  zone_awareness_enabled  = "${length(module.subnets.private_subnet_ids) > 1 ? "true" : "false"}"
-  elasticsearch_version   = "${var.elasticsearch_version}"
-  instance_type           = "${var.elasticsearch_instance_type}"
-  instance_count          = "${var.elasticsearch_instance_count}"
+  zone_awareness_enabled  = length(module.subnets.private_subnet_ids) > 1 ? "true" : "false"
+  elasticsearch_version   = var.elasticsearch_version
+  instance_type           = var.elasticsearch_instance_type
+  instance_count          = var.elasticsearch_instance_count
   iam_role_arns           = ["${local.role_arns[var.elasticsearch_permitted_nodes]}"]
   iam_actions             = ["${var.elasticsearch_iam_actions}"]
   kibana_subdomain_name   = "kibana-elasticsearch"
-  ebs_volume_size         = "${var.elasticsearch_ebs_volume_size}"
-  encrypt_at_rest_enabled = "${var.elasticsearch_encrypt_at_rest_enabled}"
-  enabled                 = "${var.elasticsearch_enabled}"
+  ebs_volume_size         = var.elasticsearch_ebs_volume_size
+  encrypt_at_rest_enabled = var.elasticsearch_encrypt_at_rest_enabled
+  enabled                 = var.elasticsearch_enabled
 
   advanced_options = {
     "rest.action.multi.allow_explicit_index" = "true"
@@ -95,36 +95,36 @@ module "elasticsearch" {
 }
 
 output "elasticsearch_security_group_id" {
-  value       = "${module.elasticsearch.security_group_id}"
+  value       = module.elasticsearch.security_group_id
   description = "Security Group ID to control access to the Elasticsearch domain"
 }
 
 output "elasticsearch_domain_arn" {
-  value       = "${module.elasticsearch.domain_arn}"
+  value       = module.elasticsearch.domain_arn
   description = "ARN of the Elasticsearch domain"
 }
 
 output "elasticsearch_domain_id" {
-  value       = "${module.elasticsearch.domain_id}"
+  value       = module.elasticsearch.domain_id
   description = "Unique identifier for the Elasticsearch domain"
 }
 
 output "elasticsearch_domain_endpoint" {
-  value       = "${module.elasticsearch.domain_endpoint}"
+  value       = module.elasticsearch.domain_endpoint
   description = "Domain-specific endpoint used to submit index, search, and data upload requests"
 }
 
 output "elasticsearch_kibana_endpoint" {
-  value       = "${module.elasticsearch.kibana_endpoint}"
+  value       = module.elasticsearch.kibana_endpoint
   description = "Domain-specific endpoint for Kibana without https scheme"
 }
 
 output "elasticsearch_domain_hostname" {
-  value       = "${module.elasticsearch.domain_hostname}"
+  value       = module.elasticsearch.domain_hostname
   description = "Elasticsearch domain hostname to submit index, search, and data upload requests"
 }
 
 output "elasticsearch_kibana_hostname" {
-  value       = "${module.elasticsearch.kibana_hostname}"
+  value       = module.elasticsearch.kibana_hostname
   description = "Kibana hostname"
 }

--- a/deprecated/aws/backing-services/flow-logs.tf
+++ b/deprecated/aws/backing-services/flow-logs.tf
@@ -1,64 +1,64 @@
 variable "flow_logs_enabled" {
-  type    = "string"
+  type    = string
   default = "true"
 }
 
 module "flow_logs" {
   source = "git::https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket.git?ref=tags/0.1.0"
 
-  name       = "${local.name}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  attributes = "${list("flow-logs")}"
+  name       = local.name
+  namespace  = var.namespace
+  stage      = var.stage
+  attributes = list("flow-logs")
 
-  region = "${var.region}"
+  region = var.region
 
-  enabled = "${var.flow_logs_enabled}"
+  enabled = var.flow_logs_enabled
 
-  vpc_id = "${module.vpc.vpc_id}"
+  vpc_id = module.vpc.vpc_id
 }
 
 output "flow_logs_kms_key_arn" {
-  value       = "${module.flow_logs.kms_key_arn}"
+  value       = module.flow_logs.kms_key_arn
   description = "Flow logs KMS Key ARN"
 }
 
 output "flow_logs_kms_key_id" {
-  value       = "${module.flow_logs.kms_key_id}"
+  value       = module.flow_logs.kms_key_id
   description = "Flow logs KMS Key ID"
 }
 
 output "flow_logs_kms_alias_arn" {
-  value       = "${module.flow_logs.kms_alias_arn}"
+  value       = module.flow_logs.kms_alias_arn
   description = "Flow logs KMS Alias ARN"
 }
 
 output "flow_logs_kms_alias_name" {
-  value       = "${module.flow_logs.kms_alias_name}"
+  value       = module.flow_logs.kms_alias_name
   description = "Flow logs KMS Alias name"
 }
 
 output "flow_logs_bucket_domain_name" {
-  value       = "${module.flow_logs.bucket_domain_name}"
+  value       = module.flow_logs.bucket_domain_name
   description = "Flow logs FQDN of bucket"
 }
 
 output "flow_logs_bucket_id" {
-  value       = "${module.flow_logs.bucket_id}"
+  value       = module.flow_logs.bucket_id
   description = "Flow logs bucket Name (aka ID)"
 }
 
 output "flow_logs_bucket_arn" {
-  value       = "${module.flow_logs.bucket_arn}"
+  value       = module.flow_logs.bucket_arn
   description = "Flow logs bucket ARN"
 }
 
 output "flow_logs_bucket_prefix" {
-  value       = "${module.flow_logs.bucket_prefix}"
+  value       = module.flow_logs.bucket_prefix
   description = "Flow logs bucket prefix configured for lifecycle rules"
 }
 
 output "flow_logs_id" {
-  value       = "${module.flow_logs.id}"
+  value       = module.flow_logs.id
   description = "Flow logs ID"
 }

--- a/deprecated/aws/backing-services/kops-metadata.tf
+++ b/deprecated/aws/backing-services/kops-metadata.tf
@@ -1,11 +1,11 @@
 variable "kops_metadata_enabled" {
   description = "Set to false to prevent the module from creating any resources"
-  type        = "string"
+  type        = string
   default     = "false"
 }
 
 module "kops_metadata" {
   source   = "git::https://github.com/cloudposse/terraform-aws-kops-metadata.git?ref=tags/0.2.0"
   dns_zone = "${var.region}.${var.zone_name}"
-  enabled  = "${var.kops_metadata_enabled}"
+  enabled  = var.kops_metadata_enabled
 }

--- a/deprecated/aws/backing-services/main.tf
+++ b/deprecated/aws/backing-services/main.tf
@@ -5,50 +5,50 @@ terraform {
 }
 
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `eg` or `cp`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "region" {
-  type        = "string"
+  type        = string
   description = "AWS region"
 }
 
 variable "availability_zones" {
-  type        = "list"
+  type        = list(string)
   description = "AWS region availability zones to use (e.g.: ['us-west-2a', 'us-west-2b']). If empty will use all available zones"
   default     = []
 }
 
 variable "zone_name" {
-  type        = "string"
+  type        = string
   description = "DNS zone name"
 }
 
 data "aws_availability_zones" "available" {}
 
 data "aws_route53_zone" "default" {
-  name = "${var.zone_name}"
+  name = var.zone_name
 }
 
 locals {
   null               = ""
-  zone_id            = "${data.aws_route53_zone.default.zone_id}"
+  zone_id            = data.aws_route53_zone.default.zone_id
   availability_zones = ["${split(",", length(var.availability_zones) == 0 ? join(",", data.aws_availability_zones.available.names) : join(",", var.availability_zones))}"]
-  chamber_service    = "${var.chamber_service == "" ? basename(pathexpand(path.module)) : var.chamber_service}"
+  chamber_service    = var.chamber_service == "" ? basename(pathexpand(path.module)) : var.chamber_service
 }
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }

--- a/deprecated/aws/backing-services/rds-replica.tf
+++ b/deprecated/aws/backing-services/rds-replica.tf
@@ -1,23 +1,23 @@
 variable "rds_replica_name" {
-  type        = "string"
+  type        = string
   default     = "rds-replica"
   description = "RDS instance name"
 }
 
 variable "rds_replica_enabled" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Set to false to prevent the module from creating any resources"
 }
 
 variable "rds_replica_replicate_source_db" {
-  type        = "string"
+  type        = string
   description = "Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. Note that if you are creating a cross-region replica of an encrypted database you will also need to specify a `kms_key_id`."
   default     = "changeme"
 }
 
 variable "rds_replica_kms_key_id" {
-  type        = "string"
+  type        = string
   description = "The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN."
   default     = ""
 }
@@ -25,155 +25,155 @@ variable "rds_replica_kms_key_id" {
 # db.t2.micro is free tier
 # https://aws.amazon.com/rds/free
 variable "rds_replica_instance_type" {
-  type        = "string"
+  type        = string
   default     = "db.t2.micro"
   description = "EC2 instance type for RDS DB"
 }
 
 variable "rds_replica_port" {
-  type        = "string"
+  type        = string
   default     = "3306"
   description = "RDS DB port"
 }
 
 variable "rds_replica_snapshot" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Set to a snapshot ID to restore from snapshot"
 }
 
 variable "rds_replica_multi_az" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Run instaces in multiple az"
 }
 
 variable "rds_replica_storage_type" {
-  type        = "string"
+  type        = string
   default     = "gp2"
   description = "Storage type"
 }
 
 variable "rds_replica_storage_size" {
-  type        = "string"
+  type        = string
   default     = "20"
   description = "Storage size in Gb"
 }
 
 variable "rds_replica_storage_encrypted" {
-  type        = "string"
+  type        = string
   default     = "true"
   description = "Set to true to encrypt storage"
 }
 
 variable "rds_replica_auto_minor_version_upgrade" {
-  type        = "string"
+  type        = string
   default     = "true"
   description = "Allow automated minor version upgrade (e.g. from Postgres 9.5.3 to Postgres 9.5.4)"
 }
 
 variable "rds_replica_allow_major_version_upgrade" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Allow major version upgrade"
 }
 
 variable "rds_replica_apply_immediately" {
-  type        = "string"
+  type        = string
   default     = "true"
   description = "Specifies whether any database modifications are applied immediately, or during the next maintenance window"
 }
 
 variable "rds_replica_skip_final_snapshot" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "If true (default), no snapshot will be made before deleting DB"
 }
 
 variable "rds_replica_backup_retention_period" {
-  type        = "string"
+  type        = string
   default     = "7"
   description = "Backup retention period in days. Must be > 0 to enable backups"
 }
 
 variable "rds_replica_backup_window" {
-  type        = "string"
+  type        = string
   default     = "22:00-03:00"
   description = "When AWS can perform DB snapshots, can't overlap with maintenance window"
 }
 
 locals {
-  rds_replica_enabled = "${var.rds_replica_enabled == "true"}"
+  rds_replica_enabled = var.rds_replica_enabled == "true"
 }
 
 module "rds_replica" {
   source                      = "git::https://github.com/cloudposse/terraform-aws-rds-replica.git?ref=tags/0.1.0"
-  enabled                     = "${var.rds_replica_enabled}"
-  namespace                   = "${var.namespace}"
-  stage                       = "${var.stage}"
-  name                        = "${var.rds_replica_name}"
-  kms_key_id                  = "${var.rds_replica_kms_key_id}"
-  replicate_source_db         = "${var.rds_replica_replicate_source_db}"
-  dns_zone_id                 = "${local.zone_id}"
-  host_name                   = "${var.rds_replica_name}"
+  enabled                     = var.rds_replica_enabled
+  namespace                   = var.namespace
+  stage                       = var.stage
+  name                        = var.rds_replica_name
+  kms_key_id                  = var.rds_replica_kms_key_id
+  replicate_source_db         = var.rds_replica_replicate_source_db
+  dns_zone_id                 = local.zone_id
+  host_name                   = var.rds_replica_name
   security_group_ids          = ["${module.kops_metadata.nodes_security_group_id}"]
-  database_port               = "${var.rds_replica_port}"
-  multi_az                    = "${var.rds_replica_multi_az}"
-  storage_type                = "${var.rds_replica_storage_type}"
-  storage_encrypted           = "${var.rds_replica_storage_encrypted}"
-  instance_class              = "${var.rds_replica_instance_type}"
+  database_port               = var.rds_replica_port
+  multi_az                    = var.rds_replica_multi_az
+  storage_type                = var.rds_replica_storage_type
+  storage_encrypted           = var.rds_replica_storage_encrypted
+  instance_class              = var.rds_replica_instance_type
   publicly_accessible         = "false"
   subnet_ids                  = ["${module.subnets.private_subnet_ids}"]
-  vpc_id                      = "${module.vpc.vpc_id}"
-  snapshot_identifier         = "${var.rds_replica_snapshot}"
-  auto_minor_version_upgrade  = "${var.rds_replica_auto_minor_version_upgrade}"
-  allow_major_version_upgrade = "${var.rds_replica_allow_major_version_upgrade}"
-  apply_immediately           = "${var.rds_replica_apply_immediately}"
-  skip_final_snapshot         = "${var.rds_replica_skip_final_snapshot}"
+  vpc_id                      = module.vpc.vpc_id
+  snapshot_identifier         = var.rds_replica_snapshot
+  auto_minor_version_upgrade  = var.rds_replica_auto_minor_version_upgrade
+  allow_major_version_upgrade = var.rds_replica_allow_major_version_upgrade
+  apply_immediately           = var.rds_replica_apply_immediately
+  skip_final_snapshot         = var.rds_replica_skip_final_snapshot
   copy_tags_to_snapshot       = "true"
-  backup_retention_period     = "${var.rds_replica_backup_retention_period}"
-  backup_window               = "${var.rds_replica_backup_window}"
+  backup_retention_period     = var.rds_replica_backup_retention_period
+  backup_window               = var.rds_replica_backup_window
 }
 
 resource "aws_ssm_parameter" "rds_replica_hostname" {
-  count       = "${local.rds_replica_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "rds_replica_hostname")}"
-  value       = "${module.rds_replica.hostname}"
+  count       = local.rds_replica_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, "rds_replica_hostname")
+  value       = module.rds_replica.hostname
   description = "RDS replica hostname"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "rds_replica_port" {
-  count       = "${local.rds_replica_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "rds_replica_port")}"
-  value       = "${var.rds_replica_port}"
+  count       = local.rds_replica_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, "rds_replica_port")
+  value       = var.rds_replica_port
   description = "RDS replica port"
   type        = "String"
   overwrite   = "true"
 }
 
 output "rds_replica_instance_id" {
-  value       = "${module.rds_replica.instance_id}"
+  value       = module.rds_replica.instance_id
   description = "RDS replica ID of the instance"
 }
 
 output "rds_replica_instance_address" {
-  value       = "${module.rds_replica.instance_address}"
+  value       = module.rds_replica.instance_address
   description = "RDS replica address of the instance"
 }
 
 output "rds_replica_instance_endpoint" {
-  value       = "${module.rds_replica.instance_endpoint}"
+  value       = module.rds_replica.instance_endpoint
   description = "RDS replica DNS Endpoint of the instance"
 }
 
 output "rds_replica_port" {
-  value       = "${local.rds_replica_enabled ? var.rds_replica_port : local.null}"
+  value       = local.rds_replica_enabled ? var.rds_replica_port : local.null
   description = "RDS replica port"
 }
 
 output "rds_replica_hostname" {
-  value       = "${module.rds_replica.hostname}"
+  value       = module.rds_replica.hostname
   description = "RDS replica host name of the instance"
 }

--- a/deprecated/aws/backing-services/rds.tf
+++ b/deprecated/aws/backing-services/rds.tf
@@ -1,11 +1,11 @@
 variable "rds_name" {
-  type        = "string"
+  type        = string
   default     = "rds"
   description = "RDS instance name"
 }
 
 variable "rds_enabled" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Set to false to prevent the module from creating any resources"
 }
@@ -13,7 +13,7 @@ variable "rds_enabled" {
 # Don't use `root`
 # ("MasterUsername root cannot be used as it is a reserved word used by the engine")
 variable "rds_admin_user" {
-  type        = "string"
+  type        = string
   description = "RDS DB admin user name"
   default     = ""
 }
@@ -21,7 +21,7 @@ variable "rds_admin_user" {
 # Must be longer than 8 chars
 # ("The parameter MasterUserPassword is not a valid password because it is shorter than 8 characters")
 variable "rds_admin_password" {
-  type        = "string"
+  type        = string
   description = "RDS DB password for the admin user"
   default     = ""
 }
@@ -29,7 +29,7 @@ variable "rds_admin_password" {
 # Don't use `default`
 # ("DatabaseName default cannot be used as it is a reserved word used by the engine")
 variable "rds_db_name" {
-  type        = "string"
+  type        = string
   description = "RDS DB database name"
   default     = ""
 }
@@ -37,248 +37,248 @@ variable "rds_db_name" {
 # db.t2.micro is free tier
 # https://aws.amazon.com/rds/free
 variable "rds_instance_type" {
-  type        = "string"
+  type        = string
   default     = "db.t2.micro"
   description = "EC2 instance type for RDS DB"
 }
 
 variable "rds_engine" {
-  type        = "string"
+  type        = string
   default     = "mysql"
   description = "RDS DB engine"
 }
 
 variable "rds_engine_version" {
-  type        = "string"
+  type        = string
   default     = "5.6"
   description = "RDS DB engine version"
 }
 
 variable "rds_port" {
-  type        = "string"
+  type        = string
   default     = "3306"
   description = "RDS DB port"
 }
 
 variable "rds_db_parameter_group" {
-  type        = "string"
+  type        = string
   default     = "mysql5.6"
   description = "RDS DB engine version"
 }
 
 variable "rds_snapshot" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Set to a snapshot ID to restore from snapshot"
 }
 
 variable "rds_parameter_group_name" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Existing parameter group name to use"
 }
 
 variable "rds_multi_az" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Run instaces in multiple az"
 }
 
 variable "rds_storage_type" {
-  type        = "string"
+  type        = string
   default     = "gp2"
   description = "Storage type"
 }
 
 variable "rds_storage_size" {
-  type        = "string"
+  type        = string
   default     = "20"
   description = "Storage size"
 }
 
 variable "rds_storage_encrypted" {
-  type        = "string"
+  type        = string
   default     = "true"
   description = "Set true to encrypt storage"
 }
 
 variable "rds_auto_minor_version_upgrade" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Allow automated minor version upgrade (e.g. from Postgres 9.5.3 to Postgres 9.5.4)"
 }
 
 variable "rds_allow_major_version_upgrade" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Allow major version upgrade"
 }
 
 variable "rds_apply_immediately" {
-  type        = "string"
+  type        = string
   default     = "true"
   description = "Specifies whether any database modifications are applied immediately, or during the next maintenance window"
 }
 
 variable "rds_skip_final_snapshot" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "If true (default), no snapshot will be made before deleting DB"
 }
 
 variable "rds_backup_retention_period" {
-  type        = "string"
+  type        = string
   default     = "7"
   description = "Backup retention period in days. Must be > 0 to enable backups"
 }
 
 variable "rds_backup_window" {
-  type        = "string"
+  type        = string
   default     = "22:00-03:00"
   description = "When AWS can perform DB snapshots, can't overlap with maintenance window"
 }
 
 resource "random_pet" "rds_db_name" {
-  count     = "${local.rds_enabled ? 1 : 0}"
+  count     = local.rds_enabled ? 1 : 0
   separator = "_"
 }
 
 resource "random_string" "rds_admin_user" {
-  count   = "${local.rds_enabled ? 1 : 0}"
+  count   = local.rds_enabled ? 1 : 0
   length  = 8
   special = false
   number  = false
 }
 
 resource "random_string" "rds_admin_password" {
-  count   = "${local.rds_enabled ? 1 : 0}"
+  count   = local.rds_enabled ? 1 : 0
   length  = 16
   special = true
 }
 
 locals {
-  rds_enabled        = "${var.rds_enabled == "true"}"
-  rds_admin_user     = "${length(var.rds_admin_user) > 0 ? var.rds_admin_user : join("", random_string.rds_admin_user.*.result)}"
-  rds_admin_password = "${length(var.rds_admin_password) > 0 ? var.rds_admin_password : join("", random_string.rds_admin_password.*.result)}"
-  rds_db_name        = "${join("", random_pet.rds_db_name.*.id)}"
+  rds_enabled        = var.rds_enabled == "true"
+  rds_admin_user     = length(var.rds_admin_user) > 0 ? var.rds_admin_user : join("", random_string.rds_admin_user.*.result)
+  rds_admin_password = length(var.rds_admin_password) > 0 ? var.rds_admin_password : join("", random_string.rds_admin_password.*.result)
+  rds_db_name        = join("", random_pet.rds_db_name.*.id)
 }
 
 module "rds" {
   source                      = "git::https://github.com/cloudposse/terraform-aws-rds.git?ref=tags/0.4.4"
-  enabled                     = "${var.rds_enabled}"
-  namespace                   = "${var.namespace}"
-  stage                       = "${var.stage}"
-  name                        = "${var.rds_name}"
-  dns_zone_id                 = "${local.zone_id}"
-  host_name                   = "${var.rds_name}"
+  enabled                     = var.rds_enabled
+  namespace                   = var.namespace
+  stage                       = var.stage
+  name                        = var.rds_name
+  dns_zone_id                 = local.zone_id
+  host_name                   = var.rds_name
   security_group_ids          = ["${module.kops_metadata.nodes_security_group_id}"]
-  database_name               = "${local.rds_db_name}"
-  database_user               = "${local.rds_admin_user}"
-  database_password           = "${local.rds_admin_password}"
-  database_port               = "${var.rds_port}"
-  multi_az                    = "${var.rds_multi_az}"
-  storage_type                = "${var.rds_storage_type}"
-  allocated_storage           = "${var.rds_storage_size}"
-  storage_encrypted           = "${var.rds_storage_encrypted}"
-  engine                      = "${var.rds_engine}"
-  engine_version              = "${var.rds_engine_version}"
-  instance_class              = "${var.rds_instance_type}"
-  db_parameter_group          = "${var.rds_db_parameter_group}"
-  parameter_group_name        = "${var.rds_parameter_group_name}"
+  database_name               = local.rds_db_name
+  database_user               = local.rds_admin_user
+  database_password           = local.rds_admin_password
+  database_port               = var.rds_port
+  multi_az                    = var.rds_multi_az
+  storage_type                = var.rds_storage_type
+  allocated_storage           = var.rds_storage_size
+  storage_encrypted           = var.rds_storage_encrypted
+  engine                      = var.rds_engine
+  engine_version              = var.rds_engine_version
+  instance_class              = var.rds_instance_type
+  db_parameter_group          = var.rds_db_parameter_group
+  parameter_group_name        = var.rds_parameter_group_name
   publicly_accessible         = "false"
   subnet_ids                  = ["${module.subnets.private_subnet_ids}"]
-  vpc_id                      = "${module.vpc.vpc_id}"
-  snapshot_identifier         = "${var.rds_snapshot}"
-  auto_minor_version_upgrade  = "${var.rds_auto_minor_version_upgrade}"
-  allow_major_version_upgrade = "${var.rds_allow_major_version_upgrade}"
-  apply_immediately           = "${var.rds_apply_immediately}"
-  skip_final_snapshot         = "${var.rds_skip_final_snapshot}"
+  vpc_id                      = module.vpc.vpc_id
+  snapshot_identifier         = var.rds_snapshot
+  auto_minor_version_upgrade  = var.rds_auto_minor_version_upgrade
+  allow_major_version_upgrade = var.rds_allow_major_version_upgrade
+  apply_immediately           = var.rds_apply_immediately
+  skip_final_snapshot         = var.rds_skip_final_snapshot
   copy_tags_to_snapshot       = "true"
-  backup_retention_period     = "${var.rds_backup_retention_period}"
-  backup_window               = "${var.rds_backup_window}"
+  backup_retention_period     = var.rds_backup_retention_period
+  backup_window               = var.rds_backup_window
 }
 
 resource "aws_ssm_parameter" "rds_db_name" {
-  count       = "${local.rds_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "rds_db_name")}"
-  value       = "${local.rds_db_name}"
+  count       = local.rds_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, "rds_db_name")
+  value       = local.rds_db_name
   description = "RDS Database Name"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "rds_admin_username" {
-  count       = "${local.rds_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "rds_admin_username")}"
-  value       = "${local.rds_admin_user}"
+  count       = local.rds_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, "rds_admin_username")
+  value       = local.rds_admin_user
   description = "RDS Username for the admin DB user"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "rds_admin_password" {
-  count       = "${local.rds_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "rds_admin_password")}"
-  value       = "${local.rds_admin_password}"
+  count       = local.rds_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, "rds_admin_password")
+  value       = local.rds_admin_password
   description = "RDS Password for the admin DB user"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "rds_hostname" {
-  count       = "${local.rds_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "rds_hostname")}"
-  value       = "${module.rds.hostname}"
+  count       = local.rds_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, "rds_hostname")
+  value       = module.rds.hostname
   description = "RDS hostname"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "rds_port" {
-  count       = "${local.rds_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "rds_port")}"
-  value       = "${var.rds_port}"
+  count       = local.rds_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, "rds_port")
+  value       = var.rds_port
   description = "RDS port"
   type        = "String"
   overwrite   = "true"
 }
 
 output "rds_instance_id" {
-  value       = "${module.rds.instance_id}"
+  value       = module.rds.instance_id
   description = "RDS ID of the instance"
 }
 
 output "rds_instance_address" {
-  value       = "${module.rds.instance_address}"
+  value       = module.rds.instance_address
   description = "RDS address of the instance"
 }
 
 output "rds_instance_endpoint" {
-  value       = "${module.rds.instance_endpoint}"
+  value       = module.rds.instance_endpoint
   description = "RDS DNS Endpoint of the instance"
 }
 
 output "rds_port" {
-  value       = "${local.rds_enabled ? var.rds_port : local.null}"
+  value       = local.rds_enabled ? var.rds_port : local.null
   description = "RDS port"
 }
 
 output "rds_db_name" {
-  value       = "${local.rds_enabled ? local.rds_db_name : local.null}"
+  value       = local.rds_enabled ? local.rds_db_name : local.null
   description = "RDS db name"
 }
 
 output "rds_admin_user" {
-  value       = "${local.rds_enabled ? local.rds_admin_user : local.null}"
+  value       = local.rds_enabled ? local.rds_admin_user : local.null
   description = "RDS admin user name"
 }
 
 output "rds_admin_password" {
-  value       = "${local.rds_enabled ? local.rds_admin_password : local.null}"
+  value       = local.rds_enabled ? local.rds_admin_password : local.null
   description = "RDS admin password"
 }
 
 output "rds_hostname" {
-  value       = "${module.rds.hostname}"
+  value       = module.rds.hostname
   description = "RDS host name of the instance"
 }

--- a/deprecated/aws/backing-services/vpc.tf
+++ b/deprecated/aws/backing-services/vpc.tf
@@ -19,29 +19,29 @@ data "aws_region" "current" {}
 
 module "vpc" {
   source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.4.2"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${local.name}"
-  cidr_block = "${var.vpc_cidr_block}"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = local.name
+  cidr_block = var.vpc_cidr_block
 }
 
 module "subnets" {
   source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.8.0"
   availability_zones  = ["${local.availability_zones}"]
-  namespace           = "${var.namespace}"
-  stage               = "${var.stage}"
-  name                = "${local.name}"
-  region              = "${var.region}"
-  vpc_id              = "${module.vpc.vpc_id}"
-  igw_id              = "${module.vpc.igw_id}"
-  cidr_block          = "${module.vpc.vpc_cidr_block}"
-  nat_gateway_enabled = "${var.vpc_nat_gateway_enabled}"
-  max_subnet_count    = "${var.vpc_max_subnet_count}"
+  namespace           = var.namespace
+  stage               = var.stage
+  name                = local.name
+  region              = var.region
+  vpc_id              = module.vpc.vpc_id
+  igw_id              = module.vpc.igw_id
+  cidr_block          = module.vpc.vpc_cidr_block
+  nat_gateway_enabled = var.vpc_nat_gateway_enabled
+  max_subnet_count    = var.vpc_max_subnet_count
 }
 
 output "vpc_id" {
   description = "VPC ID of backing services"
-  value       = "${module.vpc.vpc_id}"
+  value       = module.vpc.vpc_id
 }
 
 output "public_subnet_ids" {
@@ -56,5 +56,5 @@ output "private_subnet_ids" {
 
 output "region" {
   description = "AWS region of backing services"
-  value       = "${data.aws_region.current.name}"
+  value       = data.aws_region.current.name
 }

--- a/deprecated/aws/bootstrap/main.tf
+++ b/deprecated/aws/bootstrap/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
@@ -14,8 +14,8 @@ provider "aws" {
 module "user" {
   source = "git::https://github.com/cloudposse/terraform-aws-iam-system-user.git?ref=tags/0.3.2"
 
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
+  namespace = var.namespace
+  stage     = var.stage
   name      = "bootstrap"
 }
 
@@ -36,18 +36,18 @@ data "aws_iam_policy_document" "assume_role" {
 # Fetch the OrganizationAccountAccessRole ARNs from SSM
 module "organization_account_access_role_arns" {
   source         = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
-  parameter_read = "${formatlist("/${var.namespace}/%s/organization_account_access_role", var.accounts_enabled)}"
+  parameter_read = formatlist("/${var.namespace}/%s/organization_account_access_role", var.accounts_enabled)
 }
 
 # IAM role for bootstrapping; allow user to assume it
 resource "aws_iam_role" "bootstrap" {
-  name               = "${module.user.user_name}"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  name               = module.user.user_name
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 # Grant Administrator Access to the current "root" account to the role
 resource "aws_iam_role_policy_attachment" "administrator_access" {
-  role       = "${aws_iam_role.bootstrap.name}"
+  role       = aws_iam_role.bootstrap.name
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 
@@ -65,83 +65,83 @@ data "aws_iam_policy_document" "organization_account_access_role" {
 
 # Create an IAM policy from the generated document
 resource "aws_iam_policy" "organization_account_access_role" {
-  name   = "${aws_iam_role.bootstrap.name}"
-  policy = "${data.aws_iam_policy_document.organization_account_access_role.json}"
+  name   = aws_iam_role.bootstrap.name
+  policy = data.aws_iam_policy_document.organization_account_access_role.json
 }
 
 # Assign the policy to the user
 resource "aws_iam_user_policy_attachment" "organization_account_access_role" {
-  user       = "${aws_iam_role.bootstrap.name}"
-  policy_arn = "${aws_iam_policy.organization_account_access_role.arn}"
+  user       = aws_iam_role.bootstrap.name
+  policy_arn = aws_iam_policy.organization_account_access_role.arn
 }
 
 # Render the env file with IAM credentials
 data "template_file" "env" {
-  template = "${file("${path.module}/env.tpl")}"
+  template = file("${path.module}/env.tpl")
 
   vars {
-    aws_access_key_id     = "${module.user.access_key_id}"
-    aws_secret_access_key = "${module.user.secret_access_key}"
-    aws_assume_role_arn   = "${aws_iam_role.bootstrap.arn}"
-    aws_data_path         = "${dirname(local_file.config_file.filename)}"
-    aws_config_file       = "${local_file.config_file.filename}"
+    aws_access_key_id     = module.user.access_key_id
+    aws_secret_access_key = module.user.secret_access_key
+    aws_assume_role_arn   = aws_iam_role.bootstrap.arn
+    aws_data_path         = dirname(local_file.config_file.filename)
+    aws_config_file       = local_file.config_file.filename
   }
 }
 
 # Write the env file to disk
 resource "local_file" "env_file" {
-  content  = "${data.template_file.env.rendered}"
+  content  = data.template_file.env.rendered
   filename = "${var.output_path}/${var.env_file}"
 }
 
 # Render the credentials file with IAM credentials
 data "template_file" "credentials" {
-  template = "${file("${path.module}/credentials.tpl")}"
+  template = file("${path.module}/credentials.tpl")
 
   vars {
-    source_profile_name   = "${var.namespace}"
-    aws_access_key_id     = "${module.user.access_key_id}"
-    aws_secret_access_key = "${module.user.secret_access_key}"
-    aws_assume_role_arn   = "${aws_iam_role.bootstrap.arn}"
+    source_profile_name   = var.namespace
+    aws_access_key_id     = module.user.access_key_id
+    aws_secret_access_key = module.user.secret_access_key
+    aws_assume_role_arn   = aws_iam_role.bootstrap.arn
   }
 }
 
 # Write the credentials file to disk
 resource "local_file" "credentials_file" {
-  content  = "${data.template_file.credentials.rendered}"
+  content  = data.template_file.credentials.rendered
   filename = "${var.output_path}/${var.credentials_file}"
 }
 
 # Render the config file with IAM credentials
 data "template_file" "config_root" {
-  template = "${file("${path.module}/config.tpl")}"
+  template = file("${path.module}/config.tpl")
 
   vars {
     profile_name   = "${var.namespace}-${var.stage}-admin"
-    source_profile = "${var.namespace}"
-    region         = "${var.aws_region}"
-    role_arn       = "${aws_iam_role.bootstrap.arn}"
+    source_profile = var.namespace
+    region         = var.aws_region
+    role_arn       = aws_iam_role.bootstrap.arn
   }
 }
 
 # Render the config file with IAM credentials
 data "template_file" "config" {
-  count    = "${length(module.organization_account_access_role_arns.values)}"
-  template = "${file("${path.module}/config.tpl")}"
+  count    = length(module.organization_account_access_role_arns.values)
+  template = file("${path.module}/config.tpl")
 
   vars {
     profile_name   = "${var.namespace}-${var.accounts_enabled[count.index]}-admin"
-    source_profile = "${var.namespace}"
-    region         = "${var.aws_region}"
-    role_arn       = "${module.organization_account_access_role_arns.values[count.index]}"
+    source_profile = var.namespace
+    region         = var.aws_region
+    role_arn       = module.organization_account_access_role_arns.values[count.index]
   }
 }
 
 # Write the config file to disk
 resource "local_file" "config_file" {
-  content = "${join("\n\n",
+  content = (join("\n\n",
     concat(list("[profile ${var.namespace}]"),
-  list(data.template_file.config_root.rendered), data.template_file.config.*.rendered))}"
+  list(data.template_file.config_root.rendered), data.template_file.config.*.rendered)))
 
   filename = "${var.output_path}/${var.config_file}"
 }

--- a/deprecated/aws/bootstrap/outputs.tf
+++ b/deprecated/aws/bootstrap/outputs.tf
@@ -1,4 +1,4 @@
 output "env_file" {
   description = "Env file with IAM bootstrap credentials"
-  value       = "${var.env_file}"
+  value       = var.env_file
 }

--- a/deprecated/aws/bootstrap/variables.tf
+++ b/deprecated/aws/bootstrap/variables.tf
@@ -1,47 +1,47 @@
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "aws_region" {
-  type = "string"
+  type = string
 }
 
 variable "accounts_enabled" {
-  type        = "list"
+  type        = list(string)
   description = "Accounts to enable"
   default     = ["dev", "staging", "prod", "testing", "audit"]
 }
 
 variable "output_path" {
-  type        = "string"
+  type        = string
   default     = "./"
   description = "Base directory where files will be written"
 }
 
 variable "env_file" {
-  type        = "string"
+  type        = string
   description = "File to write the temporary bootstrap environment variable settings"
   default     = ".envrc"
 }
 
 variable "config_file" {
-  type        = "string"
+  type        = string
   description = "File to write the temporary bootstrap AWS config"
   default     = ".aws/config"
 }
 
 variable "credentials_file" {
-  type        = "string"
+  type        = string
   description = "File to write the temporary bootstrap AWS credentials"
   default     = ".aws/credentials"
 }

--- a/deprecated/aws/chamber/kms-key.tf
+++ b/deprecated/aws/chamber/kms-key.tf
@@ -1,27 +1,27 @@
 module "chamber_kms_key" {
   source      = "git::https://github.com/cloudposse/terraform-aws-kms-key.git?ref=tags/0.1.0"
-  namespace   = "${var.namespace}"
-  stage       = "${var.stage}"
+  namespace   = var.namespace
+  stage       = var.stage
   name        = "chamber"
   description = "KMS key for chamber"
 }
 
 output "chamber_kms_key_arn" {
-  value       = "${module.chamber_kms_key.key_arn}"
+  value       = module.chamber_kms_key.key_arn
   description = "KMS key ARN"
 }
 
 output "chamber_kms_key_id" {
-  value       = "${module.chamber_kms_key.key_id}"
+  value       = module.chamber_kms_key.key_id
   description = "KMS key ID"
 }
 
 output "chamber_kms_key_alias_arn" {
-  value       = "${module.chamber_kms_key.alias_arn}"
+  value       = module.chamber_kms_key.alias_arn
   description = "KMS key alias ARN"
 }
 
 output "chamber_kms_key_alias_name" {
-  value       = "${module.chamber_kms_key.alias_name}"
+  value       = module.chamber_kms_key.alias_name
   description = "KMS key alias name"
 }

--- a/deprecated/aws/chamber/main.tf
+++ b/deprecated/aws/chamber/main.tf
@@ -5,27 +5,27 @@ terraform {
 }
 
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "parameter_groups" {
-  type        = "list"
+  type        = list(string)
   description = "Parameter group names"
   default     = ["kops", "app"]
 }
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }

--- a/deprecated/aws/chamber/s3-bucket.tf
+++ b/deprecated/aws/chamber/s3-bucket.tf
@@ -10,54 +10,54 @@ variable "s3_user_enabled" {
 
 module "s3_bucket" {
   source                       = "git::https://github.com/cloudposse/terraform-aws-s3-bucket.git?ref=tags/0.3.0"
-  namespace                    = "${var.namespace}"
-  stage                        = "${var.stage}"
+  namespace                    = var.namespace
+  stage                        = var.stage
   name                         = "chamber"
-  enabled                      = "${var.s3_enabled}"
+  enabled                      = var.s3_enabled
   versioning_enabled           = "false"
-  user_enabled                 = "${var.s3_user_enabled}"
+  user_enabled                 = var.s3_user_enabled
   sse_algorithm                = "AES256"
   allow_encrypted_uploads_only = "true"
 }
 
 output "bucket_domain_name" {
-  value       = "${module.s3_bucket.bucket_domain_name}"
+  value       = module.s3_bucket.bucket_domain_name
   description = "FQDN of bucket"
 }
 
 output "bucket_id" {
-  value       = "${module.s3_bucket.bucket_arn}"
+  value       = module.s3_bucket.bucket_arn
   description = "Bucket Name (aka ID)"
 }
 
 output "bucket_arn" {
-  value       = "${module.s3_bucket.bucket_arn}"
+  value       = module.s3_bucket.bucket_arn
   description = "Bucket ARN"
 }
 
 output "user_name" {
-  value       = "${module.s3_bucket.user_name}"
+  value       = module.s3_bucket.user_name
   description = "Normalized IAM user name"
 }
 
 output "user_arn" {
-  value       = "${module.s3_bucket.user_arn}"
+  value       = module.s3_bucket.user_arn
   description = "The ARN assigned by AWS for the user"
 }
 
 output "user_unique_id" {
-  value       = "${module.s3_bucket.user_unique_id}"
+  value       = module.s3_bucket.user_unique_id
   description = "The user unique ID assigned by AWS"
 }
 
 output "access_key_id" {
   sensitive   = true
-  value       = "${module.s3_bucket.access_key_id}"
+  value       = module.s3_bucket.access_key_id
   description = "The access key ID"
 }
 
 output "secret_access_key" {
   sensitive   = true
-  value       = "${module.s3_bucket.secret_access_key}"
+  value       = module.s3_bucket.secret_access_key
   description = "The secret access key. This will be written to the state file in plain-text"
 }

--- a/deprecated/aws/chamber/user.tf
+++ b/deprecated/aws/chamber/user.tf
@@ -10,12 +10,12 @@ variable "chamber_user_enabled" {
 # https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-access.html
 module "chamber_user" {
   source      = "git::https://github.com/cloudposse/terraform-aws-iam-chamber-user.git?ref=tags/0.1.7"
-  namespace   = "${var.namespace}"
-  stage       = "${var.stage}"
+  namespace   = var.namespace
+  stage       = var.stage
   name        = "chamber"
-  enabled     = "${var.chamber_user_enabled}"
+  enabled     = var.chamber_user_enabled
   attributes  = ["codefresh"]
-  kms_key_arn = "${module.chamber_kms_key.key_arn}"
+  kms_key_arn = module.chamber_kms_key.key_arn
 
   ssm_resources = [
     "${formatlist("arn:aws:ssm:%s:%s:parameter/%s/*", data.aws_region.default.name, data.aws_caller_identity.default.account_id, var.parameter_groups)}",
@@ -23,26 +23,26 @@ module "chamber_user" {
 }
 
 output "chamber_user_name" {
-  value       = "${module.chamber_user.user_name}"
+  value       = module.chamber_user.user_name
   description = "Normalized IAM user name"
 }
 
 output "chamber_user_arn" {
-  value       = "${module.chamber_user.user_arn}"
+  value       = module.chamber_user.user_arn
   description = "The ARN assigned by AWS for the user"
 }
 
 output "chamber_user_unique_id" {
-  value       = "${module.chamber_user.user_unique_id}"
+  value       = module.chamber_user.user_unique_id
   description = "The user unique ID assigned by AWS"
 }
 
 output "chamber_access_key_id" {
-  value       = "${module.chamber_user.access_key_id}"
+  value       = module.chamber_user.access_key_id
   description = "The access key ID"
 }
 
 output "chamber_secret_access_key" {
-  value       = "${module.chamber_user.secret_access_key}"
+  value       = module.chamber_user.secret_access_key
   description = "The secret access key. This will be written to the state file in plain-text"
 }

--- a/deprecated/aws/cis-aggregator-auth/main.tf
+++ b/deprecated/aws/cis-aggregator-auth/main.tf
@@ -6,23 +6,23 @@ terraform {
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
 # Define composite variables for resources
 module "label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.5.3"
-  enabled    = "${var.enabled}"
-  namespace  = "${var.namespace}"
-  name       = "${var.name}"
-  stage      = "${var.stage}"
-  delimiter  = "${var.delimiter}"
-  attributes = "${var.attributes}"
-  tags       = "${var.tags}"
+  enabled    = var.enabled
+  namespace  = var.namespace
+  name       = var.name
+  stage      = var.stage
+  delimiter  = var.delimiter
+  attributes = var.attributes
+  tags       = var.tags
 }
 
 resource "aws_config_aggregate_authorization" "default" {
-  account_id = "${var.aggregator_account}"
-  region     = "${var.aggregator_region}"
+  account_id = var.aggregator_account
+  region     = var.aggregator_region
 }

--- a/deprecated/aws/cis-aggregator-auth/variables.tf
+++ b/deprecated/aws/cis-aggregator-auth/variables.tf
@@ -1,5 +1,5 @@
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "enabled" {
@@ -8,12 +8,12 @@ variable "enabled" {
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
@@ -23,25 +23,25 @@ variable "name" {
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter between `name`, `namespace`, `stage` and `attributes`"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   description = "Additional attributes (_e.g._ \"1\")"
   default     = []
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   description = "Additional tags (_e.g._ map(\"BusinessUnit\",\"ABC\")"
   default     = {}
 }
 
 variable "parameters" {
-  type        = "map"
+  type        = map(string)
   description = "Key-value map of input parameters for the Stack Set template. (_e.g._ map(\"BusinessUnit\",\"ABC\")"
   default     = {}
 }

--- a/deprecated/aws/cis-aggregator/main.tf
+++ b/deprecated/aws/cis-aggregator/main.tf
@@ -6,25 +6,25 @@ terraform {
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
 # Define composite variables for resources
 module "label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.5.3"
-  enabled    = "${var.enabled}"
-  namespace  = "${var.namespace}"
-  name       = "${var.name}"
-  stage      = "${var.stage}"
-  delimiter  = "${var.delimiter}"
-  attributes = "${var.attributes}"
-  tags       = "${var.tags}"
+  enabled    = var.enabled
+  namespace  = var.namespace
+  name       = var.name
+  stage      = var.stage
+  delimiter  = var.delimiter
+  attributes = var.attributes
+  tags       = var.tags
 }
 
 resource "aws_config_configuration_aggregator" "default" {
-  count = "${var.enabled == "true" ? 1 : 0}"
-  name  = "${module.label.id}"
+  count = var.enabled == "true" ? 1 : 0
+  name  = module.label.id
 
   account_aggregation_source {
     account_ids = ["${var.accounts}"]

--- a/deprecated/aws/cis-aggregator/variables.tf
+++ b/deprecated/aws/cis-aggregator/variables.tf
@@ -1,5 +1,5 @@
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "enabled" {
@@ -8,12 +8,12 @@ variable "enabled" {
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
@@ -23,35 +23,35 @@ variable "name" {
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter between `name`, `namespace`, `stage` and `attributes`"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   description = "Additional attributes (_e.g._ \"1\")"
   default     = []
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   description = "Additional tags (_e.g._ map(\"BusinessUnit\",\"ABC\")"
   default     = {}
 }
 
 variable "parameters" {
-  type        = "map"
+  type        = map(string)
   description = "Key-value map of input parameters for the Stack Set template. (_e.g._ map(\"BusinessUnit\",\"ABC\")"
   default     = {}
 }
 
 variable "accounts" {
-  type    = "list"
+  type    = list(string)
   default = []
 }
 
 variable "regions" {
-  type    = "list"
+  type    = list(string)
   default = []
 }

--- a/deprecated/aws/cis-executor/main.tf
+++ b/deprecated/aws/cis-executor/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
@@ -17,10 +17,10 @@ locals {
 module "default" {
   source = "git::https://github.com/cloudposse/terraform-aws-iam-role.git?ref=tags/0.3.0"
 
-  enabled            = "${var.enabled}"
-  namespace          = "${var.namespace}"
-  stage              = "${var.stage}"
-  name               = "${local.executor_role_name}"
+  enabled            = var.enabled
+  namespace          = var.namespace
+  stage              = var.stage
+  name               = local.executor_role_name
   use_fullname       = "false"
   attributes         = ["${var.attributes}"]
   role_description   = "IAM Role in all target accounts for Stack Set operations"

--- a/deprecated/aws/cis-executor/variables.tf
+++ b/deprecated/aws/cis-executor/variables.tf
@@ -1,5 +1,5 @@
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "enabled" {
@@ -8,29 +8,29 @@ variable "enabled" {
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter between `name`, `namespace`, `stage` and `attributes`"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   description = "Additional attributes (_e.g._ \"1\")"
   default     = ["executor"]
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   description = "Additional tags (_e.g._ map(\"BusinessUnit\",\"ABC\")"
   default     = {}
 }

--- a/deprecated/aws/cis-instances/variables.tf
+++ b/deprecated/aws/cis-instances/variables.tf
@@ -1,5 +1,5 @@
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "enabled" {
@@ -8,12 +8,12 @@ variable "enabled" {
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
@@ -23,30 +23,30 @@ variable "name" {
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter between `name`, `namespace`, `stage` and `attributes`"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   description = "Additional attributes (_e.g._ \"1\")"
   default     = []
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   description = "Additional tags (_e.g._ map(\"BusinessUnit\",\"ABC\")"
   default     = {}
 }
 
 variable "parameters" {
-  type        = "map"
+  type        = map(string)
   description = "Key-value map of input parameters override for the Stack Set template. (_e.g._ map(\"BusinessUnit\",\"ABC\")"
   default     = {}
 }
 
 variable "cis_instances" {
-  type    = "map"
+  type    = map(string)
   default = {}
 }

--- a/deprecated/aws/cis/main.tf
+++ b/deprecated/aws/cis/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
@@ -18,13 +18,13 @@ locals {
 module "default" {
   source = "git::https://github.com/cloudposse/terraform-aws-cloudformation-stack-set.git?ref=tags/0.1.0"
 
-  enabled            = "${var.enabled}"
-  namespace          = "${var.namespace}"
-  stage              = "${var.stage}"
-  name               = "${var.name}"
+  enabled            = var.enabled
+  namespace          = var.namespace
+  stage              = var.stage
+  name               = var.name
   attributes         = ["${var.attributes}"]
-  parameters         = "${var.parameters}"
-  template_url       = "${local.template_url}"
-  executor_role_name = "${local.executor_role_name}"
-  capabilities       = "${var.capabilities}"
+  parameters         = var.parameters
+  template_url       = local.template_url
+  executor_role_name = local.executor_role_name
+  capabilities       = var.capabilities
 }

--- a/deprecated/aws/cis/output.tf
+++ b/deprecated/aws/cis/output.tf
@@ -1,11 +1,11 @@
 output "administrator_role_arn" {
-  value = "${module.default.administrator_role_arn}"
+  value = module.default.administrator_role_arn
 }
 
 output "executor_role_name" {
-  value = "${module.default.executor_role_name}"
+  value = module.default.executor_role_name
 }
 
 output "name" {
-  value = "${module.default.name}"
+  value = module.default.name
 }

--- a/deprecated/aws/cis/variables.tf
+++ b/deprecated/aws/cis/variables.tf
@@ -1,5 +1,5 @@
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "enabled" {
@@ -8,12 +8,12 @@ variable "enabled" {
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
@@ -23,31 +23,31 @@ variable "name" {
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter between `name`, `namespace`, `stage` and `attributes`"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   description = "Additional attributes (_e.g._ \"1\")"
   default     = []
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   description = "Additional tags (_e.g._ map(\"BusinessUnit\",\"ABC\")"
   default     = {}
 }
 
 variable "parameters" {
-  type        = "map"
+  type        = map(string)
   description = "Key-value map of input parameters for the Stack Set template. (_e.g._ map(\"BusinessUnit\",\"ABC\")"
   default     = {}
 }
 
 variable "capabilities" {
-  type        = "list"
+  type        = list(string)
   description = "A list of capabilities. Valid values: CAPABILITY_IAM, CAPABILITY_NAMED_IAM, CAPABILITY_AUTO_EXPAND"
   default     = []
 }

--- a/deprecated/aws/cloudtrail/cloudwatch_logs.tf
+++ b/deprecated/aws/cloudtrail/cloudwatch_logs.tf
@@ -1,11 +1,11 @@
 module "logs" {
   source     = "git::https://github.com/cloudposse/terraform-aws-cloudwatch-logs.git?ref=tags/0.3.0"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
   attributes = ["cloudwatch", "logs"]
 
-  retention_in_days = "${var.cloudwatch_logs_retention_in_days}"
+  retention_in_days = var.cloudwatch_logs_retention_in_days
 
   principals = {
     Service = ["cloudtrail.amazonaws.com"]
@@ -18,16 +18,16 @@ module "logs" {
 
 module "kms_key_logs" {
   source     = "git::https://github.com/cloudposse/terraform-aws-kms-key.git?ref=tags/0.1.3"
-  namespace  = "${var.namespace}"
-  name       = "${var.name}"
-  stage      = "${var.stage}"
+  namespace  = var.namespace
+  name       = var.name
+  stage      = var.stage
   attributes = ["cloudwatch", "logs"]
 
   description             = "KMS key for CloudWatch"
   deletion_window_in_days = 10
   enable_key_rotation     = "true"
 
-  policy = "${data.aws_iam_policy_document.kms_key_logs.json}"
+  policy = data.aws_iam_policy_document.kms_key_logs.json
 }
 
 data "aws_iam_policy_document" "kms_key_logs" {

--- a/deprecated/aws/cloudtrail/main.tf
+++ b/deprecated/aws/cloudtrail/main.tf
@@ -5,38 +5,38 @@ terraform {
 }
 
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   description = "Name (e.g. `account`)"
   default     = "account"
 }
 
 variable "kms_key_arn" {
-  type        = "string"
+  type        = string
   description = ""
 }
 
 variable "region" {
-  type        = "string"
+  type        = string
   description = "AWS region"
   default     = ""
 }
@@ -49,20 +49,20 @@ variable "cloudwatch_logs_retention_in_days" {
 data "aws_region" "default" {}
 
 locals {
-  region = "${length(var.region) > 0 ? var.region : data.aws_region.default.name}"
+  region = length(var.region) > 0 ? var.region : data.aws_region.default.name
 }
 
 module "cloudtrail" {
   source                        = "git::https://github.com/cloudposse/terraform-aws-cloudtrail.git?ref=tags/0.7.1"
-  namespace                     = "${var.namespace}"
-  stage                         = "${var.stage}"
-  name                          = "${var.name}"
+  namespace                     = var.namespace
+  stage                         = var.stage
+  name                          = var.name
   enable_logging                = "true"
   enable_log_file_validation    = "true"
   include_global_service_events = "true"
   is_multi_region_trail         = "true"
   s3_bucket_name                = "${var.namespace}-audit-account"
-  kms_key_arn                   = "${var.kms_key_arn}"
-  cloud_watch_logs_group_arn    = "${module.logs.log_group_arn}"
-  cloud_watch_logs_role_arn     = "${module.logs.role_arn}"
+  kms_key_arn                   = var.kms_key_arn
+  cloud_watch_logs_group_arn    = module.logs.log_group_arn
+  cloud_watch_logs_role_arn     = module.logs.role_arn
 }

--- a/deprecated/aws/codefresh-onprem/kops-metadata.tf
+++ b/deprecated/aws/codefresh-onprem/kops-metadata.tf
@@ -1,11 +1,11 @@
 variable "kops_metadata_enabled" {
   description = "Set to false to prevent the module from creating any resources"
-  type        = "string"
+  type        = string
   default     = "false"
 }
 
 module "kops_metadata" {
   source   = "git::https://github.com/cloudposse/terraform-aws-kops-metadata.git?ref=tags/0.2.0"
   dns_zone = "${var.region}.${var.zone_name}"
-  enabled  = "${var.kops_metadata_enabled}"
+  enabled  = var.kops_metadata_enabled
 }

--- a/deprecated/aws/codefresh-onprem/main.tf
+++ b/deprecated/aws/codefresh-onprem/main.tf
@@ -6,31 +6,31 @@ terraform {
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `eg` or `cp`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "region" {
-  type        = "string"
+  type        = string
   description = "AWS region"
 }
 
 variable "zone_name" {
-  type        = "string"
+  type        = string
   description = "DNS zone name"
 }
 
@@ -44,25 +44,25 @@ variable "acm_primary_domain" {
 }
 
 variable "acm_san_domains" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "A list of domains that should be SANs in the issued certificate"
 }
 
 variable "acm_zone_name" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "The name of the desired Route53 Hosted Zone"
 }
 
 variable "redis_cluster_enabled" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Set to false to prevent the module from creating any resources"
 }
 
 variable "postgres_cluster_enabled" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Set to false to prevent the module from creating any resources"
 }
@@ -73,49 +73,49 @@ variable "documentdb_cluster_enabled" {
 }
 
 variable "documentdb_instance_class" {
-  type        = "string"
+  type        = string
   default     = "db.r4.large"
   description = "The instance class to use. For more details, see https://docs.aws.amazon.com/documentdb/latest/developerguide/db-instance-classes.html#db-instance-class-specs"
 }
 
 variable "documentdb_cluster_size" {
-  type        = "string"
+  type        = string
   default     = "3"
   description = "Number of DocumentDB instances to create in the cluster"
 }
 
 variable "documentdb_port" {
-  type        = "string"
+  type        = string
   default     = "27017"
   description = "DocumentDB port"
 }
 
 variable "documentdb_master_username" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Username for the master DocumentDB user. If left empty, will be generated automatically"
 }
 
 variable "documentdb_master_password" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Password for the master DocumentDB user. If left empty, will be generated automatically. Note that this may show up in logs, and it will be stored in the state file"
 }
 
 variable "documentdb_retention_period" {
-  type        = "string"
+  type        = string
   default     = "5"
   description = "Number of days to retain DocumentDB backups for"
 }
 
 variable "documentdb_preferred_backup_window" {
-  type        = "string"
+  type        = string
   default     = "07:00-09:00"
   description = "Daily time range during which the DocumentDB backups happen"
 }
 
 variable "documentdb_cluster_parameters" {
-  type = "list"
+  type = list(string)
 
   default = [
     {
@@ -128,19 +128,19 @@ variable "documentdb_cluster_parameters" {
 }
 
 variable "documentdb_cluster_family" {
-  type        = "string"
+  type        = string
   default     = "docdb3.6"
   description = "The family of the DocumentDB cluster parameter group. For more details, see https://docs.aws.amazon.com/documentdb/latest/developerguide/db-cluster-parameter-group-create.html"
 }
 
 variable "documentdb_engine" {
-  type        = "string"
+  type        = string
   default     = "docdb"
   description = "The name of the database engine to be used for DocumentDB cluster. Defaults to `docdb`. Valid values: `docdb`"
 }
 
 variable "documentdb_engine_version" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "The version number of the DocumentDB database engine to use"
 }
@@ -161,13 +161,13 @@ variable "documentdb_apply_immediately" {
 }
 
 variable "documentdb_enabled_cloudwatch_logs_exports" {
-  type        = "list"
+  type        = list(string)
   description = "List of DocumentDB log types to export to CloudWatch. The following log types are supported: audit, error, general, slowquery"
   default     = []
 }
 
 variable "documentdb_chamber_parameters_mapping" {
-  type = "map"
+  type = map(string)
 
   default = {
     documentdb_connection_uri = "MONGODB_URI"
@@ -187,187 +187,187 @@ data "terraform_remote_state" "backing_services" {
 
 module "codefresh_enterprise_backing_services" {
   source          = "git::https://github.com/cloudposse/terraform-aws-codefresh-backing-services.git?ref=tags/0.8.0"
-  namespace       = "${var.namespace}"
-  stage           = "${var.stage}"
-  vpc_id          = "${data.terraform_remote_state.backing_services.vpc_id}"
+  namespace       = var.namespace
+  stage           = var.stage
+  vpc_id          = data.terraform_remote_state.backing_services.vpc_id
   subnet_ids      = ["${data.terraform_remote_state.backing_services.private_subnet_ids}"]
   security_groups = ["${module.kops_metadata.nodes_security_group_id}"]
-  zone_name       = "${var.zone_name}"
+  zone_name       = var.zone_name
   chamber_service = "codefresh"
 
-  acm_enabled        = "${var.acm_enabled}"
-  acm_primary_domain = "${var.acm_primary_domain}"
+  acm_enabled        = var.acm_enabled
+  acm_primary_domain = var.acm_primary_domain
   acm_san_domains    = ["${var.acm_san_domains}"]
 
-  redis_cluster_enabled = "${var.redis_cluster_enabled}"
+  redis_cluster_enabled = var.redis_cluster_enabled
 
-  postgres_cluster_enabled = "${var.postgres_cluster_enabled}"
+  postgres_cluster_enabled = var.postgres_cluster_enabled
 
   # DocumentDB
-  documentdb_cluster_enabled                 = "${var.documentdb_cluster_enabled}"
-  documentdb_instance_class                  = "${var.documentdb_instance_class}"
-  documentdb_cluster_size                    = "${var.documentdb_cluster_size}"
-  documentdb_port                            = "${var.documentdb_port}"
-  documentdb_master_username                 = "${var.documentdb_master_username}"
-  documentdb_master_password                 = "${var.documentdb_master_password}"
-  documentdb_retention_period                = "${var.documentdb_retention_period}"
-  documentdb_preferred_backup_window         = "${var.documentdb_preferred_backup_window}"
+  documentdb_cluster_enabled                 = var.documentdb_cluster_enabled
+  documentdb_instance_class                  = var.documentdb_instance_class
+  documentdb_cluster_size                    = var.documentdb_cluster_size
+  documentdb_port                            = var.documentdb_port
+  documentdb_master_username                 = var.documentdb_master_username
+  documentdb_master_password                 = var.documentdb_master_password
+  documentdb_retention_period                = var.documentdb_retention_period
+  documentdb_preferred_backup_window         = var.documentdb_preferred_backup_window
   documentdb_cluster_parameters              = ["${var.documentdb_cluster_parameters}"]
-  documentdb_cluster_family                  = "${var.documentdb_cluster_family}"
-  documentdb_engine                          = "${var.documentdb_engine}"
-  documentdb_engine_version                  = "${var.documentdb_engine_version}"
-  documentdb_storage_encrypted               = "${var.documentdb_storage_encrypted}"
-  documentdb_skip_final_snapshot             = "${var.documentdb_skip_final_snapshot}"
-  documentdb_apply_immediately               = "${var.documentdb_apply_immediately}"
+  documentdb_cluster_family                  = var.documentdb_cluster_family
+  documentdb_engine                          = var.documentdb_engine
+  documentdb_engine_version                  = var.documentdb_engine_version
+  documentdb_storage_encrypted               = var.documentdb_storage_encrypted
+  documentdb_skip_final_snapshot             = var.documentdb_skip_final_snapshot
+  documentdb_apply_immediately               = var.documentdb_apply_immediately
   documentdb_enabled_cloudwatch_logs_exports = ["${var.documentdb_enabled_cloudwatch_logs_exports}"]
-  documentdb_chamber_parameters_mapping      = "${var.documentdb_chamber_parameters_mapping}"
+  documentdb_chamber_parameters_mapping      = var.documentdb_chamber_parameters_mapping
 }
 
 output "elasticache_redis_id" {
-  value       = "${module.codefresh_enterprise_backing_services.elasticache_redis_id}"
+  value       = module.codefresh_enterprise_backing_services.elasticache_redis_id
   description = "Elasticache Redis cluster ID"
 }
 
 output "elasticache_redis_security_group_id" {
-  value       = "${module.codefresh_enterprise_backing_services.elasticache_redis_security_group_id}"
+  value       = module.codefresh_enterprise_backing_services.elasticache_redis_security_group_id
   description = "Elasticache Redis security group ID"
 }
 
 output "elasticache_redis_host" {
-  value       = "${module.codefresh_enterprise_backing_services.elasticache_redis_host}"
+  value       = module.codefresh_enterprise_backing_services.elasticache_redis_host
   description = "Elasticache Redis host"
 }
 
 output "aurora_postgres_database_name" {
-  value       = "${module.codefresh_enterprise_backing_services.aurora_postgres_database_name}"
+  value       = module.codefresh_enterprise_backing_services.aurora_postgres_database_name
   description = "Aurora Postgres Database name"
 }
 
 output "aurora_postgres_master_username" {
-  value       = "${module.codefresh_enterprise_backing_services.aurora_postgres_master_username}"
+  value       = module.codefresh_enterprise_backing_services.aurora_postgres_master_username
   description = "Aurora Postgres Username for the master DB user"
 }
 
 output "aurora_postgres_master_hostname" {
-  value       = "${module.codefresh_enterprise_backing_services.aurora_postgres_master_hostname}"
+  value       = module.codefresh_enterprise_backing_services.aurora_postgres_master_hostname
   description = "Aurora Postgres DB Master hostname"
 }
 
 output "aurora_postgres_replicas_hostname" {
-  value       = "${module.codefresh_enterprise_backing_services.aurora_postgres_replicas_hostname}"
+  value       = module.codefresh_enterprise_backing_services.aurora_postgres_replicas_hostname
   description = "Aurora Postgres Replicas hostname"
 }
 
 output "aurora_postgres_cluster_name" {
-  value       = "${module.codefresh_enterprise_backing_services.aurora_postgres_cluster_name}"
+  value       = module.codefresh_enterprise_backing_services.aurora_postgres_cluster_name
   description = "Aurora Postgres Cluster Identifier"
 }
 
 output "s3_user_name" {
-  value       = "${module.codefresh_enterprise_backing_services.s3_user_name}"
+  value       = module.codefresh_enterprise_backing_services.s3_user_name
   description = "Normalized IAM user name"
 }
 
 output "s3_user_arn" {
-  value       = "${module.codefresh_enterprise_backing_services.s3_user_arn}"
+  value       = module.codefresh_enterprise_backing_services.s3_user_arn
   description = "The ARN assigned by AWS for the user"
 }
 
 output "s3_user_unique_id" {
-  value       = "${module.codefresh_enterprise_backing_services.s3_user_unique_id}"
+  value       = module.codefresh_enterprise_backing_services.s3_user_unique_id
   description = "The user unique ID assigned by AWS"
 }
 
 output "s3_access_key_id" {
   sensitive   = true
-  value       = "${module.codefresh_enterprise_backing_services.s3_access_key_id}"
+  value       = module.codefresh_enterprise_backing_services.s3_access_key_id
   description = "The access key ID"
 }
 
 output "s3_secret_access_key" {
   sensitive   = true
-  value       = "${module.codefresh_enterprise_backing_services.s3_secret_access_key}"
+  value       = module.codefresh_enterprise_backing_services.s3_secret_access_key
   description = "The secret access key. This will be written to the state file in plain-text"
 }
 
 output "s3_bucket_arn" {
-  value       = "${module.codefresh_enterprise_backing_services.s3_bucket_arn}"
+  value       = module.codefresh_enterprise_backing_services.s3_bucket_arn
   description = "The s3 bucket ARN"
 }
 
 output "backup_s3_user_name" {
-  value       = "${module.codefresh_enterprise_backing_services.backup_s3_user_name}"
+  value       = module.codefresh_enterprise_backing_services.backup_s3_user_name
   description = "Normalized IAM user name"
 }
 
 output "backup_s3_user_arn" {
-  value       = "${module.codefresh_enterprise_backing_services.backup_s3_user_arn}"
+  value       = module.codefresh_enterprise_backing_services.backup_s3_user_arn
   description = "The ARN assigned by AWS for the user"
 }
 
 output "backup_s3_user_unique_id" {
-  value       = "${module.codefresh_enterprise_backing_services.backup_s3_user_unique_id}"
+  value       = module.codefresh_enterprise_backing_services.backup_s3_user_unique_id
   description = "The user unique ID assigned by AWS"
 }
 
 output "backup_s3_access_key_id" {
   sensitive   = true
-  value       = "${module.codefresh_enterprise_backing_services.backup_s3_access_key_id}"
+  value       = module.codefresh_enterprise_backing_services.backup_s3_access_key_id
   description = "The access key ID"
 }
 
 output "backup_s3_secret_access_key" {
   sensitive   = true
-  value       = "${module.codefresh_enterprise_backing_services.backup_s3_secret_access_key}"
+  value       = module.codefresh_enterprise_backing_services.backup_s3_secret_access_key
   description = "The secret access key. This will be written to the state file in plain-text"
 }
 
 output "backup_s3_bucket_arn" {
-  value       = "${module.codefresh_enterprise_backing_services.backup_s3_bucket_arn}"
+  value       = module.codefresh_enterprise_backing_services.backup_s3_bucket_arn
   description = "The backup_s3 bucket ARN"
 }
 
 output "acm_arn" {
-  value       = "${module.codefresh_enterprise_backing_services.acm_arn}"
+  value       = module.codefresh_enterprise_backing_services.acm_arn
   description = "The ARN of the certificate"
 }
 
 output "acm_domain_validation_options" {
-  value       = "${module.codefresh_enterprise_backing_services.acm_domain_validation_options}"
+  value       = module.codefresh_enterprise_backing_services.acm_domain_validation_options
   description = "CNAME records that are added to the DNS zone to complete certificate validation"
 }
 
 output "documentdb_master_username" {
-  value       = "${module.codefresh_enterprise_backing_services.documentdb_master_username}"
+  value       = module.codefresh_enterprise_backing_services.documentdb_master_username
   description = "DocumentDB Username for the master DB user"
 }
 
 output "documentdb_cluster_name" {
-  value       = "${module.codefresh_enterprise_backing_services.documentdb_cluster_name}"
+  value       = module.codefresh_enterprise_backing_services.documentdb_cluster_name
   description = "DocumentDB Cluster Identifier"
 }
 
 output "documentdb_arn" {
-  value       = "${module.codefresh_enterprise_backing_services.documentdb_arn}"
+  value       = module.codefresh_enterprise_backing_services.documentdb_arn
   description = "Amazon Resource Name (ARN) of the DocumentDB cluster"
 }
 
 output "documentdb_endpoint" {
-  value       = "${module.codefresh_enterprise_backing_services.documentdb_endpoint}"
+  value       = module.codefresh_enterprise_backing_services.documentdb_endpoint
   description = "Endpoint of the DocumentDB cluster"
 }
 
 output "documentdb_reader_endpoint" {
-  value       = "${module.codefresh_enterprise_backing_services.documentdb_reader_endpoint}"
+  value       = module.codefresh_enterprise_backing_services.documentdb_reader_endpoint
   description = "Read-only endpoint of the DocumentDB cluster, automatically load-balanced across replicas"
 }
 
 output "documentdb_master_host" {
-  value       = "${module.codefresh_enterprise_backing_services.documentdb_master_host}"
+  value       = module.codefresh_enterprise_backing_services.documentdb_master_host
   description = "DocumentDB master hostname"
 }
 
 output "documentdb_replicas_host" {
-  value       = "${module.codefresh_enterprise_backing_services.documentdb_replicas_host}"
+  value       = module.codefresh_enterprise_backing_services.documentdb_replicas_host
   description = "DocumentDB replicas hostname"
 }

--- a/deprecated/aws/datadog/main.tf
+++ b/deprecated/aws/datadog/main.tf
@@ -5,12 +5,12 @@ terraform {
 }
 
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
@@ -21,15 +21,15 @@ module "datadog_ids" {
 
 module "datadog_aws_integration" {
   source              = "git::https://github.com/cloudposse/terraform-datadog-aws-integration.git?ref=tags/0.2.0"
-  namespace           = "${var.namespace}"
-  stage               = "${var.stage}"
+  namespace           = var.namespace
+  stage               = var.stage
   name                = "datadog"
-  datadog_external_id = "${lookup(module.datadog_ids.map, "/datadog/datadog_external_id")}"
-  integrations        = "${var.integrations}"
+  datadog_external_id = lookup(module.datadog_ids.map, "/datadog/datadog_external_id")
+  integrations        = var.integrations
 }
 
 locals {
-  chamber_service = "${var.chamber_service == "" ? basename(pathexpand(path.module)) : var.chamber_service}"
+  chamber_service = var.chamber_service == "" ? basename(pathexpand(path.module)) : var.chamber_service
 }
 
 resource "random_string" "tokens" {
@@ -39,12 +39,12 @@ resource "random_string" "tokens" {
   number  = false
   special = false
 
-  keepers = "${module.datadog_ids.map}"
+  keepers = module.datadog_ids.map
 }
 
 resource "aws_ssm_parameter" "datadog_cluster_agent_token" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "datadog_cluster_agent_token")}"
-  value       = "${random_string.tokens.result}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, "datadog_cluster_agent_token")
+  value       = random_string.tokens.result
   description = "A cluster-internal secret for agent-to-agent communication. Must be 32+ characters a-zA-Z"
   type        = "String"
   overwrite   = "true"

--- a/deprecated/aws/datadog/variables.tf
+++ b/deprecated/aws/datadog/variables.tf
@@ -7,7 +7,7 @@ variable "stage" {
 }
 
 variable "integrations" {
-  type        = "list"
+  type        = list(string)
   description = "List of integration names with permissions to apply (`all`, `core`, `rds`)"
 }
 

--- a/deprecated/aws/docs/outputs.tf
+++ b/deprecated/aws/docs/outputs.tf
@@ -1,80 +1,80 @@
 output "docs_user_name" {
-  value       = "${module.docs_user.user_name}"
+  value       = module.docs_user.user_name
   description = "Normalized IAM user name"
 }
 
 output "docs_user_arn" {
-  value       = "${module.docs_user.user_arn}"
+  value       = module.docs_user.user_arn
   description = "The ARN assigned by AWS for the user"
 }
 
 output "docs_user_unique_id" {
-  value       = "${module.docs_user.user_unique_id}"
+  value       = module.docs_user.user_unique_id
   description = "The user unique ID assigned by AWS"
 }
 
 output "docs_user_access_key_id" {
-  value       = "${module.docs_user.access_key_id}"
+  value       = module.docs_user.access_key_id
   description = "The access key ID"
 }
 
 output "docs_user_secret_access_key" {
-  value       = "${module.docs_user.secret_access_key}"
+  value       = module.docs_user.secret_access_key
   description = "The secret access key. This will be written to the state file in plain-text"
 }
 
 output "docs_s3_bucket_name" {
-  value = "${module.origin.s3_bucket_name}"
+  value = module.origin.s3_bucket_name
 }
 
 output "docs_s3_bucket_domain_name" {
-  value = "${module.origin.s3_bucket_domain_name}"
+  value = module.origin.s3_bucket_domain_name
 }
 
 output "docs_s3_bucket_arn" {
-  value = "${module.origin.s3_bucket_arn}"
+  value = module.origin.s3_bucket_arn
 }
 
 output "docs_s3_bucket_website_endpoint" {
-  value = "${module.origin.s3_bucket_website_endpoint}"
+  value = module.origin.s3_bucket_website_endpoint
 }
 
 output "docs_s3_bucket_website_domain" {
-  value = "${module.origin.s3_bucket_website_domain}"
+  value = module.origin.s3_bucket_website_domain
 }
 
 output "docs_s3_bucket_hosted_zone_id" {
-  value = "${module.origin.s3_bucket_hosted_zone_id}"
+  value = module.origin.s3_bucket_hosted_zone_id
 }
 
 output "docs_cloudfront_id" {
-  value = "${module.cdn.cf_id}"
+  value = module.cdn.cf_id
 }
 
 output "docs_cloudfront_arn" {
-  value = "${module.cdn.cf_arn}"
+  value = module.cdn.cf_arn
 }
 
 output "docs_cloudfront_aliases" {
-  value = "${module.cdn.cf_aliases}"
+  value = module.cdn.cf_aliases
 }
 
 output "docs_cloudfront_status" {
-  value = "${module.cdn.cf_status}"
+  value = module.cdn.cf_status
 }
 
 output "docs_cloudfront_domain_name" {
-  value = "${module.cdn.cf_domain_name}"
+  value = module.cdn.cf_domain_name
 }
 
 output "docs_cloudfront_etag" {
-  value = "${module.cdn.cf_etag}"
+  value = module.cdn.cf_etag
 }
 
 output "docs_cloudfront_hosted_zone_id" {
-  value = "${module.cdn.cf_hosted_zone_id}"
+  value = module.cdn.cf_hosted_zone_id
 }
 
 output "docs_cloudfront_origin_access_identity_path" {
-  value = "${module.cdn.cf_origin_access_identity}"
+  value = module.cdn.cf_origin_access_identity
 }

--- a/deprecated/aws/ecr/kops_ecr_app.tf
+++ b/deprecated/aws/ecr/kops_ecr_app.tf
@@ -10,29 +10,29 @@ variable "kops_ecr_app_enabled" {
 
 module "kops_ecr_app" {
   source    = "git::https://github.com/cloudposse/terraform-aws-ecr.git?ref=tags/0.6.1"
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
-  name      = "${var.kops_ecr_app_repository_name}"
+  namespace = var.namespace
+  stage     = var.stage
+  name      = var.kops_ecr_app_repository_name
 
-  enabled = "${var.kops_ecr_app_enabled}"
+  enabled = var.kops_ecr_app_enabled
 
   principals_full_access     = ["${local.principals_full_access}"]
   principals_readonly_access = ["${local.principals_readonly_access}"]
 
-  tags = "${module.label.tags}"
+  tags = module.label.tags
 }
 
 output "kops_ecr_app_registry_id" {
-  value       = "${module.kops_ecr_app.registry_id}"
+  value       = module.kops_ecr_app.registry_id
   description = "Registry app ID"
 }
 
 output "kops_ecr_app_registry_url" {
-  value       = "${module.kops_ecr_app.registry_url}"
+  value       = module.kops_ecr_app.registry_url
   description = "Registry app URL"
 }
 
 output "kops_ecr_app_repository_name" {
-  value       = "${module.kops_ecr_app.repository_name}"
+  value       = module.kops_ecr_app.repository_name
   description = "Registry app name"
 }

--- a/deprecated/aws/ecr/kops_ecr_user.tf
+++ b/deprecated/aws/ecr/kops_ecr_user.tf
@@ -1,10 +1,10 @@
 module "kops_ecr_user" {
   source    = "git::https://github.com/cloudposse/terraform-aws-iam-system-user.git?ref=tags/0.3.0"
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
+  namespace = var.namespace
+  stage     = var.stage
   name      = "cicd"
 
-  tags = "${module.label.tags}"
+  tags = module.label.tags
 }
 
 data "aws_iam_policy_document" "login" {
@@ -17,38 +17,38 @@ data "aws_iam_policy_document" "login" {
 }
 
 resource "aws_iam_policy" "login" {
-  name   = "${module.label.id}"
-  policy = "${data.aws_iam_policy_document.login.json}"
+  name   = module.label.id
+  policy = data.aws_iam_policy_document.login.json
 }
 
 resource "aws_iam_user_policy_attachment" "user_login" {
-  user       = "${module.kops_ecr_user.user_name}"
-  policy_arn = "${aws_iam_policy.login.arn}"
+  user       = module.kops_ecr_user.user_name
+  policy_arn = aws_iam_policy.login.arn
 }
 
 output "kops_ecr_user_name" {
-  value       = "${module.kops_ecr_user.user_name}"
+  value       = module.kops_ecr_user.user_name
   description = "Normalized IAM user name"
 }
 
 output "kops_ecr_user_arn" {
-  value       = "${module.kops_ecr_user.user_arn}"
+  value       = module.kops_ecr_user.user_arn
   description = "The ARN assigned by AWS for the user"
 }
 
 output "kops_ecr_user_unique_id" {
-  value       = "${module.kops_ecr_user.user_unique_id}"
+  value       = module.kops_ecr_user.user_unique_id
   description = "The user unique ID assigned by AWS"
 }
 
 output "kops_ecr_user_access_key_id" {
   sensitive   = true
-  value       = "${module.kops_ecr_user.access_key_id}"
+  value       = module.kops_ecr_user.access_key_id
   description = "The access key ID"
 }
 
 output "kops_ecr_user_secret_access_key" {
   sensitive   = true
-  value       = "${module.kops_ecr_user.secret_access_key}"
+  value       = module.kops_ecr_user.secret_access_key
   description = "The secret access key. This will be written to the state file in plain-text"
 }

--- a/deprecated/aws/ecr/main.tf
+++ b/deprecated/aws/ecr/main.tf
@@ -5,39 +5,39 @@ terraform {
 }
 
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "cluster_name" {
-  type        = "string"
+  type        = string
   description = "kops cluster name"
 }
 
 variable "external_principals_full_access" {
-  type        = "list"
+  type        = list(string)
   description = "Principal ARN to provide with full access to the ECR"
   default     = []
 }
 
 variable "external_principals_readonly_access" {
-  type        = "list"
+  type        = list(string)
   description = "Principal ARN to provide with readonly access to the ECR"
   default     = []
 }
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
@@ -48,13 +48,13 @@ locals {
 
 module "label" {
   source    = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.5.4"
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
+  namespace = var.namespace
+  stage     = var.stage
   name      = "ecr"
-  tags      = "${map("Cluster", var.cluster_name)}"
+  tags      = map("Cluster", var.cluster_name)
 }
 
 module "kops_metadata" {
   source       = "git::https://github.com/cloudposse/terraform-aws-kops-data-iam.git?ref=tags/0.1.0"
-  cluster_name = "${var.cluster_name}"
+  cluster_name = var.cluster_name
 }

--- a/deprecated/aws/eks-backing-services-peering/main.tf
+++ b/deprecated/aws/eks-backing-services-peering/main.tf
@@ -16,12 +16,12 @@ data "aws_vpc" "backing_services_vpc" {
 
 module "vpc_peering" {
   source           = "git::https://github.com/cloudposse/terraform-aws-vpc-peering.git?ref=tags/0.1.2"
-  namespace        = "${var.namespace}"
-  stage            = "${var.stage}"
-  name             = "${var.name}"
-  delimiter        = "${var.delimiter}"
+  namespace        = var.namespace
+  stage            = var.stage
+  name             = var.name
+  delimiter        = var.delimiter
   attributes       = ["${compact(concat(var.attributes, list("peering")))}"]
-  tags             = "${var.tags}"
-  requestor_vpc_id = "${data.aws_vpc.eks_vpc.id}"
-  acceptor_vpc_id  = "${data.aws_vpc.backing_services_vpc.id}"
+  tags             = var.tags
+  requestor_vpc_id = data.aws_vpc.eks_vpc.id
+  acceptor_vpc_id  = data.aws_vpc.backing_services_vpc.id
 }

--- a/deprecated/aws/eks-backing-services-peering/outputs.tf
+++ b/deprecated/aws/eks-backing-services-peering/outputs.tf
@@ -1,9 +1,9 @@
 output "vpc_peering_connection_id" {
-  value       = "${module.vpc_peering.connection_id}"
+  value       = module.vpc_peering.connection_id
   description = "VPC peering connection ID"
 }
 
 output "vpc_peering_accept_status" {
-  value       = "${module.vpc_peering.accept_status}"
+  value       = module.vpc_peering.accept_status
   description = "The status of the VPC peering connection request"
 }

--- a/deprecated/aws/eks-backing-services-peering/variables.tf
+++ b/deprecated/aws/eks-backing-services-peering/variables.tf
@@ -1,33 +1,33 @@
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace, which could be your organization name, e.g. 'eg' or 'cp'"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage, e.g. 'prod', 'staging', 'dev' or 'testing'"
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   default     = "eks"
   description = "Solution name, e.g. 'app' or 'cluster'"
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `name`, `namespace`, `stage`, etc."
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Additional attributes (e.g. `1`)"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
 }

--- a/deprecated/aws/eks/eks.tf
+++ b/deprecated/aws/eks/eks.tf
@@ -1,89 +1,89 @@
 module "label" {
   source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.1.6"
-  namespace  = "${var.namespace}"
-  name       = "${var.name}"
-  stage      = "${var.stage}"
-  delimiter  = "${var.delimiter}"
-  attributes = "${var.attributes}"
-  tags       = "${var.tags}"
-  enabled    = "${var.enabled}"
+  namespace  = var.namespace
+  name       = var.name
+  stage      = var.stage
+  delimiter  = var.delimiter
+  attributes = var.attributes
+  tags       = var.tags
+  enabled    = var.enabled
 }
 
 locals {
   # The usage of the specific kubernetes.io/cluster/* resource tags below are required
   # for EKS and Kubernetes to discover and manage networking resources
   # https://www.terraform.io/docs/providers/aws/guides/eks-getting-started.html#base-vpc-networking
-  tags = "${merge(var.tags, map("kubernetes.io/cluster/${module.label.id}", "shared"))}"
+  tags = merge(var.tags, map("kubernetes.io/cluster/${module.label.id}", "shared"))
 }
 
 data "aws_availability_zones" "available" {}
 
 module "vpc" {
   source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.3.4"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
-  attributes = "${var.attributes}"
-  tags       = "${local.tags}"
-  cidr_block = "${var.vpc_cidr_block}"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  attributes = var.attributes
+  tags       = local.tags
+  cidr_block = var.vpc_cidr_block
 }
 
 module "subnets" {
   source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.3.6"
   availability_zones  = ["${data.aws_availability_zones.available.names}"]
-  namespace           = "${var.namespace}"
-  stage               = "${var.stage}"
-  name                = "${var.name}"
-  attributes          = "${var.attributes}"
-  tags                = "${local.tags}"
-  region              = "${var.region}"
-  vpc_id              = "${module.vpc.vpc_id}"
-  igw_id              = "${module.vpc.igw_id}"
-  cidr_block          = "${module.vpc.vpc_cidr_block}"
+  namespace           = var.namespace
+  stage               = var.stage
+  name                = var.name
+  attributes          = var.attributes
+  tags                = local.tags
+  region              = var.region
+  vpc_id              = module.vpc.vpc_id
+  igw_id              = module.vpc.igw_id
+  cidr_block          = module.vpc.vpc_cidr_block
   nat_gateway_enabled = "true"
 }
 
 module "eks_cluster" {
   source                  = "git::https://github.com/cloudposse/terraform-aws-eks-cluster.git?ref=tags/0.1.1"
-  namespace               = "${var.namespace}"
-  stage                   = "${var.stage}"
-  name                    = "${var.name}"
-  attributes              = "${var.attributes}"
-  tags                    = "${var.tags}"
-  vpc_id                  = "${module.vpc.vpc_id}"
+  namespace               = var.namespace
+  stage                   = var.stage
+  name                    = var.name
+  attributes              = var.attributes
+  tags                    = var.tags
+  vpc_id                  = module.vpc.vpc_id
   subnet_ids              = ["${module.subnets.public_subnet_ids}"]
   allowed_security_groups = ["${distinct(compact(concat(var.allowed_security_groups_cluster, list(module.eks_workers.security_group_id))))}"]
   allowed_cidr_blocks     = ["${var.allowed_cidr_blocks_cluster}"]
-  enabled                 = "${var.enabled}"
+  enabled                 = var.enabled
 }
 
 module "eks_workers" {
   source                             = "git::https://github.com/cloudposse/terraform-aws-eks-workers.git?ref=tags/0.1.1"
-  namespace                          = "${var.namespace}"
-  stage                              = "${var.stage}"
-  name                               = "${var.name}"
-  attributes                         = "${var.attributes}"
-  tags                               = "${var.tags}"
-  image_id                           = "${var.image_id}"
-  eks_worker_ami_name_filter         = "${var.eks_worker_ami_name_filter}"
-  instance_type                      = "${var.instance_type}"
-  vpc_id                             = "${module.vpc.vpc_id}"
+  namespace                          = var.namespace
+  stage                              = var.stage
+  name                               = var.name
+  attributes                         = var.attributes
+  tags                               = var.tags
+  image_id                           = var.image_id
+  eks_worker_ami_name_filter         = var.eks_worker_ami_name_filter
+  instance_type                      = var.instance_type
+  vpc_id                             = module.vpc.vpc_id
   subnet_ids                         = ["${module.subnets.public_subnet_ids}"]
-  health_check_type                  = "${var.health_check_type}"
-  min_size                           = "${var.min_size}"
-  max_size                           = "${var.max_size}"
-  wait_for_capacity_timeout          = "${var.wait_for_capacity_timeout}"
-  associate_public_ip_address        = "${var.associate_public_ip_address}"
-  cluster_name                       = "${module.eks_cluster.eks_cluster_id}"
-  cluster_endpoint                   = "${module.eks_cluster.eks_cluster_endpoint}"
-  cluster_certificate_authority_data = "${module.eks_cluster.eks_cluster_certificate_authority_data}"
-  cluster_security_group_id          = "${module.eks_cluster.security_group_id}"
+  health_check_type                  = var.health_check_type
+  min_size                           = var.min_size
+  max_size                           = var.max_size
+  wait_for_capacity_timeout          = var.wait_for_capacity_timeout
+  associate_public_ip_address        = var.associate_public_ip_address
+  cluster_name                       = module.eks_cluster.eks_cluster_id
+  cluster_endpoint                   = module.eks_cluster.eks_cluster_endpoint
+  cluster_certificate_authority_data = module.eks_cluster.eks_cluster_certificate_authority_data
+  cluster_security_group_id          = module.eks_cluster.security_group_id
   allowed_security_groups            = ["${var.allowed_security_groups_workers}"]
   allowed_cidr_blocks                = ["${var.allowed_cidr_blocks_workers}"]
-  enabled                            = "${var.enabled}"
+  enabled                            = var.enabled
 
   # Auto-scaling policies and CloudWatch metric alarms
-  autoscaling_policies_enabled           = "${var.autoscaling_policies_enabled}"
-  cpu_utilization_high_threshold_percent = "${var.cpu_utilization_high_threshold_percent}"
-  cpu_utilization_low_threshold_percent  = "${var.cpu_utilization_low_threshold_percent}"
+  autoscaling_policies_enabled           = var.autoscaling_policies_enabled
+  cpu_utilization_high_threshold_percent = var.cpu_utilization_high_threshold_percent
+  cpu_utilization_low_threshold_percent  = var.cpu_utilization_low_threshold_percent
 }

--- a/deprecated/aws/eks/kubectl.tf
+++ b/deprecated/aws/eks/kubectl.tf
@@ -4,26 +4,26 @@ locals {
 }
 
 resource "local_file" "kubeconfig" {
-  count    = "${var.enabled == "true" && var.apply_config_map_aws_auth == "true" ? 1 : 0}"
-  content  = "${module.eks_cluster.kubeconfig}"
-  filename = "${local.kubeconfig_filename}"
+  count    = var.enabled == "true" && var.apply_config_map_aws_auth == "true" ? 1 : 0
+  content  = module.eks_cluster.kubeconfig
+  filename = local.kubeconfig_filename
 }
 
 resource "local_file" "config_map_aws_auth" {
-  count    = "${var.enabled == "true" && var.apply_config_map_aws_auth == "true" ? 1 : 0}"
-  content  = "${module.eks_workers.config_map_aws_auth}"
-  filename = "${local.config_map_aws_auth_filename}"
+  count    = var.enabled == "true" && var.apply_config_map_aws_auth == "true" ? 1 : 0
+  content  = module.eks_workers.config_map_aws_auth
+  filename = local.config_map_aws_auth_filename
 }
 
 resource "null_resource" "apply_config_map_aws_auth" {
-  count = "${var.enabled == "true" && var.apply_config_map_aws_auth == "true" ? 1 : 0}"
+  count = var.enabled == "true" && var.apply_config_map_aws_auth == "true" ? 1 : 0
 
   provisioner "local-exec" {
     command = "kubectl apply -f ${local.config_map_aws_auth_filename} --kubeconfig ${local.kubeconfig_filename}"
   }
 
   triggers {
-    kubeconfig_rendered          = "${module.eks_cluster.kubeconfig}"
-    config_map_aws_auth_rendered = "${module.eks_workers.config_map_aws_auth}"
+    kubeconfig_rendered          = module.eks_cluster.kubeconfig
+    config_map_aws_auth_rendered = module.eks_workers.config_map_aws_auth
   }
 }

--- a/deprecated/aws/eks/main.tf
+++ b/deprecated/aws/eks/main.tf
@@ -5,11 +5,11 @@ terraform {
 }
 
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }

--- a/deprecated/aws/eks/outputs.tf
+++ b/deprecated/aws/eks/outputs.tf
@@ -1,119 +1,119 @@
 output "kubeconfig" {
   description = "`kubeconfig` configuration to connect to the cluster using `kubectl`. https://www.terraform.io/docs/providers/aws/guides/eks-getting-started.html#obtaining-kubectl-configuration-from-terraform"
-  value       = "${module.eks_cluster.kubeconfig}"
+  value       = module.eks_cluster.kubeconfig
 }
 
 output "config_map_aws_auth" {
   description = "Kubernetes ConfigMap configuration to allow the worker nodes to join the EKS cluster. https://www.terraform.io/docs/providers/aws/guides/eks-getting-started.html#required-kubernetes-configuration-to-join-worker-nodes"
-  value       = "${module.eks_workers.config_map_aws_auth}"
+  value       = module.eks_workers.config_map_aws_auth
 }
 
 output "eks_cluster_security_group_id" {
   description = "ID of the EKS cluster Security Group"
-  value       = "${module.eks_cluster.security_group_id}"
+  value       = module.eks_cluster.security_group_id
 }
 
 output "eks_cluster_security_group_arn" {
   description = "ARN of the EKS cluster Security Group"
-  value       = "${module.eks_cluster.security_group_arn}"
+  value       = module.eks_cluster.security_group_arn
 }
 
 output "eks_cluster_security_group_name" {
   description = "Name of the EKS cluster Security Group"
-  value       = "${module.eks_cluster.security_group_name}"
+  value       = module.eks_cluster.security_group_name
 }
 
 output "eks_cluster_id" {
   description = "The name of the cluster"
-  value       = "${module.eks_cluster.eks_cluster_id}"
+  value       = module.eks_cluster.eks_cluster_id
 }
 
 output "eks_cluster_arn" {
   description = "The Amazon Resource Name (ARN) of the cluster"
-  value       = "${module.eks_cluster.eks_cluster_arn}"
+  value       = module.eks_cluster.eks_cluster_arn
 }
 
 output "eks_cluster_certificate_authority_data" {
   description = "The base64 encoded certificate data required to communicate with the cluster"
-  value       = "${module.eks_cluster.eks_cluster_certificate_authority_data}"
+  value       = module.eks_cluster.eks_cluster_certificate_authority_data
 }
 
 output "eks_cluster_endpoint" {
   description = "The endpoint for the Kubernetes API server"
-  value       = "${module.eks_cluster.eks_cluster_endpoint}"
+  value       = module.eks_cluster.eks_cluster_endpoint
 }
 
 output "eks_cluster_version" {
   description = "The Kubernetes server version of the cluster"
-  value       = "${module.eks_cluster.eks_cluster_version}"
+  value       = module.eks_cluster.eks_cluster_version
 }
 
 output "workers_launch_template_id" {
   description = "ID of the launch template"
-  value       = "${module.eks_workers.launch_template_id}"
+  value       = module.eks_workers.launch_template_id
 }
 
 output "workers_launch_template_arn" {
   description = "ARN of the launch template"
-  value       = "${module.eks_workers.launch_template_arn}"
+  value       = module.eks_workers.launch_template_arn
 }
 
 output "workers_autoscaling_group_id" {
   description = "The AutoScaling Group ID"
-  value       = "${module.eks_workers.autoscaling_group_id}"
+  value       = module.eks_workers.autoscaling_group_id
 }
 
 output "workers_autoscaling_group_name" {
   description = "The AutoScaling Group name"
-  value       = "${module.eks_workers.autoscaling_group_name}"
+  value       = module.eks_workers.autoscaling_group_name
 }
 
 output "workers_autoscaling_group_arn" {
   description = "ARN of the AutoScaling Group"
-  value       = "${module.eks_workers.autoscaling_group_arn}"
+  value       = module.eks_workers.autoscaling_group_arn
 }
 
 output "workers_autoscaling_group_min_size" {
   description = "The minimum size of the AutoScaling Group"
-  value       = "${module.eks_workers.autoscaling_group_min_size}"
+  value       = module.eks_workers.autoscaling_group_min_size
 }
 
 output "workers_autoscaling_group_max_size" {
   description = "The maximum size of the AutoScaling Group"
-  value       = "${module.eks_workers.autoscaling_group_max_size}"
+  value       = module.eks_workers.autoscaling_group_max_size
 }
 
 output "workers_autoscaling_group_desired_capacity" {
   description = "The number of Amazon EC2 instances that should be running in the group"
-  value       = "${module.eks_workers.autoscaling_group_desired_capacity}"
+  value       = module.eks_workers.autoscaling_group_desired_capacity
 }
 
 output "workers_autoscaling_group_default_cooldown" {
   description = "Time between a scaling activity and the succeeding scaling activity"
-  value       = "${module.eks_workers.autoscaling_group_default_cooldown}"
+  value       = module.eks_workers.autoscaling_group_default_cooldown
 }
 
 output "workers_autoscaling_group_health_check_grace_period" {
   description = "Time after instance comes into service before checking health"
-  value       = "${module.eks_workers.autoscaling_group_health_check_grace_period}"
+  value       = module.eks_workers.autoscaling_group_health_check_grace_period
 }
 
 output "workers_autoscaling_group_health_check_type" {
   description = "`EC2` or `ELB`. Controls how health checking is done"
-  value       = "${module.eks_workers.autoscaling_group_health_check_type}"
+  value       = module.eks_workers.autoscaling_group_health_check_type
 }
 
 output "workers_security_group_id" {
   description = "ID of the worker nodes Security Group"
-  value       = "${module.eks_workers.security_group_id}"
+  value       = module.eks_workers.security_group_id
 }
 
 output "workers_security_group_arn" {
   description = "ARN of the worker nodes Security Group"
-  value       = "${module.eks_workers.security_group_arn}"
+  value       = module.eks_workers.security_group_arn
 }
 
 output "workers_security_group_name" {
   description = "Name of the worker nodes Security Group"
-  value       = "${module.eks_workers.security_group_name}"
+  value       = module.eks_workers.security_group_name
 }

--- a/deprecated/aws/eks/variables.tf
+++ b/deprecated/aws/eks/variables.tf
@@ -1,98 +1,98 @@
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace, which could be your organization name, e.g. 'eg' or 'cp'"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage, e.g. 'prod', 'staging', 'dev' or 'testing'"
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   default     = "eks"
   description = "Solution name, e.g. 'app' or 'cluster'"
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `name`, `namespace`, `stage`, etc."
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Additional attributes (e.g. `1`)"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
 }
 
 variable "enabled" {
-  type        = "string"
+  type        = string
   description = "Whether to create the resources. Set to `false` to prevent the module from creating any resources"
   default     = "true"
 }
 
 variable "allowed_security_groups_cluster" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "List of Security Group IDs to be allowed to connect to the EKS cluster"
 }
 
 variable "allowed_security_groups_workers" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "List of Security Group IDs to be allowed to connect to the worker nodes"
 }
 
 variable "allowed_cidr_blocks_cluster" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "List of CIDR blocks to be allowed to connect to the EKS cluster"
 }
 
 variable "allowed_cidr_blocks_workers" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "List of CIDR blocks to be allowed to connect to the worker nodes"
 }
 
 variable "region" {
-  type        = "string"
+  type        = string
   description = "AWS Region"
 }
 
 variable "vpc_cidr_block" {
-  type        = "string"
+  type        = string
   default     = "172.30.0.0/16"
   description = "VPC CIDR block. See https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html for more details"
 }
 
 variable "image_id" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "EC2 image ID to launch. If not provided, the module will lookup the most recent EKS AMI. See https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html for more details on EKS-optimized images"
 }
 
 variable "eks_worker_ami_name_filter" {
-  type        = "string"
+  type        = string
   description = "AMI name filter to lookup the most recent EKS AMI if `image_id` is not provided"
   default     = "amazon-eks-node-v*"
 }
 
 variable "instance_type" {
-  type        = "string"
+  type        = string
   default     = "t2.medium"
   description = "Instance type to launch"
 }
 
 variable "health_check_type" {
-  type        = "string"
+  type        = string
   description = "Controls how health checking is done. Valid values are `EC2` or `ELB`"
   default     = "EC2"
 }
@@ -108,7 +108,7 @@ variable "min_size" {
 }
 
 variable "wait_for_capacity_timeout" {
-  type        = "string"
+  type        = string
   description = "A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior"
   default     = "10m"
 }
@@ -119,25 +119,25 @@ variable "associate_public_ip_address" {
 }
 
 variable "autoscaling_policies_enabled" {
-  type        = "string"
+  type        = string
   default     = "true"
   description = "Whether to create `aws_autoscaling_policy` and `aws_cloudwatch_metric_alarm` resources to control Auto Scaling"
 }
 
 variable "cpu_utilization_high_threshold_percent" {
-  type        = "string"
+  type        = string
   default     = "80"
   description = "Worker nodes AutoScaling Group CPU utilization high threshold percent"
 }
 
 variable "cpu_utilization_low_threshold_percent" {
-  type        = "string"
+  type        = string
   default     = "20"
   description = "Worker nodes AutoScaling Group CPU utilization low threshold percent"
 }
 
 variable "apply_config_map_aws_auth" {
-  type        = "string"
+  type        = string
   default     = "true"
   description = "Whether to generate local files from `kubeconfig` and `config_map_aws_auth` and perform `kubectl apply` to apply the ConfigMap to allow the worker nodes to join the EKS cluster"
 }

--- a/deprecated/aws/iam/audit.tf
+++ b/deprecated/aws/iam/audit.tf
@@ -1,5 +1,5 @@
 variable "audit_account_user_names" {
-  type        = "list"
+  type        = list(string)
   description = "IAM user names to grant access to the `audit` account"
   default     = []
 }
@@ -7,18 +7,18 @@ variable "audit_account_user_names" {
 # Provision group access to audit account. Careful! Very few people, if any should have access to this account.
 module "organization_access_group_audit" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
-  enabled           = "${contains(var.accounts_enabled, "audit") == true ? "true" : "false"}"
-  namespace         = "${var.namespace}"
+  enabled           = contains(var.accounts_enabled, "audit") == true ? "true" : "false"
+  namespace         = var.namespace
   stage             = "audit"
   name              = "admin"
-  user_names        = "${var.audit_account_user_names}"
-  member_account_id = "${data.terraform_remote_state.accounts.audit_account_id}"
+  user_names        = var.audit_account_user_names
+  member_account_id = data.terraform_remote_state.accounts.audit_account_id
   require_mfa       = "true"
 }
 
 module "organization_access_group_ssm_audit" {
   source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
-  enabled = "${contains(var.accounts_enabled, "audit") == true ? "true" : "false"}"
+  enabled = contains(var.accounts_enabled, "audit") == true ? "true" : "false"
 
   parameter_write = [
     {
@@ -33,5 +33,5 @@ module "organization_access_group_ssm_audit" {
 
 output "audit_switchrole_url" {
   description = "URL to the IAM console to switch to the audit account organization access role"
-  value       = "${module.organization_access_group_audit.switchrole_url}"
+  value       = module.organization_access_group_audit.switchrole_url
 }

--- a/deprecated/aws/iam/corp.tf
+++ b/deprecated/aws/iam/corp.tf
@@ -1,5 +1,5 @@
 variable "corp_account_user_names" {
-  type        = "list"
+  type        = list(string)
   description = "IAM user names to grant access to the `corp` account"
   default     = []
 }
@@ -7,18 +7,18 @@ variable "corp_account_user_names" {
 # Provision group access to corp account
 module "organization_access_group_corp" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
-  enabled           = "${contains(var.accounts_enabled, "corp") == true ? "true" : "false"}"
-  namespace         = "${var.namespace}"
+  enabled           = contains(var.accounts_enabled, "corp") == true ? "true" : "false"
+  namespace         = var.namespace
   stage             = "corp"
   name              = "admin"
-  user_names        = "${var.corp_account_user_names}"
-  member_account_id = "${data.terraform_remote_state.accounts.corp_account_id}"
+  user_names        = var.corp_account_user_names
+  member_account_id = data.terraform_remote_state.accounts.corp_account_id
   require_mfa       = "true"
 }
 
 module "organization_access_group_ssm_corp" {
   source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
-  enabled = "${contains(var.accounts_enabled, "corp") == true ? "true" : "false"}"
+  enabled = contains(var.accounts_enabled, "corp") == true ? "true" : "false"
 
   parameter_write = [
     {
@@ -33,5 +33,5 @@ module "organization_access_group_ssm_corp" {
 
 output "corp_switchrole_url" {
   description = "URL to the IAM console to switch to the corp account organization access role"
-  value       = "${module.organization_access_group_corp.switchrole_url}"
+  value       = module.organization_access_group_corp.switchrole_url
 }

--- a/deprecated/aws/iam/data.tf
+++ b/deprecated/aws/iam/data.tf
@@ -1,5 +1,5 @@
 variable "data_account_user_names" {
-  type        = "list"
+  type        = list(string)
   description = "IAM user names to grant access to the `data` account"
   default     = []
 }
@@ -7,18 +7,18 @@ variable "data_account_user_names" {
 # Provision group access to data account
 module "organization_access_group_data" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
-  enabled           = "${contains(var.accounts_enabled, "data") == true ? "true" : "false"}"
-  namespace         = "${var.namespace}"
+  enabled           = contains(var.accounts_enabled, "data") == true ? "true" : "false"
+  namespace         = var.namespace
   stage             = "data"
   name              = "admin"
-  user_names        = "${var.data_account_user_names}"
-  member_account_id = "${data.terraform_remote_state.accounts.data_account_id}"
+  user_names        = var.data_account_user_names
+  member_account_id = data.terraform_remote_state.accounts.data_account_id
   require_mfa       = "true"
 }
 
 module "organization_access_group_ssm_data" {
   source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
-  enabled = "${contains(var.accounts_enabled, "data") == true ? "true" : "false"}"
+  enabled = contains(var.accounts_enabled, "data") == true ? "true" : "false"
 
   parameter_write = [
     {
@@ -33,5 +33,5 @@ module "organization_access_group_ssm_data" {
 
 output "data_switchrole_url" {
   description = "URL to the IAM console to switch to the data account organization access role"
-  value       = "${module.organization_access_group_data.switchrole_url}"
+  value       = module.organization_access_group_data.switchrole_url
 }

--- a/deprecated/aws/iam/dev.tf
+++ b/deprecated/aws/iam/dev.tf
@@ -1,5 +1,5 @@
 variable "dev_account_user_names" {
-  type        = "list"
+  type        = list(string)
   description = "IAM user names to grant access to the `dev` account"
   default     = []
 }
@@ -7,18 +7,18 @@ variable "dev_account_user_names" {
 # Provision group access to dev account
 module "organization_access_group_dev" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
-  enabled           = "${contains(var.accounts_enabled, "dev") == true ? "true" : "false"}"
-  namespace         = "${var.namespace}"
+  enabled           = contains(var.accounts_enabled, "dev") == true ? "true" : "false"
+  namespace         = var.namespace
   stage             = "dev"
   name              = "admin"
-  user_names        = "${var.dev_account_user_names}"
-  member_account_id = "${data.terraform_remote_state.accounts.dev_account_id}"
+  user_names        = var.dev_account_user_names
+  member_account_id = data.terraform_remote_state.accounts.dev_account_id
   require_mfa       = "true"
 }
 
 module "organization_access_group_ssm_dev" {
   source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
-  enabled = "${contains(var.accounts_enabled, "dev") == true ? "true" : "false"}"
+  enabled = contains(var.accounts_enabled, "dev") == true ? "true" : "false"
 
   parameter_write = [
     {
@@ -33,5 +33,5 @@ module "organization_access_group_ssm_dev" {
 
 output "dev_switchrole_url" {
   description = "URL to the IAM console to switch to the dev account organization access role"
-  value       = "${module.organization_access_group_dev.switchrole_url}"
+  value       = module.organization_access_group_dev.switchrole_url
 }

--- a/deprecated/aws/iam/identity.tf
+++ b/deprecated/aws/iam/identity.tf
@@ -1,5 +1,5 @@
 variable "identity_account_user_names" {
-  type        = "list"
+  type        = list(string)
   description = "IAM user names to grant access to the `identity` account"
   default     = []
 }
@@ -7,18 +7,18 @@ variable "identity_account_user_names" {
 # Provision group access to identity account
 module "organization_access_group_identity" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
-  enabled           = "${contains(var.accounts_enabled, "identity") == true ? "true" : "false"}"
-  namespace         = "${var.namespace}"
+  enabled           = contains(var.accounts_enabled, "identity") == true ? "true" : "false"
+  namespace         = var.namespace
   stage             = "identity"
   name              = "admin"
-  user_names        = "${var.identity_account_user_names}"
-  member_account_id = "${data.terraform_remote_state.accounts.identity_account_id}"
+  user_names        = var.identity_account_user_names
+  member_account_id = data.terraform_remote_state.accounts.identity_account_id
   require_mfa       = "true"
 }
 
 module "organization_access_group_ssm_identity" {
   source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
-  enabled = "${contains(var.accounts_enabled, "identity") == true ? "true" : "false"}"
+  enabled = contains(var.accounts_enabled, "identity") == true ? "true" : "false"
 
   parameter_write = [
     {
@@ -33,5 +33,5 @@ module "organization_access_group_ssm_identity" {
 
 output "identity_switchrole_url" {
   description = "URL to the IAM console to switch to the identity account organization access role"
-  value       = "${module.organization_access_group_identity.switchrole_url}"
+  value       = module.organization_access_group_identity.switchrole_url
 }

--- a/deprecated/aws/iam/main.tf
+++ b/deprecated/aws/iam/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 

--- a/deprecated/aws/iam/prod.tf
+++ b/deprecated/aws/iam/prod.tf
@@ -1,5 +1,5 @@
 variable "prod_account_user_names" {
-  type        = "list"
+  type        = list(string)
   description = "IAM user names to grant access to the `prod` account"
   default     = []
 }
@@ -7,18 +7,18 @@ variable "prod_account_user_names" {
 # Provision group access to production account
 module "organization_access_group_prod" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
-  enabled           = "${contains(var.accounts_enabled, "prod") == true ? "true" : "false"}"
-  namespace         = "${var.namespace}"
+  enabled           = contains(var.accounts_enabled, "prod") == true ? "true" : "false"
+  namespace         = var.namespace
   stage             = "prod"
   name              = "admin"
-  user_names        = "${var.prod_account_user_names}"
-  member_account_id = "${data.terraform_remote_state.accounts.prod_account_id}"
+  user_names        = var.prod_account_user_names
+  member_account_id = data.terraform_remote_state.accounts.prod_account_id
   require_mfa       = "true"
 }
 
 module "organization_access_group_ssm_prod" {
   source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
-  enabled = "${contains(var.accounts_enabled, "prod") == true ? "true" : "false"}"
+  enabled = contains(var.accounts_enabled, "prod") == true ? "true" : "false"
 
   parameter_write = [
     {
@@ -33,5 +33,5 @@ module "organization_access_group_ssm_prod" {
 
 output "prod_switchrole_url" {
   description = "URL to the IAM console to switch to the prod account organization access role"
-  value       = "${module.organization_access_group_prod.switchrole_url}"
+  value       = module.organization_access_group_prod.switchrole_url
 }

--- a/deprecated/aws/iam/security.tf
+++ b/deprecated/aws/iam/security.tf
@@ -1,5 +1,5 @@
 variable "security_account_user_names" {
-  type        = "list"
+  type        = list(string)
   description = "IAM user names to grant access to the `security` account"
   default     = []
 }
@@ -7,18 +7,18 @@ variable "security_account_user_names" {
 # Provision group access to security account
 module "organization_access_group_security" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
-  enabled           = "${contains(var.accounts_enabled, "security") == true ? "true" : "false"}"
-  namespace         = "${var.namespace}"
+  enabled           = contains(var.accounts_enabled, "security") == true ? "true" : "false"
+  namespace         = var.namespace
   stage             = "security"
   name              = "admin"
-  user_names        = "${var.security_account_user_names}"
-  member_account_id = "${data.terraform_remote_state.accounts.security_account_id}"
+  user_names        = var.security_account_user_names
+  member_account_id = data.terraform_remote_state.accounts.security_account_id
   require_mfa       = "true"
 }
 
 module "organization_access_group_ssm_security" {
   source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
-  enabled = "${contains(var.accounts_enabled, "security") == true ? "true" : "false"}"
+  enabled = contains(var.accounts_enabled, "security") == true ? "true" : "false"
 
   parameter_write = [
     {
@@ -33,5 +33,5 @@ module "organization_access_group_ssm_security" {
 
 output "security_switchrole_url" {
   description = "URL to the IAM console to switch to the security account organization access role"
-  value       = "${module.organization_access_group_security.switchrole_url}"
+  value       = module.organization_access_group_security.switchrole_url
 }

--- a/deprecated/aws/iam/staging.tf
+++ b/deprecated/aws/iam/staging.tf
@@ -1,5 +1,5 @@
 variable "staging_account_user_names" {
-  type        = "list"
+  type        = list(string)
   description = "IAM user names to grant access to the `staging` account"
   default     = []
 }
@@ -7,18 +7,18 @@ variable "staging_account_user_names" {
 # Provision group access to staging account
 module "organization_access_group_staging" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
-  enabled           = "${contains(var.accounts_enabled, "staging") == true ? "true" : "false"}"
-  namespace         = "${var.namespace}"
+  enabled           = contains(var.accounts_enabled, "staging") == true ? "true" : "false"
+  namespace         = var.namespace
   stage             = "staging"
   name              = "admin"
-  user_names        = "${var.staging_account_user_names}"
-  member_account_id = "${data.terraform_remote_state.accounts.staging_account_id}"
+  user_names        = var.staging_account_user_names
+  member_account_id = data.terraform_remote_state.accounts.staging_account_id
   require_mfa       = "true"
 }
 
 module "organization_access_group_ssm_staging" {
   source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
-  enabled = "${contains(var.accounts_enabled, "staging") == true ? "true" : "false"}"
+  enabled = contains(var.accounts_enabled, "staging") == true ? "true" : "false"
 
   parameter_write = [
     {
@@ -33,5 +33,5 @@ module "organization_access_group_ssm_staging" {
 
 output "staging_switchrole_url" {
   description = "URL to the IAM console to switch to the staging account organization access role"
-  value       = "${module.organization_access_group_staging.switchrole_url}"
+  value       = module.organization_access_group_staging.switchrole_url
 }

--- a/deprecated/aws/iam/testing.tf
+++ b/deprecated/aws/iam/testing.tf
@@ -1,5 +1,5 @@
 variable "testing_account_user_names" {
-  type        = "list"
+  type        = list(string)
   description = "IAM user names to grant access to the `testing` account"
   default     = []
 }
@@ -7,18 +7,18 @@ variable "testing_account_user_names" {
 # Provision group access to testing account
 module "organization_access_group_testing" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
-  enabled           = "${contains(var.accounts_enabled, "testing") == true ? "true" : "false"}"
-  namespace         = "${var.namespace}"
+  enabled           = contains(var.accounts_enabled, "testing") == true ? "true" : "false"
+  namespace         = var.namespace
   stage             = "testing"
   name              = "admin"
-  user_names        = "${var.testing_account_user_names}"
-  member_account_id = "${data.terraform_remote_state.accounts.testing_account_id}"
+  user_names        = var.testing_account_user_names
+  member_account_id = data.terraform_remote_state.accounts.testing_account_id
   require_mfa       = "true"
 }
 
 module "organization_access_group_ssm_testing" {
   source  = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
-  enabled = "${contains(var.accounts_enabled, "testing") == true ? "true" : "false"}"
+  enabled = contains(var.accounts_enabled, "testing") == true ? "true" : "false"
 
   parameter_write = [
     {
@@ -33,5 +33,5 @@ module "organization_access_group_ssm_testing" {
 
 output "testing_switchrole_url" {
   description = "URL to the IAM console to switch to the testing account organization access role"
-  value       = "${module.organization_access_group_testing.switchrole_url}"
+  value       = module.organization_access_group_testing.switchrole_url
 }

--- a/deprecated/aws/iam/variables.tf
+++ b/deprecated/aws/iam/variables.tf
@@ -1,19 +1,19 @@
 variable "accounts_enabled" {
-  type        = "list"
+  type        = list(string)
   description = "Accounts to enable"
   default     = ["dev", "staging", "prod", "testing", "audit"]
 }
 
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage, e.g. 'prod', 'staging', 'dev', or 'test'"
 }

--- a/deprecated/aws/keycloak-backing-services/aurora-mysql.tf
+++ b/deprecated/aws/keycloak-backing-services/aurora-mysql.tf
@@ -1,44 +1,44 @@
 # https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html
 
 variable "mysql_name" {
-  type        = "string"
+  type        = string
   description = "Name of the application, e.g. `app` or `analytics`"
   default     = "mysql"
 }
 
 variable "mysql_admin_user" {
-  type        = "string"
+  type        = string
   description = "MySQL admin user name"
   default     = ""
 }
 
 variable "mysql_admin_password" {
-  type        = "string"
+  type        = string
   description = "MySQL password for the admin user"
   default     = ""
 }
 
 variable "mysql_db_name" {
-  type        = "string"
+  type        = string
   description = "MySQL database name"
   default     = ""
 }
 
 # https://aws.amazon.com/rds/aurora/pricing
 variable "mysql_instance_type" {
-  type        = "string"
+  type        = string
   default     = "db.t3.small"
   description = "EC2 instance type for Aurora MySQL cluster"
 }
 
 variable "mysql_cluster_size" {
-  type        = "string"
+  type        = string
   default     = "2"
   description = "MySQL cluster size"
 }
 
 variable "mysql_cluster_enabled" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Set to false to prevent the module from creating any resources"
 }
@@ -49,108 +49,108 @@ variable "mysql_cluster_publicly_accessible" {
 }
 
 variable "mysql_cluster_allowed_cidr_blocks" {
-  type        = "string"
+  type        = string
   default     = "0.0.0.0/0"
   description = "Comma separated string list of CIDR blocks allowed to access the cluster, or SSM parameter key for it"
 }
 
 variable "mysql_storage_encrypted" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Set to true to keep the database contents encrypted"
 }
 
 variable "mysql_kms_key_id" {
-  type        = "string"
+  type        = string
   default     = "alias/aws/rds"
   description = "KMS key ID, ARN, or alias to use for encrypting MySQL database"
 }
 
 variable "mysql_deletion_protection" {
-  type        = "string"
+  type        = string
   default     = "true"
   description = "Set to true to protect the database from deletion"
 }
 
 variable "mysql_skip_final_snapshot" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Determines whether a final DB snapshot is created before the DB cluster is deleted"
 }
 
 variable "vpc_id" {
-  type        = "string"
+  type        = string
   description = "The AWS ID of the VPC to create the cluster in, or SSM parameter key for it"
 }
 
 variable "vpc_subnet_ids" {
-  type        = "string"
+  type        = string
   description = "Comma separated string list of AWS Subnet IDs in which to place the database, or SSM parameter key for it"
 }
 
 resource "random_pet" "mysql_db_name" {
-  count     = "${local.mysql_cluster_enabled && length(var.mysql_db_name) == 0 ? 1 : 0}"
+  count     = local.mysql_cluster_enabled && length(var.mysql_db_name) == 0 ? 1 : 0
   separator = "_"
 }
 
 resource "random_string" "mysql_admin_user" {
-  count   = "${local.mysql_cluster_enabled && length(var.mysql_admin_user) == 0 ? 1 : 0}"
+  count   = local.mysql_cluster_enabled && length(var.mysql_admin_user) == 0 ? 1 : 0
   length  = 8
   number  = false
   special = false
 }
 
 resource "random_string" "mysql_admin_password" {
-  count   = "${local.mysql_cluster_enabled && length(var.mysql_admin_password) == 0 ? 1 : 0}"
+  count   = local.mysql_cluster_enabled && length(var.mysql_admin_password) == 0 ? 1 : 0
   length  = 33
   special = false
 }
 
 #  "Read SSM parameter to get allowed CIDR blocks"
 data "aws_ssm_parameter" "allowed_cidr_blocks" {
-  count = "${local.allowed_cidr_blocks_use_ssm ? 1 : 0}"
+  count = local.allowed_cidr_blocks_use_ssm ? 1 : 0
 
   # The data source will throw an error if it cannot find the parameter,
   # name = "${substr(mysql_cluster_allowed_cidr_blocks, 0, 1) == "/" ? mysql_cluster_allowed_cidr_blocks : "/aws/service/global-infrastructure/version"}"
-  name = "${var.mysql_cluster_allowed_cidr_blocks}"
+  name = var.mysql_cluster_allowed_cidr_blocks
 }
 
 #  "Read SSM parameter to get allowed VPC ID"
 data "aws_ssm_parameter" "vpc_id" {
-  count = "${local.vpc_id_use_ssm ? 1 : 0}"
+  count = local.vpc_id_use_ssm ? 1 : 0
 
   # The data source will throw an error if it cannot find the parameter,
   # name = "${substr(mysql_cluster_allowed_cidr_blocks, 0, 1) == "/" ? mysql_cluster_allowed_cidr_blocks : "/aws/service/global-infrastructure/version"}"
-  name = "${var.vpc_id}"
+  name = var.vpc_id
 }
 
 #  "Read SSM parameter to get allowed VPC subnet IDs"
 data "aws_ssm_parameter" "vpc_subnet_ids" {
-  count = "${local.vpc_subnet_ids_use_ssm ? 1 : 0}"
+  count = local.vpc_subnet_ids_use_ssm ? 1 : 0
 
   # The data source will throw an error if it cannot find the parameter,
   # name = "${substr(mysql_cluster_allowed_cidr_blocks, 0, 1) == "/" ? mysql_cluster_allowed_cidr_blocks : "/aws/service/global-infrastructure/version"}"
-  name = "${var.vpc_subnet_ids}"
+  name = var.vpc_subnet_ids
 }
 
 locals {
-  mysql_cluster_enabled = "${var.mysql_cluster_enabled == "true"}"
-  mysql_admin_user      = "${length(var.mysql_admin_user) > 0 ? var.mysql_admin_user : join("", random_string.mysql_admin_user.*.result)}"
-  mysql_admin_password  = "${length(var.mysql_admin_password) > 0 ? var.mysql_admin_password : join("", random_string.mysql_admin_password.*.result)}"
-  mysql_db_name         = "${length(var.mysql_db_name) > 0 ? var.mysql_db_name : join("", random_pet.mysql_db_name.*.id)}"
+  mysql_cluster_enabled = var.mysql_cluster_enabled == "true"
+  mysql_admin_user      = length(var.mysql_admin_user) > 0 ? var.mysql_admin_user : join("", random_string.mysql_admin_user.*.result)
+  mysql_admin_password  = length(var.mysql_admin_password) > 0 ? var.mysql_admin_password : join("", random_string.mysql_admin_password.*.result)
+  mysql_db_name         = length(var.mysql_db_name) > 0 ? var.mysql_db_name : join("", random_pet.mysql_db_name.*.id)
 
-  allowed_cidr_blocks_use_ssm = "${substr(var.mysql_cluster_allowed_cidr_blocks, 0, 1) == "/" && local.mysql_cluster_enabled}"
-  vpc_id_use_ssm              = "${substr(var.vpc_id, 0, 1) == "/" && local.mysql_cluster_enabled}"
-  vpc_subnet_ids_use_ssm      = "${substr(var.vpc_subnet_ids, 0, 1) == "/" && local.mysql_cluster_enabled}"
+  allowed_cidr_blocks_use_ssm = substr(var.mysql_cluster_allowed_cidr_blocks, 0, 1) == "/" && local.mysql_cluster_enabled
+  vpc_id_use_ssm              = substr(var.vpc_id, 0, 1) == "/" && local.mysql_cluster_enabled
+  vpc_subnet_ids_use_ssm      = substr(var.vpc_subnet_ids, 0, 1) == "/" && local.mysql_cluster_enabled
 
-  allowed_cidr_blocks_string = "${local.allowed_cidr_blocks_use_ssm ? join("", data.aws_ssm_parameter.allowed_cidr_blocks.*.value) : var.mysql_cluster_allowed_cidr_blocks}"
-  vpc_subnet_ids_string      = "${local.vpc_subnet_ids_use_ssm ? join("", data.aws_ssm_parameter.vpc_subnet_ids.*.value) : var.vpc_subnet_ids}"
+  allowed_cidr_blocks_string = local.allowed_cidr_blocks_use_ssm ? join("", data.aws_ssm_parameter.allowed_cidr_blocks.*.value) : var.mysql_cluster_allowed_cidr_blocks
+  vpc_subnet_ids_string      = local.vpc_subnet_ids_use_ssm ? join("", data.aws_ssm_parameter.vpc_subnet_ids.*.value) : var.vpc_subnet_ids
 
   allowed_cidr_blocks = [
     "${split(",", local.allowed_cidr_blocks_string)}",
   ]
 
-  vpc_id = "${local.vpc_id_use_ssm ? join("", data.aws_ssm_parameter.vpc_id.*.value) : var.vpc_id}"
+  vpc_id = local.vpc_id_use_ssm ? join("", data.aws_ssm_parameter.vpc_id.*.value) : var.vpc_id
 
   vpc_subnet_ids = [
     "${split(",", local.vpc_subnet_ids_string)}",
@@ -158,76 +158,76 @@ locals {
 }
 
 data "aws_kms_key" "mysql" {
-  key_id = "${var.mysql_kms_key_id}"
+  key_id = var.mysql_kms_key_id
 }
 
 module "aurora_mysql" {
   source         = "git::https://github.com/cloudposse/terraform-aws-rds-cluster.git?ref=tags/0.15.0"
-  namespace      = "${var.namespace}"
-  stage          = "${var.stage}"
-  name           = "${var.mysql_name}"
+  namespace      = var.namespace
+  stage          = var.stage
+  name           = var.mysql_name
   attributes     = ["keycloak"]
   engine         = "aurora-mysql"
   cluster_family = "aurora-mysql5.7"
-  instance_type  = "${var.mysql_instance_type}"
-  cluster_size   = "${var.mysql_cluster_size}"
-  admin_user     = "${local.mysql_admin_user}"
-  admin_password = "${local.mysql_admin_password}"
-  db_name        = "${local.mysql_db_name}"
+  instance_type  = var.mysql_instance_type
+  cluster_size   = var.mysql_cluster_size
+  admin_user     = local.mysql_admin_user
+  admin_password = local.mysql_admin_password
+  db_name        = local.mysql_db_name
   db_port        = "3306"
-  vpc_id         = "${local.vpc_id}"
-  subnets        = "${local.vpc_subnet_ids}"
-  zone_id        = "${local.dns_zone_id}"
-  enabled        = "${var.mysql_cluster_enabled}"
+  vpc_id         = local.vpc_id
+  subnets        = local.vpc_subnet_ids
+  zone_id        = local.dns_zone_id
+  enabled        = var.mysql_cluster_enabled
 
-  storage_encrypted   = "${var.mysql_storage_encrypted}"
-  kms_key_arn         = "${var.mysql_storage_encrypted ? data.aws_kms_key.mysql.arn : ""}"
-  deletion_protection = "${var.mysql_deletion_protection}"
-  skip_final_snapshot = "${var.mysql_skip_final_snapshot}"
-  publicly_accessible = "${var.mysql_cluster_publicly_accessible}"
-  allowed_cidr_blocks = "${local.allowed_cidr_blocks}"
+  storage_encrypted   = var.mysql_storage_encrypted
+  kms_key_arn         = var.mysql_storage_encrypted ? data.aws_kms_key.mysql.arn : ""
+  deletion_protection = var.mysql_deletion_protection
+  skip_final_snapshot = var.mysql_skip_final_snapshot
+  publicly_accessible = var.mysql_cluster_publicly_accessible
+  allowed_cidr_blocks = local.allowed_cidr_blocks
 }
 
 resource "aws_ssm_parameter" "aurora_mysql_database_name" {
-  count       = "${local.mysql_cluster_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name_pattern, local.chamber_service, "keycloak_db_name")}"
-  value       = "${module.aurora_mysql.name}"
+  count       = local.mysql_cluster_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name_pattern, local.chamber_service, "keycloak_db_name")
+  value       = module.aurora_mysql.name
   description = "Aurora MySQL Database Name"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "aurora_mysql_master_username" {
-  count       = "${local.mysql_cluster_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name_pattern, local.chamber_service, "keycloak_db_user")}"
-  value       = "${module.aurora_mysql.user}"
+  count       = local.mysql_cluster_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name_pattern, local.chamber_service, "keycloak_db_user")
+  value       = module.aurora_mysql.user
   description = "Aurora MySQL Username for the master DB user"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "aurora_mysql_master_password" {
-  count       = "${local.mysql_cluster_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name_pattern, local.chamber_service, "keycloak_db_password")}"
-  value       = "${local.mysql_admin_password}"
+  count       = local.mysql_cluster_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name_pattern, local.chamber_service, "keycloak_db_password")
+  value       = local.mysql_admin_password
   description = "Aurora MySQL Password for the master DB user"
   type        = "SecureString"
   overwrite   = "true"
-  key_id      = "${var.chamber_kms_key_id}"
+  key_id      = var.chamber_kms_key_id
 }
 
 resource "aws_ssm_parameter" "aurora_mysql_master_hostname" {
-  count       = "${local.mysql_cluster_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name_pattern, local.chamber_service, "keycloak_db_host")}"
-  value       = "${module.aurora_mysql.master_host}"
+  count       = local.mysql_cluster_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name_pattern, local.chamber_service, "keycloak_db_host")
+  value       = module.aurora_mysql.master_host
   description = "Aurora MySQL DB Master hostname"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "aurora_mysql_port" {
-  count       = "${local.mysql_cluster_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name_pattern, local.chamber_service, "keycloak_db_port")}"
+  count       = local.mysql_cluster_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name_pattern, local.chamber_service, "keycloak_db_port")
   value       = "3306"
   description = "Aurora MySQL DB Master hostname"
   type        = "String"
@@ -235,44 +235,44 @@ resource "aws_ssm_parameter" "aurora_mysql_port" {
 }
 
 resource "aws_ssm_parameter" "aurora_mysql_replicas_hostname" {
-  count       = "${local.mysql_cluster_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name_pattern, local.chamber_service, "keycloak_aurora_mysql_replicas_hostname")}"
-  value       = "${module.aurora_mysql.replicas_host}"
+  count       = local.mysql_cluster_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name_pattern, local.chamber_service, "keycloak_aurora_mysql_replicas_hostname")
+  value       = module.aurora_mysql.replicas_host
   description = "Aurora MySQL DB Replicas hostname"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "aurora_mysql_cluster_name" {
-  count       = "${local.mysql_cluster_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name_pattern, local.chamber_service, "keycloak_aurora_mysql_cluster_name")}"
-  value       = "${module.aurora_mysql.cluster_name}"
+  count       = local.mysql_cluster_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name_pattern, local.chamber_service, "keycloak_aurora_mysql_cluster_name")
+  value       = module.aurora_mysql.cluster_name
   description = "Aurora MySQL DB Cluster Identifier"
   type        = "String"
   overwrite   = "true"
 }
 
 output "aurora_mysql_database_name" {
-  value       = "${module.aurora_mysql.name}"
+  value       = module.aurora_mysql.name
   description = "Aurora MySQL Database name"
 }
 
 output "aurora_mysql_master_username" {
-  value       = "${module.aurora_mysql.user}"
+  value       = module.aurora_mysql.user
   description = "Aurora MySQL Username for the master DB user"
 }
 
 output "aurora_mysql_master_hostname" {
-  value       = "${module.aurora_mysql.master_host}"
+  value       = module.aurora_mysql.master_host
   description = "Aurora MySQL DB Master hostname"
 }
 
 output "aurora_mysql_replicas_hostname" {
-  value       = "${module.aurora_mysql.replicas_host}"
+  value       = module.aurora_mysql.replicas_host
   description = "Aurora MySQL Replicas hostname"
 }
 
 output "aurora_mysql_cluster_name" {
-  value       = "${module.aurora_mysql.cluster_name}"
+  value       = module.aurora_mysql.cluster_name
   description = "Aurora MySQL Cluster Identifier"
 }

--- a/deprecated/aws/keycloak-backing-services/main.tf
+++ b/deprecated/aws/keycloak-backing-services/main.tf
@@ -8,31 +8,31 @@ provider "aws" {
   version = "~> 2.17"
 
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `eg` or `cp`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "region" {
-  type        = "string"
+  type        = string
   description = "AWS region"
 }
 
 variable "dns_zone_name" {
-  type        = "string"
+  type        = string
   description = "The DNS domain under which to put entries for the database. Usually the same as the cluster name, e.g. us-west-2.prod.cpco.io"
 }
 
@@ -47,24 +47,24 @@ variable "chamber_parameter_name_pattern" {
 }
 
 variable "chamber_kms_key_id" {
-  type        = "string"
+  type        = string
   default     = "alias/aws/ssm"
   description = "KMS key ID, ARN, or alias to use for encrypting SSM secrets"
 }
 
 data "aws_route53_zone" "default" {
-  name = "${var.dns_zone_name}"
+  name = var.dns_zone_name
 }
 
 locals {
   //  availability_zones = ["${split(",", length(var.availability_zones) == 0 ? join(",", data.aws_availability_zones.available.names) : join(",", var.availability_zones))}"]
-  chamber_service = "${var.chamber_service == "" ? basename(pathexpand(path.module)) : var.chamber_service}"
-  dns_zone_id     = "${data.aws_route53_zone.default.zone_id}"
+  chamber_service = var.chamber_service == "" ? basename(pathexpand(path.module)) : var.chamber_service
+  dns_zone_id     = data.aws_route53_zone.default.zone_id
 }
 
 resource "aws_ssm_parameter" "keycloak_db_vendor" {
-  count       = "${local.mysql_cluster_enabled ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name_pattern, local.chamber_service, "keycloak_db_vendor")}"
+  count       = local.mysql_cluster_enabled ? 1 : 0
+  name        = format(var.chamber_parameter_name_pattern, local.chamber_service, "keycloak_db_vendor")
   value       = "mysql"
   description = "Database Vendor, e.g. mysql, postgres"
   type        = "String"

--- a/deprecated/aws/kops-aws-platform/acm.tf
+++ b/deprecated/aws/kops-aws-platform/acm.tf
@@ -4,17 +4,17 @@ variable "kops_acm_enabled" {
 }
 
 variable "kops_acm_san_domains" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "A list of domains (except *.{cluster_name}) that should be SANs in the issued certificate"
 }
 
 resource "aws_acm_certificate" "default" {
-  count                     = "${var.kops_acm_enabled ? 1 : 0}"
+  count                     = var.kops_acm_enabled ? 1 : 0
   domain_name               = "*.${var.region}.${var.zone_name}"
   validation_method         = "DNS"
   subject_alternative_names = ["${var.kops_acm_san_domains}"]
-  tags                      = "${var.tags}"
+  tags                      = var.tags
 
   lifecycle {
     create_before_destroy = true
@@ -22,11 +22,11 @@ resource "aws_acm_certificate" "default" {
 }
 
 output "kops_acm_arn" {
-  value       = "${join("", aws_acm_certificate.default.*.arn)}"
+  value       = join("", aws_acm_certificate.default.*.arn)
   description = "The ARN of the certificate"
 }
 
 output "kops_acm_domain_validation_options" {
-  value       = "${flatten(aws_acm_certificate.default.*.domain_validation_options)}"
+  value       = flatten(aws_acm_certificate.default.*.domain_validation_options)
   description = "CNAME records that need to be added to the DNS zone to complete certificate validation"
 }

--- a/deprecated/aws/kops-aws-platform/alb-ingress.tf
+++ b/deprecated/aws/kops-aws-platform/alb-ingress.tf
@@ -5,13 +5,13 @@ variable "kops_alb_ingress_enabled" {
 
 module "kops_alb_ingress" {
   source       = "git::https://github.com/cloudposse/terraform-aws-kops-aws-alb-ingress.git?ref=tags/0.2.0"
-  namespace    = "${var.namespace}"
-  stage        = "${var.stage}"
+  namespace    = var.namespace
+  stage        = var.stage
   name         = "alb-ingress"
   cluster_name = "${var.region}.${var.zone_name}"
-  enabled      = "${var.kops_alb_ingress_enabled}"
+  enabled      = var.kops_alb_ingress_enabled
 
-  iam_role_max_session_duration = "${var.iam_role_max_session_duration}"
+  iam_role_max_session_duration = var.iam_role_max_session_duration
 
   tags = {
     Cluster = "${var.region}.${var.zone_name}"
@@ -19,25 +19,25 @@ module "kops_alb_ingress" {
 }
 
 output "kops_alb_ingress_role_name" {
-  value = "${module.kops_alb_ingress.role_name}"
+  value = module.kops_alb_ingress.role_name
 }
 
 output "kops_alb_ingress_role_unique_id" {
-  value = "${module.kops_alb_ingress.role_unique_id}"
+  value = module.kops_alb_ingress.role_unique_id
 }
 
 output "kops_alb_ingress_role_arn" {
-  value = "${module.kops_alb_ingress.role_arn}"
+  value = module.kops_alb_ingress.role_arn
 }
 
 output "kops_alb_ingress_policy_name" {
-  value = "${module.kops_alb_ingress.policy_name}"
+  value = module.kops_alb_ingress.policy_name
 }
 
 output "kops_alb_ingress_policy_id" {
-  value = "${module.kops_alb_ingress.policy_id}"
+  value = module.kops_alb_ingress.policy_id
 }
 
 output "kops_alb_ingress_policy_arn" {
-  value = "${module.kops_alb_ingress.policy_arn}"
+  value = module.kops_alb_ingress.policy_arn
 }

--- a/deprecated/aws/kops-aws-platform/autoscaler-role.tf
+++ b/deprecated/aws/kops-aws-platform/autoscaler-role.tf
@@ -20,14 +20,14 @@ module "autoscaler_role" {
   source = "git::https://github.com/cloudposse/terraform-aws-iam-role.git?ref=tags/0.4.0"
 
   enabled            = "true"
-  namespace          = "${var.namespace}"
-  stage              = "${var.stage}"
+  namespace          = var.namespace
+  stage              = var.stage
   name               = "kubernetes"
   attributes         = ["autoscaler", "role"]
   role_description   = "Role for Cluster Auto-Scaler"
   policy_description = "Permit auto-scaling operations on auto-scaling groups"
 
-  max_session_duration = "${var.iam_role_max_session_duration}"
+  max_session_duration = var.iam_role_max_session_duration
 
   principals = {
     AWS = ["${module.kops_metadata_iam.masters_role_arn}"]
@@ -37,24 +37,24 @@ module "autoscaler_role" {
 }
 
 resource "aws_ssm_parameter" "kops_autoscaler_iam_role_name" {
-  name        = "${format(local.chamber_parameter_format, var.chamber_service, "kubernetes_autoscaler_iam_role_name")}"
-  value       = "${module.autoscaler_role.name}"
+  name        = format(local.chamber_parameter_format, var.chamber_service, "kubernetes_autoscaler_iam_role_name")
+  value       = module.autoscaler_role.name
   description = "IAM role name for cluster autoscaler"
   type        = "String"
   overwrite   = "true"
 }
 
 output "autoscaler_role_name" {
-  value       = "${module.autoscaler_role.name}"
+  value       = module.autoscaler_role.name
   description = "The name of the IAM role created"
 }
 
 output "autoscaler_role_id" {
-  value       = "${module.autoscaler_role.id}"
+  value       = module.autoscaler_role.id
   description = "The stable and unique string identifying the role"
 }
 
 output "autoscaler_role_arn" {
-  value       = "${module.autoscaler_role.arn}"
+  value       = module.autoscaler_role.arn
   description = "The Amazon Resource Name (ARN) specifying the role"
 }

--- a/deprecated/aws/kops-aws-platform/chart-repo.tf
+++ b/deprecated/aws/kops-aws-platform/chart-repo.tf
@@ -1,12 +1,12 @@
 module "kops_chart_repo" {
   source          = "git::https://github.com/cloudposse/terraform-aws-kops-chart-repo.git?ref=tags/0.3.0"
-  namespace       = "${var.namespace}"
-  stage           = "${var.stage}"
+  namespace       = var.namespace
+  stage           = var.stage
   name            = "chart-repo"
   cluster_name    = "${var.region}.${var.zone_name}"
-  permitted_nodes = "${var.permitted_nodes}"
+  permitted_nodes = var.permitted_nodes
 
-  iam_role_max_session_duration = "${var.iam_role_max_session_duration}"
+  iam_role_max_session_duration = var.iam_role_max_session_duration
 
   tags = {
     Cluster = "${var.region}.${var.zone_name}"
@@ -14,37 +14,37 @@ module "kops_chart_repo" {
 }
 
 output "kops_chart_repo_bucket_domain_name" {
-  value = "${module.kops_chart_repo.bucket_domain_name}"
+  value = module.kops_chart_repo.bucket_domain_name
 }
 
 output "kops_chart_repo_bucket_id" {
-  value = "${module.kops_chart_repo.bucket_id}"
+  value = module.kops_chart_repo.bucket_id
 }
 
 output "kops_chart_repo_bucket_arn" {
-  value = "${module.kops_chart_repo.bucket_arn}"
+  value = module.kops_chart_repo.bucket_arn
 }
 
 output "kops_chart_repo_role_name" {
-  value = "${module.kops_chart_repo.role_name}"
+  value = module.kops_chart_repo.role_name
 }
 
 output "kops_chart_repo_role_unique_id" {
-  value = "${module.kops_chart_repo.role_unique_id}"
+  value = module.kops_chart_repo.role_unique_id
 }
 
 output "kops_chart_repo_role_arn" {
-  value = "${module.kops_chart_repo.role_arn}"
+  value = module.kops_chart_repo.role_arn
 }
 
 output "kops_chart_repo_policy_name" {
-  value = "${module.kops_chart_repo.policy_name}"
+  value = module.kops_chart_repo.policy_name
 }
 
 output "kops_chart_repo_policy_id" {
-  value = "${module.kops_chart_repo.policy_id}"
+  value = module.kops_chart_repo.policy_id
 }
 
 output "kops_chart_repo_policy_arn" {
-  value = "${module.kops_chart_repo.policy_arn}"
+  value = module.kops_chart_repo.policy_arn
 }

--- a/deprecated/aws/kops-aws-platform/efs-provisioner.tf
+++ b/deprecated/aws/kops-aws-platform/efs-provisioner.tf
@@ -1,23 +1,23 @@
 variable "efs_enabled" {
-  type        = "string"
+  type        = string
   description = "Set to true to allow the module to create EFS resources"
   default     = "false"
 }
 
 variable "kops_dns_zone_id" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "DNS Zone ID for kops. EFS DNS entries will be added to this zone. If empyty, zone ID will be retrieved from SSM Parameter store"
 }
 
 variable "efs_encrypted" {
-  type        = "string"
+  type        = string
   description = "If true, the disk will be encrypted"
   default     = "false"
 }
 
 variable "efs_performance_mode" {
-  type        = "string"
+  type        = string
   description = "The file system performance mode. Can be either `generalPurpose` or `maxIO`"
   default     = "generalPurpose"
 }
@@ -28,42 +28,42 @@ variable "efs_provisioned_throughput_in_mibps" {
 }
 
 variable "efs_throughput_mode" {
-  type        = "string"
+  type        = string
   description = "Throughput mode for the file system. Defaults to bursting. Valid values: bursting, provisioned. When using provisioned, also set provisioned_throughput_in_mibps"
   default     = "bursting"
 }
 
 data "aws_ssm_parameter" "kops_availability_zones" {
-  name = "${format(local.chamber_parameter_format, var.chamber_service_kops, "kops_availability_zones")}"
+  name = format(local.chamber_parameter_format, var.chamber_service_kops, "kops_availability_zones")
 }
 
 data "aws_ssm_parameter" "kops_zone_id" {
-  count = "${var.efs_enabled == "true" && var.kops_dns_zone_id == "" ? 1 : 0}"
-  name  = "${format(local.chamber_parameter_format, var.chamber_service_kops, "kops_dns_zone_id")}"
+  count = var.efs_enabled == "true" && var.kops_dns_zone_id == "" ? 1 : 0
+  name  = format(local.chamber_parameter_format, var.chamber_service_kops, "kops_dns_zone_id")
 }
 
 locals {
-  kops_zone_id = "${coalesce(var.kops_dns_zone_id, join("", data.aws_ssm_parameter.kops_zone_id.*.value))}"
+  kops_zone_id = coalesce(var.kops_dns_zone_id, join("", data.aws_ssm_parameter.kops_zone_id.*.value))
 }
 
 module "kops_efs_provisioner" {
   source             = "git::https://github.com/cloudposse/terraform-aws-kops-efs.git?ref=tags/0.6.0"
-  enabled            = "${var.efs_enabled}"
-  namespace          = "${var.namespace}"
-  stage              = "${var.stage}"
+  enabled            = var.efs_enabled
+  namespace          = var.namespace
+  stage              = var.stage
   name               = "efs-provisioner"
-  region             = "${var.region}"
+  region             = var.region
   availability_zones = ["${split(",", data.aws_ssm_parameter.kops_availability_zones.value)}"]
-  zone_id            = "${local.kops_zone_id}"
+  zone_id            = local.kops_zone_id
   cluster_name       = "${var.region}.${var.zone_name}"
 
-  encrypted        = "${var.efs_encrypted}"
-  performance_mode = "${var.efs_performance_mode}"
+  encrypted        = var.efs_encrypted
+  performance_mode = var.efs_performance_mode
 
-  throughput_mode                 = "${var.efs_throughput_mode}"
-  provisioned_throughput_in_mibps = "${var.efs_provisioned_throughput_in_mibps}"
+  throughput_mode                 = var.efs_throughput_mode
+  provisioned_throughput_in_mibps = var.efs_provisioned_throughput_in_mibps
 
-  iam_role_max_session_duration = "${var.iam_role_max_session_duration}"
+  iam_role_max_session_duration = var.iam_role_max_session_duration
 
   tags = {
     Cluster = "${var.region}.${var.zone_name}"
@@ -71,71 +71,71 @@ module "kops_efs_provisioner" {
 }
 
 resource "aws_ssm_parameter" "kops_efs_provisioner_role_name" {
-  count       = "${var.efs_enabled == "true" ? 1 : 0}"
-  name        = "${format(local.chamber_parameter_format, var.chamber_service, "kops_efs_provisioner_role_name")}"
-  value       = "${module.kops_efs_provisioner.role_name}"
+  count       = var.efs_enabled == "true" ? 1 : 0
+  name        = format(local.chamber_parameter_format, var.chamber_service, "kops_efs_provisioner_role_name")
+  value       = module.kops_efs_provisioner.role_name
   description = "IAM role name for EFS provisioner"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "kops_efs_file_system_id" {
-  count       = "${var.efs_enabled == "true" ? 1 : 0}"
-  name        = "${format(local.chamber_parameter_format, var.chamber_service, "kops_efs_file_system_id")}"
-  value       = "${module.kops_efs_provisioner.efs_id}"
+  count       = var.efs_enabled == "true" ? 1 : 0
+  name        = format(local.chamber_parameter_format, var.chamber_service, "kops_efs_file_system_id")
+  value       = module.kops_efs_provisioner.efs_id
   description = "ID for shared EFS file system"
   type        = "String"
   overwrite   = "true"
 }
 
 output "kops_efs_provisioner_role_name" {
-  value = "${module.kops_efs_provisioner.role_name}"
+  value = module.kops_efs_provisioner.role_name
 }
 
 output "kops_efs_provisioner_role_unique_id" {
-  value = "${module.kops_efs_provisioner.role_unique_id}"
+  value = module.kops_efs_provisioner.role_unique_id
 }
 
 output "kops_efs_provisioner_role_arn" {
-  value = "${module.kops_efs_provisioner.role_arn}"
+  value = module.kops_efs_provisioner.role_arn
 }
 
 output "efs_arn" {
-  value       = "${module.kops_efs_provisioner.efs_arn}"
+  value       = module.kops_efs_provisioner.efs_arn
   description = "EFS ARN"
 }
 
 output "efs_id" {
-  value       = "${module.kops_efs_provisioner.efs_id}"
+  value       = module.kops_efs_provisioner.efs_id
   description = "EFS ID"
 }
 
 output "efs_host" {
-  value       = "${module.kops_efs_provisioner.efs_host}"
+  value       = module.kops_efs_provisioner.efs_host
   description = "EFS host"
 }
 
 output "efs_dns_name" {
-  value       = "${module.kops_efs_provisioner.efs_dns_name}"
+  value       = module.kops_efs_provisioner.efs_dns_name
   description = "EFS DNS name"
 }
 
 output "efs_mount_target_dns_names" {
-  value       = "${module.kops_efs_provisioner.efs_mount_target_dns_names}"
+  value       = module.kops_efs_provisioner.efs_mount_target_dns_names
   description = "EFS mount target DNS name"
 }
 
 output "efs_mount_target_ids" {
-  value       = "${module.kops_efs_provisioner.efs_mount_target_ids}"
+  value       = module.kops_efs_provisioner.efs_mount_target_ids
   description = "EFS mount target IDs"
 }
 
 output "efs_mount_target_ips" {
-  value       = "${module.kops_efs_provisioner.efs_mount_target_ips}"
+  value       = module.kops_efs_provisioner.efs_mount_target_ips
   description = "EFS mount target IPs"
 }
 
 output "efs_network_interface_ids" {
-  value       = "${module.kops_efs_provisioner.efs_network_interface_ids}"
+  value       = module.kops_efs_provisioner.efs_network_interface_ids
   description = "EFS network interface IDs"
 }

--- a/deprecated/aws/kops-aws-platform/external-dns.tf
+++ b/deprecated/aws/kops-aws-platform/external-dns.tf
@@ -1,12 +1,12 @@
 module "kops_external_dns" {
   source         = "git::https://github.com/cloudposse/terraform-aws-kops-external-dns.git?ref=tags/0.3.0"
-  namespace      = "${var.namespace}"
-  stage          = "${var.stage}"
+  namespace      = var.namespace
+  stage          = var.stage
   name           = "external-dns"
   cluster_name   = "${var.region}.${var.zone_name}"
-  dns_zone_names = "${var.dns_zone_names}"
+  dns_zone_names = var.dns_zone_names
 
-  iam_role_max_session_duration = "${var.iam_role_max_session_duration}"
+  iam_role_max_session_duration = var.iam_role_max_session_duration
 
   tags = {
     Cluster = "${var.region}.${var.zone_name}"
@@ -14,25 +14,25 @@ module "kops_external_dns" {
 }
 
 output "kops_external_dns_role_name" {
-  value = "${module.kops_external_dns.role_name}"
+  value = module.kops_external_dns.role_name
 }
 
 output "kops_external_dns_role_unique_id" {
-  value = "${module.kops_external_dns.role_unique_id}"
+  value = module.kops_external_dns.role_unique_id
 }
 
 output "kops_external_dns_role_arn" {
-  value = "${module.kops_external_dns.role_arn}"
+  value = module.kops_external_dns.role_arn
 }
 
 output "kops_external_dns_policy_name" {
-  value = "${module.kops_external_dns.policy_name}"
+  value = module.kops_external_dns.policy_name
 }
 
 output "kops_external_dns_policy_id" {
-  value = "${module.kops_external_dns.policy_id}"
+  value = module.kops_external_dns.policy_id
 }
 
 output "kops_external_dns_policy_arn" {
-  value = "${module.kops_external_dns.policy_arn}"
+  value = module.kops_external_dns.policy_arn
 }

--- a/deprecated/aws/kops-aws-platform/flow-logs.tf
+++ b/deprecated/aws/kops-aws-platform/flow-logs.tf
@@ -1,63 +1,63 @@
 variable "flow_logs_enabled" {
-  type    = "string"
+  type    = string
   default = "true"
 }
 
 module "flow_logs" {
   source     = "git::https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket.git?ref=tags/0.1.1"
   name       = "kops"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  attributes = "${list("flow-logs")}"
+  namespace  = var.namespace
+  stage      = var.stage
+  attributes = list("flow-logs")
 
-  region = "${var.region}"
+  region = var.region
 
-  enabled = "${var.flow_logs_enabled}"
+  enabled = var.flow_logs_enabled
 
-  vpc_id = "${module.kops_metadata.vpc_id}"
+  vpc_id = module.kops_metadata.vpc_id
 }
 
 output "flow_logs_kms_key_arn" {
-  value       = "${module.flow_logs.kms_key_arn}"
+  value       = module.flow_logs.kms_key_arn
   description = "Flow logs KMS Key ARN"
 }
 
 output "flow_logs_kms_key_id" {
-  value       = "${module.flow_logs.kms_key_id}"
+  value       = module.flow_logs.kms_key_id
   description = "Flow logs KMS Key ID"
 }
 
 output "flow_logs_kms_alias_arn" {
-  value       = "${module.flow_logs.kms_alias_arn}"
+  value       = module.flow_logs.kms_alias_arn
   description = "Flow logs KMS Alias ARN"
 }
 
 output "flow_logs_kms_alias_name" {
-  value       = "${module.flow_logs.kms_alias_name}"
+  value       = module.flow_logs.kms_alias_name
   description = "Flow logs KMS Alias name"
 }
 
 output "flow_logs_bucket_domain_name" {
-  value       = "${module.flow_logs.bucket_domain_name}"
+  value       = module.flow_logs.bucket_domain_name
   description = "Flow logs FQDN of bucket"
 }
 
 output "flow_logs_bucket_id" {
-  value       = "${module.flow_logs.bucket_id}"
+  value       = module.flow_logs.bucket_id
   description = "Flow logs bucket Name (aka ID)"
 }
 
 output "flow_logs_bucket_arn" {
-  value       = "${module.flow_logs.bucket_arn}"
+  value       = module.flow_logs.bucket_arn
   description = "Flow logs bucket ARN"
 }
 
 output "flow_logs_bucket_prefix" {
-  value       = "${module.flow_logs.bucket_prefix}"
+  value       = module.flow_logs.bucket_prefix
   description = "Flow logs bucket prefix configured for lifecycle rules"
 }
 
 output "flow_logs_id" {
-  value       = "${module.flow_logs.id}"
+  value       = module.flow_logs.id
   description = "Flow logs ID"
 }

--- a/deprecated/aws/kops-aws-platform/iam-authenticator.tf
+++ b/deprecated/aws/kops-aws-platform/iam-authenticator.tf
@@ -1,47 +1,47 @@
 variable "kops_iam_enabled" {
-  type        = "string"
+  type        = string
   description = "Set to true to allow the module to create Kubernetes and IAM resources"
   default     = "false"
 }
 
 variable "cluster_id" {
-  type        = "string"
+  type        = string
   description = "A unique-per-cluster identifier to prevent replay attacks. Good choices are a random token or a domain name that will be unique to your cluster"
   default     = "random"
 }
 
 variable "kube_config_path" {
-  type        = "string"
+  type        = string
   default     = "/dev/shm/kubecfg"
   description = "Path to the kube config file"
 }
 
 variable "admin_k8s_username" {
-  type        = "string"
+  type        = string
   description = "Kops admin username to be mapped to `admin_iam_role_arn`"
   default     = "kubernetes-admin"
 }
 
 variable "admin_k8s_groups" {
-  type        = "list"
+  type        = list(string)
   description = "List of Kops groups to be mapped to `admin_iam_role_arn`"
   default     = ["system:masters"]
 }
 
 variable "readonly_k8s_username" {
-  type        = "string"
+  type        = string
   description = "Kops readonly username to be mapped to `readonly_iam_role_arn`"
   default     = "kubernetes-readonly"
 }
 
 variable "readonly_k8s_groups" {
-  type        = "list"
+  type        = list(string)
   description = "List of Kops groups to be mapped to `readonly_iam_role_arn`"
   default     = ["view"]
 }
 
 resource "kubernetes_cluster_role_binding" "view" {
-  count = "${var.kops_iam_enabled == "true" ? 1 : 0}"
+  count = var.kops_iam_enabled == "true" ? 1 : 0
 
   metadata {
     name = "view-binding"
@@ -61,34 +61,34 @@ resource "kubernetes_cluster_role_binding" "view" {
 }
 
 variable "aws_root_account_id" {
-  type        = "string"
+  type        = string
   description = "AWS root account ID"
 }
 
 module "kops_admin_label" {
   source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
-  namespace  = "${var.namespace}"
+  namespace  = var.namespace
   name       = "kops"
-  stage      = "${var.stage}"
+  stage      = var.stage
   attributes = ["admin"]
-  delimiter  = "${var.delimiter}"
-  tags       = "${var.tags}"
-  enabled    = "${var.kops_iam_enabled}"
+  delimiter  = var.delimiter
+  tags       = var.tags
+  enabled    = var.kops_iam_enabled
 }
 
 module "kops_readonly_label" {
   source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
-  namespace  = "${var.namespace}"
+  namespace  = var.namespace
   name       = "kops"
-  stage      = "${var.stage}"
+  stage      = var.stage
   attributes = ["readonly"]
-  delimiter  = "${var.delimiter}"
-  tags       = "${var.tags}"
-  enabled    = "${var.kops_iam_enabled}"
+  delimiter  = var.delimiter
+  tags       = var.tags
+  enabled    = var.kops_iam_enabled
 }
 
 data "aws_iam_policy_document" "readonly" {
-  count = "${var.kops_iam_enabled == "true" ? 1 : 0}"
+  count = var.kops_iam_enabled == "true" ? 1 : 0
 
   statement {
     actions = [
@@ -105,16 +105,16 @@ data "aws_iam_policy_document" "readonly" {
 }
 
 resource "aws_iam_role" "readonly" {
-  count              = "${var.kops_iam_enabled == "true" ? 1 : 0}"
-  name               = "${module.kops_readonly_label.id}"
-  assume_role_policy = "${data.aws_iam_policy_document.readonly.json}"
+  count              = var.kops_iam_enabled == "true" ? 1 : 0
+  name               = module.kops_readonly_label.id
+  assume_role_policy = data.aws_iam_policy_document.readonly.json
   description        = "The Kops readonly role for aws-iam-authenticator"
 
-  max_session_duration = "${var.iam_role_max_session_duration}"
+  max_session_duration = var.iam_role_max_session_duration
 }
 
 data "aws_iam_policy_document" "admin" {
-  count = "${var.kops_iam_enabled == "true" ? 1 : 0}"
+  count = var.kops_iam_enabled == "true" ? 1 : 0
 
   statement {
     actions = [
@@ -131,23 +131,23 @@ data "aws_iam_policy_document" "admin" {
 }
 
 resource "aws_iam_role" "admin" {
-  count              = "${var.kops_iam_enabled == "true" ? 1 : 0}"
-  name               = "${module.kops_admin_label.id}"
-  assume_role_policy = "${data.aws_iam_policy_document.admin.json}"
+  count              = var.kops_iam_enabled == "true" ? 1 : 0
+  name               = module.kops_admin_label.id
+  assume_role_policy = data.aws_iam_policy_document.admin.json
   description        = "The Kops admin role for aws-iam-authenticator"
 
-  max_session_duration = "${var.iam_role_max_session_duration}"
+  max_session_duration = var.iam_role_max_session_duration
 }
 
 module "iam_authenticator_config" {
-  enabled               = "${var.kops_iam_enabled}"
+  enabled               = var.kops_iam_enabled
   source                = "git::https://github.com/cloudposse/terraform-aws-kops-iam-authenticator-config.git?ref=tags/0.2.2"
-  cluster_id            = "${var.cluster_id}"
-  kube_config_path      = "${var.kube_config_path}"
-  admin_iam_role_arn    = "${element(concat(aws_iam_role.admin.*.arn, list("")), 0)}"
-  admin_k8s_username    = "${var.admin_k8s_username}"
-  admin_k8s_groups      = "${var.admin_k8s_groups}"
-  readonly_iam_role_arn = "${element(concat(aws_iam_role.readonly.*.arn, list("")), 0)}"
-  readonly_k8s_username = "${var.readonly_k8s_username}"
-  readonly_k8s_groups   = "${var.readonly_k8s_groups}"
+  cluster_id            = var.cluster_id
+  kube_config_path      = var.kube_config_path
+  admin_iam_role_arn    = element(concat(aws_iam_role.admin.*.arn, list("")), 0)
+  admin_k8s_username    = var.admin_k8s_username
+  admin_k8s_groups      = var.admin_k8s_groups
+  readonly_iam_role_arn = element(concat(aws_iam_role.readonly.*.arn, list("")), 0)
+  readonly_k8s_username = var.readonly_k8s_username
+  readonly_k8s_groups   = var.readonly_k8s_groups
 }

--- a/deprecated/aws/kops-aws-platform/main.tf
+++ b/deprecated/aws/kops-aws-platform/main.tf
@@ -6,13 +6,13 @@ terraform {
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
 module "kops_metadata" {
   source       = "git::https://github.com/cloudposse/terraform-aws-kops-data-network.git?ref=tags/0.1.1"
-  enabled      = "${var.flow_logs_enabled}"
+  enabled      = var.flow_logs_enabled
   cluster_name = "${var.region}.${var.zone_name}"
 }
 
@@ -25,9 +25,9 @@ resource "aws_default_security_group" "default" {
   # If kops is using a shared VPC, then it is likely that the kops_metadata module will
   # return an empty vpc_id, in which case we will leave it to the VPC owner to manage
   # the default security group.
-  count = "${module.kops_metadata.vpc_id == "" ? 0 : 1}"
+  count = module.kops_metadata.vpc_id == "" ? 0 : 1
 
-  vpc_id = "${module.kops_metadata.vpc_id}"
+  vpc_id = module.kops_metadata.vpc_id
 
   tags = {
     Name = "Default Security Group"

--- a/deprecated/aws/kops-aws-platform/variables.tf
+++ b/deprecated/aws/kops-aws-platform/variables.tf
@@ -1,59 +1,59 @@
 variable "aws_assume_role_arn" {
-  type        = "string"
+  type        = string
   description = "AWS IAM Role for Terraform to assume during operation"
 }
 
 variable "region" {
-  type        = "string"
+  type        = string
   description = "AWS region"
 }
 
 variable "zone_name" {
-  type        = "string"
+  type        = string
   description = "DNS zone name"
 }
 
 variable "dns_zone_names" {
-  type        = "list"
+  type        = list(string)
   description = "Names of zones for external-dns to manage (e.g. `us-east-1.cloudposse.com` or `cluster-1.cloudposse.com`)"
 }
 
 variable "permitted_nodes" {
-  type        = "string"
+  type        = string
   description = "Kops kubernetes nodes that are permitted to assume IAM roles (e.g. 'nodes', 'masters', or 'both')"
   default     = "both"
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`"
 }
 
 variable "chamber_service" {
-  type        = "string"
+  type        = string
   default     = "kops"
   description = "Service under which to store SSM parameters"
 }
 
 variable "chamber_service_kops" {
-  type        = "string"
+  type        = string
   default     = "kops"
   description = "Service where kops stores its configuration information"
 }

--- a/deprecated/aws/kops-iam-users/corp.tf
+++ b/deprecated/aws/kops-iam-users/corp.tf
@@ -1,47 +1,47 @@
 module "kops_admin_corp_label" {
   source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
-  namespace  = "${var.namespace}"
+  namespace  = var.namespace
   name       = "kops"
   stage      = "corp"
   attributes = ["admin"]
-  delimiter  = "${var.delimiter}"
-  tags       = "${var.tags}"
+  delimiter  = var.delimiter
+  tags       = var.tags
   enabled    = "true"
 }
 
 module "kops_readonly_corp_label" {
   source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
-  namespace  = "${var.namespace}"
+  namespace  = var.namespace
   name       = "kops"
   stage      = "corp"
   attributes = ["readonly"]
-  delimiter  = "${var.delimiter}"
-  tags       = "${var.tags}"
+  delimiter  = var.delimiter
+  tags       = var.tags
   enabled    = "true"
 }
 
 module "kops_admin_access_group_corp" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
-  enabled           = "${contains(var.kops_iam_accounts_enabled, "corp") == true ? "true" : "false"}"
-  namespace         = "${var.namespace}"
+  enabled           = contains(var.kops_iam_accounts_enabled, "corp") == true ? "true" : "false"
+  namespace         = var.namespace
   stage             = "corp"
   name              = "kops"
   attributes        = ["admin"]
-  role_name         = "${module.kops_admin_corp_label.id}"
+  role_name         = module.kops_admin_corp_label.id
   user_names        = []
-  member_account_id = "${data.terraform_remote_state.accounts.corp_account_id}"
+  member_account_id = data.terraform_remote_state.accounts.corp_account_id
   require_mfa       = "true"
 }
 
 module "kops_readonly_access_group_corp" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
-  enabled           = "${contains(var.kops_iam_accounts_enabled, "corp") == true ? "true" : "false"}"
-  namespace         = "${var.namespace}"
+  enabled           = contains(var.kops_iam_accounts_enabled, "corp") == true ? "true" : "false"
+  namespace         = var.namespace
   stage             = "corp"
   name              = "kops"
   attributes        = ["readonly"]
-  role_name         = "${module.kops_readonly_corp_label.id}"
+  role_name         = module.kops_readonly_corp_label.id
   user_names        = []
-  member_account_id = "${data.terraform_remote_state.accounts.corp_account_id}"
+  member_account_id = data.terraform_remote_state.accounts.corp_account_id
   require_mfa       = "true"
 }

--- a/deprecated/aws/kops-iam-users/data.tf
+++ b/deprecated/aws/kops-iam-users/data.tf
@@ -1,47 +1,47 @@
 module "kops_admin_data_label" {
   source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
-  namespace  = "${var.namespace}"
+  namespace  = var.namespace
   name       = "kops"
   stage      = "data"
   attributes = ["admin"]
-  delimiter  = "${var.delimiter}"
-  tags       = "${var.tags}"
+  delimiter  = var.delimiter
+  tags       = var.tags
   enabled    = "true"
 }
 
 module "kops_readonly_data_label" {
   source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
-  namespace  = "${var.namespace}"
+  namespace  = var.namespace
   name       = "kops"
   stage      = "data"
   attributes = ["readonly"]
-  delimiter  = "${var.delimiter}"
-  tags       = "${var.tags}"
+  delimiter  = var.delimiter
+  tags       = var.tags
   enabled    = "true"
 }
 
 module "kops_admin_access_group_data" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
-  enabled           = "${contains(var.kops_iam_accounts_enabled, "data") == true ? "true" : "false"}"
-  namespace         = "${var.namespace}"
+  enabled           = contains(var.kops_iam_accounts_enabled, "data") == true ? "true" : "false"
+  namespace         = var.namespace
   stage             = "data"
   name              = "kops"
   attributes        = ["admin"]
-  role_name         = "${module.kops_admin_data_label.id}"
+  role_name         = module.kops_admin_data_label.id
   user_names        = []
-  member_account_id = "${data.terraform_remote_state.accounts.data_account_id}"
+  member_account_id = data.terraform_remote_state.accounts.data_account_id
   require_mfa       = "true"
 }
 
 module "kops_readonly_access_group_data" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
-  enabled           = "${contains(var.kops_iam_accounts_enabled, "data") == true ? "true" : "false"}"
-  namespace         = "${var.namespace}"
+  enabled           = contains(var.kops_iam_accounts_enabled, "data") == true ? "true" : "false"
+  namespace         = var.namespace
   stage             = "data"
   name              = "kops"
   attributes        = ["readonly"]
-  role_name         = "${module.kops_readonly_data_label.id}"
+  role_name         = module.kops_readonly_data_label.id
   user_names        = []
-  member_account_id = "${data.terraform_remote_state.accounts.data_account_id}"
+  member_account_id = data.terraform_remote_state.accounts.data_account_id
   require_mfa       = "true"
 }

--- a/deprecated/aws/kops-iam-users/dev.tf
+++ b/deprecated/aws/kops-iam-users/dev.tf
@@ -1,47 +1,47 @@
 module "kops_admin_dev_label" {
   source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
-  namespace  = "${var.namespace}"
+  namespace  = var.namespace
   name       = "kops"
   stage      = "dev"
   attributes = ["admin"]
-  delimiter  = "${var.delimiter}"
-  tags       = "${var.tags}"
+  delimiter  = var.delimiter
+  tags       = var.tags
   enabled    = "true"
 }
 
 module "kops_readonly_dev_label" {
   source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
-  namespace  = "${var.namespace}"
+  namespace  = var.namespace
   name       = "kops"
   stage      = "dev"
   attributes = ["readonly"]
-  delimiter  = "${var.delimiter}"
-  tags       = "${var.tags}"
+  delimiter  = var.delimiter
+  tags       = var.tags
   enabled    = "true"
 }
 
 module "kops_admin_access_group_dev" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
-  enabled           = "${contains(var.kops_iam_accounts_enabled, "dev") == true ? "true" : "false"}"
-  namespace         = "${var.namespace}"
+  enabled           = contains(var.kops_iam_accounts_enabled, "dev") == true ? "true" : "false"
+  namespace         = var.namespace
   stage             = "dev"
   name              = "kops"
   attributes        = ["admin"]
-  role_name         = "${module.kops_admin_dev_label.id}"
+  role_name         = module.kops_admin_dev_label.id
   user_names        = []
-  member_account_id = "${data.terraform_remote_state.accounts.dev_account_id}"
+  member_account_id = data.terraform_remote_state.accounts.dev_account_id
   require_mfa       = "true"
 }
 
 module "kops_readonly_access_group_dev" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
-  enabled           = "${contains(var.kops_iam_accounts_enabled, "dev") == true ? "true" : "false"}"
-  namespace         = "${var.namespace}"
+  enabled           = contains(var.kops_iam_accounts_enabled, "dev") == true ? "true" : "false"
+  namespace         = var.namespace
   stage             = "dev"
   name              = "kops"
   attributes        = ["readonly"]
-  role_name         = "${module.kops_readonly_dev_label.id}"
+  role_name         = module.kops_readonly_dev_label.id
   user_names        = []
-  member_account_id = "${data.terraform_remote_state.accounts.dev_account_id}"
+  member_account_id = data.terraform_remote_state.accounts.dev_account_id
   require_mfa       = "true"
 }

--- a/deprecated/aws/kops-iam-users/main.tf
+++ b/deprecated/aws/kops-iam-users/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 

--- a/deprecated/aws/kops-iam-users/prod.tf
+++ b/deprecated/aws/kops-iam-users/prod.tf
@@ -1,47 +1,47 @@
 module "kops_admin_prod_label" {
   source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
-  namespace  = "${var.namespace}"
+  namespace  = var.namespace
   name       = "kops"
   stage      = "prod"
   attributes = ["admin"]
-  delimiter  = "${var.delimiter}"
-  tags       = "${var.tags}"
+  delimiter  = var.delimiter
+  tags       = var.tags
   enabled    = "true"
 }
 
 module "kops_readonly_prod_label" {
   source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
-  namespace  = "${var.namespace}"
+  namespace  = var.namespace
   name       = "kops"
   stage      = "prod"
   attributes = ["readonly"]
-  delimiter  = "${var.delimiter}"
-  tags       = "${var.tags}"
+  delimiter  = var.delimiter
+  tags       = var.tags
   enabled    = "true"
 }
 
 module "kops_admin_access_group_prod" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
-  enabled           = "${contains(var.kops_iam_accounts_enabled, "prod") == true ? "true" : "false"}"
-  namespace         = "${var.namespace}"
+  enabled           = contains(var.kops_iam_accounts_enabled, "prod") == true ? "true" : "false"
+  namespace         = var.namespace
   stage             = "prod"
   name              = "kops"
   attributes        = ["admin"]
-  role_name         = "${module.kops_admin_prod_label.id}"
+  role_name         = module.kops_admin_prod_label.id
   user_names        = []
-  member_account_id = "${data.terraform_remote_state.accounts.prod_account_id}"
+  member_account_id = data.terraform_remote_state.accounts.prod_account_id
   require_mfa       = "true"
 }
 
 module "kops_readonly_access_group_prod" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
-  enabled           = "${contains(var.kops_iam_accounts_enabled, "prod") == true ? "true" : "false"}"
-  namespace         = "${var.namespace}"
+  enabled           = contains(var.kops_iam_accounts_enabled, "prod") == true ? "true" : "false"
+  namespace         = var.namespace
   stage             = "prod"
   name              = "kops"
   attributes        = ["readonly"]
-  role_name         = "${module.kops_readonly_prod_label.id}"
+  role_name         = module.kops_readonly_prod_label.id
   user_names        = []
-  member_account_id = "${data.terraform_remote_state.accounts.prod_account_id}"
+  member_account_id = data.terraform_remote_state.accounts.prod_account_id
   require_mfa       = "true"
 }

--- a/deprecated/aws/kops-iam-users/staging.tf
+++ b/deprecated/aws/kops-iam-users/staging.tf
@@ -1,47 +1,47 @@
 module "kops_admin_staging_label" {
   source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
-  namespace  = "${var.namespace}"
+  namespace  = var.namespace
   name       = "kops"
   stage      = "staging"
   attributes = ["admin"]
-  delimiter  = "${var.delimiter}"
-  tags       = "${var.tags}"
+  delimiter  = var.delimiter
+  tags       = var.tags
   enabled    = "true"
 }
 
 module "kops_readonly_staging_label" {
   source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
-  namespace  = "${var.namespace}"
+  namespace  = var.namespace
   name       = "kops"
   stage      = "staging"
   attributes = ["readonly"]
-  delimiter  = "${var.delimiter}"
-  tags       = "${var.tags}"
+  delimiter  = var.delimiter
+  tags       = var.tags
   enabled    = "true"
 }
 
 module "kops_admin_access_group_staging" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
-  enabled           = "${contains(var.kops_iam_accounts_enabled, "staging") == true ? "true" : "false"}"
-  namespace         = "${var.namespace}"
+  enabled           = contains(var.kops_iam_accounts_enabled, "staging") == true ? "true" : "false"
+  namespace         = var.namespace
   stage             = "staging"
   name              = "kops"
   attributes        = ["admin"]
-  role_name         = "${module.kops_admin_staging_label.id}"
+  role_name         = module.kops_admin_staging_label.id
   user_names        = []
-  member_account_id = "${data.terraform_remote_state.accounts.staging_account_id}"
+  member_account_id = data.terraform_remote_state.accounts.staging_account_id
   require_mfa       = "true"
 }
 
 module "kops_readonly_access_group_staging" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
-  enabled           = "${contains(var.kops_iam_accounts_enabled, "staging") == true ? "true" : "false"}"
-  namespace         = "${var.namespace}"
+  enabled           = contains(var.kops_iam_accounts_enabled, "staging") == true ? "true" : "false"
+  namespace         = var.namespace
   stage             = "staging"
   name              = "kops"
   attributes        = ["readonly"]
-  role_name         = "${module.kops_readonly_staging_label.id}"
+  role_name         = module.kops_readonly_staging_label.id
   user_names        = []
-  member_account_id = "${data.terraform_remote_state.accounts.staging_account_id}"
+  member_account_id = data.terraform_remote_state.accounts.staging_account_id
   require_mfa       = "true"
 }

--- a/deprecated/aws/kops-iam-users/testing.tf
+++ b/deprecated/aws/kops-iam-users/testing.tf
@@ -1,47 +1,47 @@
 module "kops_admin_testing_label" {
   source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
-  namespace  = "${var.namespace}"
+  namespace  = var.namespace
   name       = "kops"
   stage      = "testing"
   attributes = ["admin"]
-  delimiter  = "${var.delimiter}"
-  tags       = "${var.tags}"
+  delimiter  = var.delimiter
+  tags       = var.tags
   enabled    = "true"
 }
 
 module "kops_readonly_testing_label" {
   source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
-  namespace  = "${var.namespace}"
+  namespace  = var.namespace
   name       = "kops"
   stage      = "testing"
   attributes = ["readonly"]
-  delimiter  = "${var.delimiter}"
-  tags       = "${var.tags}"
+  delimiter  = var.delimiter
+  tags       = var.tags
   enabled    = "true"
 }
 
 module "kops_admin_access_group_testing" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
-  enabled           = "${contains(var.kops_iam_accounts_enabled, "testing") == true ? "true" : "false"}"
-  namespace         = "${var.namespace}"
+  enabled           = contains(var.kops_iam_accounts_enabled, "testing") == true ? "true" : "false"
+  namespace         = var.namespace
   stage             = "testing"
   name              = "kops"
   attributes        = ["admin"]
-  role_name         = "${module.kops_admin_testing_label.id}"
+  role_name         = module.kops_admin_testing_label.id
   user_names        = []
-  member_account_id = "${data.terraform_remote_state.accounts.testing_account_id}"
+  member_account_id = data.terraform_remote_state.accounts.testing_account_id
   require_mfa       = "true"
 }
 
 module "kops_readonly_access_group_testing" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=tags/0.4.0"
-  enabled           = "${contains(var.kops_iam_accounts_enabled, "testing") == true ? "true" : "false"}"
-  namespace         = "${var.namespace}"
+  enabled           = contains(var.kops_iam_accounts_enabled, "testing") == true ? "true" : "false"
+  namespace         = var.namespace
   stage             = "testing"
   name              = "kops"
   attributes        = ["readonly"]
-  role_name         = "${module.kops_readonly_testing_label.id}"
+  role_name         = module.kops_readonly_testing_label.id
   user_names        = []
-  member_account_id = "${data.terraform_remote_state.accounts.testing_account_id}"
+  member_account_id = data.terraform_remote_state.accounts.testing_account_id
   require_mfa       = "true"
 }

--- a/deprecated/aws/kops-iam-users/variables.tf
+++ b/deprecated/aws/kops-iam-users/variables.tf
@@ -1,31 +1,31 @@
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "kops_iam_accounts_enabled" {
-  type        = "list"
+  type        = list(string)
   description = "Accounts to create an IAM role and group for Kops users"
   default     = ["dev", "staging", "prod", "testing"]
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage, e.g. 'prod', 'staging', 'dev', or 'test'"
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`"
 }

--- a/deprecated/aws/kops-legacy-account-vpc-peering/main.tf
+++ b/deprecated/aws/kops-legacy-account-vpc-peering/main.tf
@@ -6,36 +6,36 @@ terraform {
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
 # Lookup VPC of the kops cluster
 module "kops_metadata" {
   source         = "git::https://github.com/cloudposse/terraform-aws-kops-metadata.git?ref=tags/0.2.1"
-  enabled        = "${var.enabled}"
+  enabled        = var.enabled
   dns_zone       = "${var.region}.${var.zone_name}"
-  vpc_tag        = "${var.vpc_tag}"
+  vpc_tag        = var.vpc_tag
   vpc_tag_values = ["${var.vpc_tag_values}"]
 }
 
 module "kops_legacy_account_vpc_peering" {
   source  = "git::https://github.com/cloudposse/terraform-aws-vpc-peering-multi-account.git?ref=tags/0.5.0"
-  enabled = "${var.enabled}"
+  enabled = var.enabled
 
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
-  name      = "${var.name}"
+  namespace = var.namespace
+  stage     = var.stage
+  name      = var.name
 
   auto_accept = true
 
   # Requester
-  requester_vpc_id              = "${module.kops_metadata.vpc_id}"
-  requester_region              = "${var.region}"
-  requester_aws_assume_role_arn = "${var.aws_assume_role_arn}"
+  requester_vpc_id              = module.kops_metadata.vpc_id
+  requester_region              = var.region
+  requester_aws_assume_role_arn = var.aws_assume_role_arn
 
   # Accepter
-  accepter_vpc_id              = "${var.legacy_account_vpc_id}"
-  accepter_region              = "${var.legacy_account_region}"
-  accepter_aws_assume_role_arn = "${var.legacy_account_assume_role_arn}"
+  accepter_vpc_id              = var.legacy_account_vpc_id
+  accepter_region              = var.legacy_account_region
+  accepter_aws_assume_role_arn = var.legacy_account_assume_role_arn
 }

--- a/deprecated/aws/kops-legacy-account-vpc-peering/outputs.tf
+++ b/deprecated/aws/kops-legacy-account-vpc-peering/outputs.tf
@@ -1,19 +1,19 @@
 output "accepter_accept_status" {
   description = "Accepter VPC peering connection request status"
-  value       = "${module.kops_legacy_account_vpc_peering.accepter_accept_status}"
+  value       = module.kops_legacy_account_vpc_peering.accepter_accept_status
 }
 
 output "accepter_connection_id" {
   description = "Accepter VPC peering connection ID"
-  value       = "${module.kops_legacy_account_vpc_peering.accepter_connection_id}"
+  value       = module.kops_legacy_account_vpc_peering.accepter_connection_id
 }
 
 output "requester_accept_status" {
   description = "Requester VPC peering connection request status"
-  value       = "${module.kops_legacy_account_vpc_peering.requester_accept_status}"
+  value       = module.kops_legacy_account_vpc_peering.requester_accept_status
 }
 
 output "requester_connection_id" {
   description = "Requester VPC peering connection ID"
-  value       = "${module.kops_legacy_account_vpc_peering.requester_connection_id}"
+  value       = module.kops_legacy_account_vpc_peering.requester_connection_id
 }

--- a/deprecated/aws/kops-legacy-account-vpc-peering/variables.tf
+++ b/deprecated/aws/kops-legacy-account-vpc-peering/variables.tf
@@ -1,60 +1,60 @@
 variable "aws_assume_role_arn" {}
 
 variable "enabled" {
-  type        = "string"
+  type        = string
   description = "Whether to create the resources. Set to `false` to prevent the module from creating any resources"
   default     = "true"
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `eg` or `cp`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   description = "Application or solution name (e.g. `app`)"
   default     = "vpc-peering"
 }
 
 variable "region" {
-  type        = "string"
+  type        = string
   description = "AWS region"
 }
 
 variable "zone_name" {
-  type        = "string"
+  type        = string
   description = "DNS zone name"
 }
 
 variable "vpc_tag" {
-  type        = "string"
+  type        = string
   default     = "Name"
   description = "Tag used to lookup the Kops VPC"
 }
 
 variable "vpc_tag_values" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Tag values list to lookup the Kops VPC"
 }
 
 variable "legacy_account_assume_role_arn" {
-  type        = "string"
+  type        = string
   description = "Legacy account assume role ARN"
 }
 
 variable "legacy_account_region" {
-  type        = "string"
+  type        = string
   description = "Legacy account AWS region"
 }
 
 variable "legacy_account_vpc_id" {
-  type        = "string"
+  type        = string
   description = "Legacy account VPC ID"
 }

--- a/deprecated/aws/kops/main.tf
+++ b/deprecated/aws/kops/main.tf
@@ -6,49 +6,49 @@ terraform {
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
 data "aws_availability_zones" "default" {}
 
 locals {
-  chamber_service             = "${var.chamber_service == "" ? basename(pathexpand(path.module)) : var.chamber_service}"
-  computed_availability_zones = "${data.aws_availability_zones.default.names}"
-  distinct_availability_zones = "${distinct(compact(concat(var.availability_zones, local.computed_availability_zones)))}"
+  chamber_service             = var.chamber_service == "" ? basename(pathexpand(path.module)) : var.chamber_service
+  computed_availability_zones = data.aws_availability_zones.default.names
+  distinct_availability_zones = distinct(compact(concat(var.availability_zones, local.computed_availability_zones)))
 
   # If we are creating the VPC, concatenate the predefined AZs with the computed AZs and select the first N distinct AZs.
   # If we are using a shared VPC, use the availability zones dictated by the VPC
-  availability_zones = "${split(",", var.create_vpc == "true" ? join(",", slice(local.distinct_availability_zones, 0, var.availability_zone_count)) : join("", data.aws_ssm_parameter.availability_zones.*.value))}"
+  availability_zones = split(",", var.create_vpc == "true" ? join(",", slice(local.distinct_availability_zones, 0, var.availability_zone_count)) : join("", data.aws_ssm_parameter.availability_zones.*.value))
 
-  availability_zone_count = "${length(local.availability_zones)}"
+  availability_zone_count = length(local.availability_zones)
 }
 
 module "kops_state_backend" {
   source           = "git::https://github.com/cloudposse/terraform-aws-kops-state-backend.git?ref=tags/0.3.0"
-  namespace        = "${var.namespace}"
-  stage            = "${var.stage}"
-  name             = "${var.name}"
+  namespace        = var.namespace
+  stage            = var.stage
+  name             = var.name
   attributes       = ["${var.kops_attribute}"]
-  cluster_name     = "${coalesce(var.cluster_name_prefix, var.resource_region, var.region)}"
-  parent_zone_name = "${var.zone_name}"
-  zone_name        = "${var.complete_zone_name}"
-  domain_enabled   = "${var.domain_enabled}"
-  force_destroy    = "${var.force_destroy}"
-  region           = "${coalesce(var.state_store_region, var.region)}"
-  create_bucket    = "${var.create_state_store_bucket}"
+  cluster_name     = coalesce(var.cluster_name_prefix, var.resource_region, var.region)
+  parent_zone_name = var.zone_name
+  zone_name        = var.complete_zone_name
+  domain_enabled   = var.domain_enabled
+  force_destroy    = var.force_destroy
+  region           = coalesce(var.state_store_region, var.region)
+  create_bucket    = var.create_state_store_bucket
 }
 
 module "ssh_key_pair" {
   source               = "git::https://github.com/cloudposse/terraform-aws-ssm-tls-ssh-key-pair.git?ref=tags/0.2.0"
-  namespace            = "${var.namespace}"
-  stage                = "${var.stage}"
-  name                 = "${var.name}"
+  namespace            = var.namespace
+  stage                = var.stage
+  name                 = var.name
   attributes           = ["${coalesce(var.resource_region, var.region)}"]
-  ssm_path_prefix      = "${local.chamber_service}"
-  rsa_bits             = "${var.ssh_key_rsa_bits}"
-  ssh_key_algorithm    = "${var.ssh_key_algorithm}"
-  ecdsa_curve          = "${var.ssh_key_ecdsa_curve}"
+  ssm_path_prefix      = local.chamber_service
+  rsa_bits             = var.ssh_key_rsa_bits
+  ssh_key_algorithm    = var.ssh_key_algorithm
+  ecdsa_curve          = var.ssh_key_ecdsa_curve
   ssh_public_key_name  = "kops_ssh_public_key"
   ssh_private_key_name = "kops_ssh_private_key"
 }
@@ -56,70 +56,70 @@ module "ssh_key_pair" {
 # Allocate one large subnet for each AZ, plus one additional one for the utility subnets.
 module "private_subnets" {
   source       = "subnets"
-  iprange      = "${local.vpc_network_cidr}"
-  newbits      = "${var.private_subnets_newbits > 0 ? var.private_subnets_newbits : local.availability_zone_count}"
-  netnum       = "${var.private_subnets_netnum}"
-  subnet_count = "${local.availability_zone_count + 1}"
+  iprange      = local.vpc_network_cidr
+  newbits      = var.private_subnets_newbits > 0 ? var.private_subnets_newbits : local.availability_zone_count
+  netnum       = var.private_subnets_netnum
+  subnet_count = local.availability_zone_count + 1
 }
 
 # Divide up the first private subnet and use it for the utility subnet
 module "utility_subnets" {
   source       = "subnets"
-  iprange      = "${module.private_subnets.cidrs[0]}"
-  newbits      = "${var.utility_subnets_newbits > 0 ? var.utility_subnets_newbits : local.availability_zone_count}"
-  netnum       = "${var.utility_subnets_netnum}"
-  subnet_count = "${local.availability_zone_count}"
+  iprange      = module.private_subnets.cidrs[0]
+  newbits      = var.utility_subnets_newbits > 0 ? var.utility_subnets_newbits : local.availability_zone_count
+  netnum       = var.utility_subnets_netnum
+  subnet_count = local.availability_zone_count
 }
 
 #######
 # If create_vpc is not true, then we import all the VPC configuration from the VPC chamber service
 #
 data "aws_ssm_parameter" "vpc_id" {
-  count = "${var.create_vpc == "true" ? 0 : 1}"
-  name  = "${format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "vpc_id")}"
+  count = var.create_vpc == "true" ? 0 : 1
+  name  = format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "vpc_id")
 }
 
 data "aws_ssm_parameter" "vpc_cidr_block" {
-  count = "${var.create_vpc == "true" ? 0 : 1}"
-  name  = "${format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "cidr_block")}"
+  count = var.create_vpc == "true" ? 0 : 1
+  name  = format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "cidr_block")
 }
 
 ###
 # The following are lists, and must all be the same size and in the same order
 #
 data "aws_ssm_parameter" "availability_zones" {
-  count = "${var.create_vpc == "true" ? 0 : 1}"
-  name  = "${format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "availability_zones")}"
+  count = var.create_vpc == "true" ? 0 : 1
+  name  = format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "availability_zones")
 }
 
 # List of NAT gateways from private subnet to public, one per subnet, which is one per availability zone
 data "aws_ssm_parameter" "nat_gateways" {
-  count = "${var.create_vpc == "false" && var.use_shared_nat_gateways == "true" ? 1 : 0}"
-  name  = "${format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "nat_gateways")}"
+  count = var.create_vpc == "false" && var.use_shared_nat_gateways == "true" ? 1 : 0
+  name  = format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "nat_gateways")
 }
 
 # List of private subnet CIDR blocks, one per availability zone
 data "aws_ssm_parameter" "private_subnet_cidrs" {
-  count = "${var.create_vpc == "true" ? 0 : 1}"
-  name  = "${format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "private_subnet_cidrs")}"
+  count = var.create_vpc == "true" ? 0 : 1
+  name  = format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "private_subnet_cidrs")
 }
 
 # List of private subnet AWS IDs, one per availability zone
 data "aws_ssm_parameter" "private_subnet_ids" {
-  count = "${var.create_vpc == "true" ? 0 : 1}"
-  name  = "${format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "private_subnet_ids")}"
+  count = var.create_vpc == "true" ? 0 : 1
+  name  = format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "private_subnet_ids")
 }
 
 # List of public subnet CIDR blocks, one per availability zone
 data "aws_ssm_parameter" "public_subnet_cidrs" {
-  count = "${var.create_vpc == "true" ? 0 : 1}"
-  name  = "${format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "public_subnet_cidrs")}"
+  count = var.create_vpc == "true" ? 0 : 1
+  name  = format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "public_subnet_cidrs")
 }
 
 # List of public subnet AWS IDs, one per availability zone
 data "aws_ssm_parameter" "public_subnet_ids" {
-  count = "${var.create_vpc == "true" ? 0 : 1}"
-  name  = "${format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "public_subnet_ids")}"
+  count = var.create_vpc == "true" ? 0 : 1
+  name  = format(var.vpc_chamber_parameter_name, var.vpc_chamber_service, var.vpc_paramter_prefix, "public_subnet_ids")
 }
 
 #
@@ -127,24 +127,24 @@ data "aws_ssm_parameter" "public_subnet_ids" {
 ######
 
 locals {
-  vpc_network_cidr     = "${var.create_vpc == "true" ? var.network_cidr : join("", data.aws_ssm_parameter.vpc_cidr_block.*.value)}"
-  private_subnet_cidrs = "${var.create_vpc == "true" ? join(",", slice(module.private_subnets.cidrs, 1, local.availability_zone_count + 1)) : join("", data.aws_ssm_parameter.private_subnet_cidrs.*.value)}"
-  utility_subnet_cidrs = "${var.create_vpc == "true" ? join(",", module.utility_subnets.cidrs) : join("", data.aws_ssm_parameter.public_subnet_cidrs.*.value)}"
+  vpc_network_cidr     = var.create_vpc == "true" ? var.network_cidr : join("", data.aws_ssm_parameter.vpc_cidr_block.*.value)
+  private_subnet_cidrs = var.create_vpc == "true" ? join(",", slice(module.private_subnets.cidrs, 1, local.availability_zone_count + 1)) : join("", data.aws_ssm_parameter.private_subnet_cidrs.*.value)
+  utility_subnet_cidrs = var.create_vpc == "true" ? join(",", module.utility_subnets.cidrs) : join("", data.aws_ssm_parameter.public_subnet_cidrs.*.value)
 }
 
 # These parameters correspond to the kops manifest template:
 # Read more: <https://github.com/cloudposse/geodesic/blob/master/rootfs/templates/kops/default.yaml>
 
 resource "aws_ssm_parameter" "kops_cluster_name" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_cluster_name")}"
-  value       = "${module.kops_state_backend.zone_name}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, "kops_cluster_name")
+  value       = module.kops_state_backend.zone_name
   description = "Kops cluster name"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "kops_state_store" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_state_store")}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, "kops_state_store")
   value       = "s3://${module.kops_state_backend.bucket_name}"
   description = "Kops state store S3 bucket name"
   type        = "String"
@@ -152,32 +152,32 @@ resource "aws_ssm_parameter" "kops_state_store" {
 }
 
 resource "aws_ssm_parameter" "kops_state_store_region" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_state_store_region")}"
-  value       = "${module.kops_state_backend.bucket_region}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, "kops_state_store_region")
+  value       = module.kops_state_backend.bucket_region
   description = "Kops state store (S3 bucket) region"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "kops_dns_zone" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_dns_zone")}"
-  value       = "${module.kops_state_backend.zone_name}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, "kops_dns_zone")
+  value       = module.kops_state_backend.zone_name
   description = "Kops DNS zone name"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "kops_dns_zone_id" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_dns_zone_id")}"
-  value       = "${module.kops_state_backend.zone_id}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, "kops_dns_zone_id")
+  value       = module.kops_state_backend.zone_id
   description = "Kops DNS zone ID"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "kops_network_cidr" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_network_cidr")}"
-  value       = "${local.vpc_network_cidr}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, "kops_network_cidr")
+  value       = local.vpc_network_cidr
   description = "CIDR block of the kops virtual network"
   type        = "String"
   overwrite   = "true"
@@ -185,9 +185,9 @@ resource "aws_ssm_parameter" "kops_network_cidr" {
 
 # If we are using a shared VPC, we save its AWS ID here. If kops is creating the VPC, we do not export the ID
 resource "aws_ssm_parameter" "kops_shared_vpc_id" {
-  count       = "${var.create_vpc == "true" ? 0 : 1}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_shared_vpc_id")}"
-  value       = "${join("", data.aws_ssm_parameter.vpc_id.*.value)}"
+  count       = var.create_vpc == "true" ? 0 : 1
+  name        = format(var.chamber_parameter_name, local.chamber_service, "kops_shared_vpc_id")
+  value       = join("", data.aws_ssm_parameter.vpc_id.*.value)
   description = "Kops (shared) VPC AWS ID"
   type        = "String"
   overwrite   = "true"
@@ -195,9 +195,9 @@ resource "aws_ssm_parameter" "kops_shared_vpc_id" {
 
 # If we are using a shared VPC, we save the list of NAT gateway IDs here. If kops is creating the VPC, we do not export the IDs
 resource "aws_ssm_parameter" "kops_shared_nat_gateways" {
-  count       = "${var.create_vpc == "true" ? 0 : 1}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_shared_nat_gateways")}"
-  value       = "${var.use_shared_nat_gateways == "true" ? join("", data.aws_ssm_parameter.nat_gateways.*.value) : replace(local.private_subnet_cidrs, "/[^,]+/", "External")}"
+  count       = var.create_vpc == "true" ? 0 : 1
+  name        = format(var.chamber_parameter_name, local.chamber_service, "kops_shared_nat_gateways")
+  value       = var.use_shared_nat_gateways == "true" ? join("", data.aws_ssm_parameter.nat_gateways.*.value) : replace(local.private_subnet_cidrs, "/[^,]+/", "External")
   description = "Kops (shared) private subnet NAT gateway AWS IDs"
   type        = "String"
   overwrite   = "true"
@@ -205,9 +205,9 @@ resource "aws_ssm_parameter" "kops_shared_nat_gateways" {
 
 # If we are using a shared VPC, we save the list of private subnet IDs here. If kops is creating the VPC, we do not export the IDs
 resource "aws_ssm_parameter" "kops_shared_private_subnet_ids" {
-  count       = "${var.create_vpc == "true" ? 0 : 1}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_shared_private_subnet_ids")}"
-  value       = "${join("", data.aws_ssm_parameter.private_subnet_ids.*.value)}"
+  count       = var.create_vpc == "true" ? 0 : 1
+  name        = format(var.chamber_parameter_name, local.chamber_service, "kops_shared_private_subnet_ids")
+  value       = join("", data.aws_ssm_parameter.private_subnet_ids.*.value)
   description = "Kops private subnet AWS IDs"
   type        = "String"
   overwrite   = "true"
@@ -215,41 +215,41 @@ resource "aws_ssm_parameter" "kops_shared_private_subnet_ids" {
 
 # If we are using a shared VPC, we save the list of utility (public) subnet IDs here. If kops is creating the VPC, we do not export the IDs
 resource "aws_ssm_parameter" "kops_shared_utility_subnet_ids" {
-  count       = "${var.create_vpc == "true" ? 0 : 1}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_shared_utility_subnet_ids")}"
-  value       = "${join("", data.aws_ssm_parameter.public_subnet_ids.*.value)}"
+  count       = var.create_vpc == "true" ? 0 : 1
+  name        = format(var.chamber_parameter_name, local.chamber_service, "kops_shared_utility_subnet_ids")
+  value       = join("", data.aws_ssm_parameter.public_subnet_ids.*.value)
   description = "Kops utility subnet AWS IDs"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "kops_private_subnets" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_private_subnets")}"
-  value       = "${local.private_subnet_cidrs}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, "kops_private_subnets")
+  value       = local.private_subnet_cidrs
   description = "Kops private subnet CIDRs"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "kops_utility_subnets" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_utility_subnets")}"
-  value       = "${local.utility_subnet_cidrs}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, "kops_utility_subnets")
+  value       = local.utility_subnet_cidrs
   description = "Kops utility subnet CIDRs"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "kops_non_masquerade_cidr" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_non_masquerade_cidr")}"
-  value       = "${var.kops_non_masquerade_cidr}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, "kops_non_masquerade_cidr")
+  value       = var.kops_non_masquerade_cidr
   description = "The CIDR range for Pod IPs"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "kops_availability_zones" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "kops_availability_zones")}"
-  value       = "${join(",", local.availability_zones)}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, "kops_availability_zones")
+  value       = join(",", local.availability_zones)
   description = "Kops availability zones in which cluster will be provisioned"
   type        = "String"
   overwrite   = "true"

--- a/deprecated/aws/kops/outputs.tf
+++ b/deprecated/aws/kops/outputs.tf
@@ -1,67 +1,67 @@
 output "parent_zone_id" {
-  value = "${module.kops_state_backend.parent_zone_id}"
+  value = module.kops_state_backend.parent_zone_id
 }
 
 output "parent_zone_name" {
-  value = "${module.kops_state_backend.parent_zone_name}"
+  value = module.kops_state_backend.parent_zone_name
 }
 
 output "zone_id" {
-  value = "${module.kops_state_backend.zone_id}"
+  value = module.kops_state_backend.zone_id
 }
 
 output "zone_name" {
-  value = "${module.kops_state_backend.zone_name}"
+  value = module.kops_state_backend.zone_name
 }
 
 output "bucket_name" {
-  value = "${module.kops_state_backend.bucket_name}"
+  value = module.kops_state_backend.bucket_name
 }
 
 output "bucket_region" {
-  value = "${module.kops_state_backend.bucket_region}"
+  value = module.kops_state_backend.bucket_region
 }
 
 output "bucket_domain_name" {
-  value = "${module.kops_state_backend.bucket_domain_name}"
+  value = module.kops_state_backend.bucket_domain_name
 }
 
 output "bucket_id" {
-  value = "${module.kops_state_backend.bucket_id}"
+  value = module.kops_state_backend.bucket_id
 }
 
 output "bucket_arn" {
-  value = "${module.kops_state_backend.bucket_arn}"
+  value = module.kops_state_backend.bucket_arn
 }
 
 output "ssh_public_key" {
-  value = "${module.ssh_key_pair.public_key}"
+  value = module.ssh_key_pair.public_key
 }
 
 output "availability_zones" {
-  value = "${join(",", local.availability_zones)}"
+  value = join(",", local.availability_zones)
 }
 
 output "kops_shared_vpc_id" {
-  value = "${join("", aws_ssm_parameter.kops_shared_vpc_id.*.value)}"
+  value = join("", aws_ssm_parameter.kops_shared_vpc_id.*.value)
 }
 
 output "kops_shared_nat_gateways" {
-  value = "${join("", aws_ssm_parameter.kops_shared_nat_gateways.*.value)}"
+  value = join("", aws_ssm_parameter.kops_shared_nat_gateways.*.value)
 }
 
 output "kops_shared_utility_subnet_ids" {
-  value = "${join("", aws_ssm_parameter.kops_shared_utility_subnet_ids.*.value)}"
+  value = join("", aws_ssm_parameter.kops_shared_utility_subnet_ids.*.value)
 }
 
 output "kops_shared_private_subnet_ids" {
-  value = "${join("", aws_ssm_parameter.kops_shared_private_subnet_ids.*.value)}"
+  value = join("", aws_ssm_parameter.kops_shared_private_subnet_ids.*.value)
 }
 
 output "private_subnets" {
-  value = "${local.private_subnet_cidrs}"
+  value = local.private_subnet_cidrs
 }
 
 output "utility_subnets" {
-  value = "${local.utility_subnet_cidrs}"
+  value = local.utility_subnet_cidrs
 }

--- a/deprecated/aws/kops/subnets/main.tf
+++ b/deprecated/aws/kops/subnets/main.tf
@@ -1,7 +1,7 @@
 # Read more: <http://blog.itsjustcode.net/blog/2017/11/18/terraform-cidrsubnet-deconstructed/>
 
 data "null_data_source" "subnets" {
-  count = "${var.subnet_count}"
+  count = var.subnet_count
 
   inputs = {
     cidr = "${cidrsubnet(var.iprange, var.newbits, var.netnum + count.index)}"

--- a/deprecated/aws/kops/subnets/outputs.tf
+++ b/deprecated/aws/kops/subnets/outputs.tf
@@ -1,7 +1,7 @@
 output "iprange" {
-  value = "${var.iprange}"
+  value = var.iprange
 }
 
 output "cidrs" {
-  value = "${data.null_data_source.subnets.*.outputs.cidr}"
+  value = data.null_data_source.subnets.*.outputs.cidr
 }

--- a/deprecated/aws/kops/variables.tf
+++ b/deprecated/aws/kops/variables.tf
@@ -1,55 +1,55 @@
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   description = "Name  (e.g. `kops`)"
   default     = "kops"
 }
 
 variable "region" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "AWS region for resources. Can be overriden by `resource_region` and `state_store_region`"
 }
 
 variable "state_store_region" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Region where to create the S3 bucket for the kops state store. Defaults to `var.region`"
 }
 
 variable "resource_region" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Region where to create region-specific resources. Defaults to `var.region`"
 }
 
 variable "create_state_store_bucket" {
-  type        = "string"
+  type        = string
   default     = "true"
   description = "Set to `false` to use existing S3 bucket (e.g. from another region)"
 }
 
 variable "cluster_name_prefix" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Prefix to add before parent DNS zone name to identify this cluster, e.g. `us-east-1`. Defaults to `var.resource_region`"
 }
 
 variable "availability_zones" {
-  type        = "list"
+  type        = list(string)
   description = "List of availability zones in which to provision the cluster (should be an odd number to avoid split-brain)."
   default     = []
 }
@@ -60,48 +60,48 @@ variable "availability_zone_count" {
 }
 
 variable "zone_name" {
-  type        = "string"
+  type        = string
   description = "DNS zone name"
 }
 
 variable "domain_enabled" {
-  type        = "string"
+  type        = string
   description = "Enable DNS Zone creation for kops"
   default     = "true"
 }
 
 variable "force_destroy" {
-  type        = "string"
+  type        = string
   description = "A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without errors. These objects are not recoverable."
   default     = "false"
 }
 
 variable "ssh_key_algorithm" {
-  type        = "string"
+  type        = string
   default     = "RSA"
   description = "SSH key algorithm to use. Currently-supported values are 'RSA' and 'ECDSA'"
 }
 
 variable "ssh_key_rsa_bits" {
-  type        = "string"
+  type        = string
   description = "When ssh_key_algorithm is 'RSA', the size of the generated RSA key in bits"
   default     = "4096"
 }
 
 variable "ssh_key_ecdsa_curve" {
-  type        = "string"
+  type        = string
   description = "When ssh_key_algorithm is 'ECDSA', the name of the elliptic curve to use. May be any one of 'P256', 'P384' or P521'"
   default     = "P521"
 }
 
 variable "kops_attribute" {
-  type        = "string"
+  type        = string
   description = "Additional attribute to kops state bucket"
   default     = "state"
 }
 
 variable "complete_zone_name" {
-  type        = "string"
+  type        = string
   description = "Region or any classifier prefixed to zone name"
   default     = "$${name}.$${parent_zone_name}"
 }

--- a/deprecated/aws/organization/main.tf
+++ b/deprecated/aws/organization/main.tf
@@ -8,41 +8,41 @@ terraform {
 }
 
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "organization_feature_set" {
-  type        = "string"
+  type        = string
   default     = "ALL"
   description = "`ALL` (default) or `CONSOLIDATED_BILLING`"
 }
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
 resource "aws_organizations_organization" "default" {
-  feature_set = "${var.organization_feature_set}"
+  feature_set = var.organization_feature_set
 }
 
 output "organization_id" {
-  value = "${aws_organizations_organization.default.id}"
+  value = aws_organizations_organization.default.id
 }
 
 output "organization_arn" {
-  value = "${aws_organizations_organization.default.arn}"
+  value = aws_organizations_organization.default.arn
 }
 
 output "organization_master_account_id" {
-  value = "${aws_organizations_organization.default.master_account_id}"
+  value = aws_organizations_organization.default.master_account_id
 }
 
 output "organization_master_account_arn" {
-  value = "${aws_organizations_organization.default.master_account_arn}"
+  value = aws_organizations_organization.default.master_account_arn
 }
 
 output "organization_master_account_email" {
-  value = "${aws_organizations_organization.default.master_account_email}"
+  value = aws_organizations_organization.default.master_account_email
 }

--- a/deprecated/aws/root-dns/main.tf
+++ b/deprecated/aws/root-dns/main.tf
@@ -5,19 +5,19 @@ terraform {
 }
 
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "namespace" {}
 
 variable "accounts_enabled" {
-  type        = "list"
+  type        = list(string)
   description = "Accounts to enable"
   default     = ["dev", "staging", "prod", "testing", "audit"]
 }
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }

--- a/deprecated/aws/root-dns/ns/main.tf
+++ b/deprecated/aws/root-dns/ns/main.tf
@@ -1,52 +1,52 @@
 locals {
-  enabled = "${contains(var.accounts_enabled, var.stage) == true}"
-  account = "${length(var.account) > 0 ? var.account : var.stage}"
+  enabled = contains(var.accounts_enabled, var.stage) == true
+  account = length(var.account) > 0 ? var.account : var.stage
 }
 
 module "label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.5.4"
-  enabled    = "${local.enabled ? "true" : "false"}"
-  namespace  = "${var.namespace}"
-  stage      = "${local.account}"
-  name       = "${var.name}"
-  delimiter  = "${var.delimiter}"
-  attributes = "${var.attributes}"
-  tags       = "${var.tags}"
+  enabled    = local.enabled ? "true" : "false"
+  namespace  = var.namespace
+  stage      = local.account
+  name       = var.name
+  delimiter  = var.delimiter
+  attributes = var.attributes
+  tags       = var.tags
 }
 
 # Fetch the OrganizationAccountAccessRole ARNs from SSM
 module "organization_account_access_role_arn" {
-  enabled        = "${local.enabled ? "true" : "false"}"
+  enabled        = local.enabled ? "true" : "false"
   source         = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
   parameter_read = ["/${var.namespace}/${local.account}/organization_account_access_role"]
 }
 
 locals {
-  role_arn_values = "${module.organization_account_access_role_arn.values}"
+  role_arn_values = module.organization_account_access_role_arn.values
 }
 
 data "terraform_remote_state" "stage" {
-  count   = "${local.enabled ? 1 : 0}"
+  count   = local.enabled ? 1 : 0
   backend = "s3"
 
   # This assumes stage is using a `terraform-aws-tfstate-backend`
   #   https://github.com/cloudposse/terraform-aws-tfstate-backend
   config {
-    role_arn = "${local.role_arn_values[0]}"
-    bucket   = "${module.label.id}"
-    key      = "${var.key}"
+    role_arn = local.role_arn_values[0]
+    bucket   = module.label.id
+    key      = var.key
   }
 }
 
 locals {
-  name_servers = "${flatten(data.terraform_remote_state.stage.*.name_servers)}"
+  name_servers = flatten(data.terraform_remote_state.stage.*.name_servers)
 }
 
 resource "aws_route53_record" "dns_zone_ns" {
-  count   = "${local.enabled ? 1 : 0}"
-  zone_id = "${var.zone_id}"
-  name    = "${var.stage}"
+  count   = local.enabled ? 1 : 0
+  zone_id = var.zone_id
+  name    = var.stage
   type    = "NS"
-  ttl     = "${var.ttl}"
+  ttl     = var.ttl
   records = ["${local.name_servers}"]
 }

--- a/deprecated/aws/root-dns/ns/outputs.tf
+++ b/deprecated/aws/root-dns/ns/outputs.tf
@@ -1,9 +1,9 @@
 output "stage" {
   description = "Name of the subaccount corresponding to the name servers"
-  value       = "${var.stage}"
+  value       = var.stage
 }
 
 output "name_servers" {
   description = "Name servers for the account's delegated DNS zone"
-  value       = "${local.name_servers}"
+  value       = local.name_servers
 }

--- a/deprecated/aws/root-dns/ns/variables.tf
+++ b/deprecated/aws/root-dns/ns/variables.tf
@@ -1,39 +1,39 @@
 variable "accounts_enabled" {
-  type        = "list"
+  type        = list(string)
   description = "Accounts to enable"
   default     = ["dev", "staging", "prod", "testing", "audit"]
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `eg` or `example`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   default     = "terraform"
   description = "Name  (e.g. `app` or `cluster`)"
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   default     = ["state"]
   description = "Additional attributes (e.g. `state`)"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
 }
@@ -54,6 +54,6 @@ variable "key" {
 
 variable "account" {
   description = "If set, then it will be used instead of 'stage' to assume role. This is useful when you need another domain for existing stage"
-  type        = "string"
+  type        = string
   default     = ""
 }

--- a/deprecated/aws/root-dns/parent-alerts-ns.tf
+++ b/deprecated/aws/root-dns/parent-alerts-ns.tf
@@ -1,11 +1,11 @@
 module "alerts" {
   source           = "ns"
-  accounts_enabled = "${var.accounts_enabled}"
-  namespace        = "${var.namespace}"
+  accounts_enabled = var.accounts_enabled
+  namespace        = var.namespace
   stage            = "alerts"
-  zone_id          = "${aws_route53_zone.parent_dns_zone.zone_id}"
+  zone_id          = aws_route53_zone.parent_dns_zone.zone_id
 }
 
 output "alerts_name_servers" {
-  value = "${module.alerts.name_servers}"
+  value = module.alerts.name_servers
 }

--- a/deprecated/aws/root-dns/parent-audit-ns.tf
+++ b/deprecated/aws/root-dns/parent-audit-ns.tf
@@ -1,11 +1,11 @@
 module "audit" {
   source           = "ns"
-  accounts_enabled = "${var.accounts_enabled}"
-  namespace        = "${var.namespace}"
+  accounts_enabled = var.accounts_enabled
+  namespace        = var.namespace
   stage            = "audit"
-  zone_id          = "${aws_route53_zone.parent_dns_zone.zone_id}"
+  zone_id          = aws_route53_zone.parent_dns_zone.zone_id
 }
 
 output "audit_name_servers" {
-  value = "${module.audit.name_servers}"
+  value = module.audit.name_servers
 }

--- a/deprecated/aws/root-dns/parent-corp-ns.tf
+++ b/deprecated/aws/root-dns/parent-corp-ns.tf
@@ -1,11 +1,11 @@
 module "corp" {
   source           = "ns"
-  accounts_enabled = "${var.accounts_enabled}"
-  namespace        = "${var.namespace}"
+  accounts_enabled = var.accounts_enabled
+  namespace        = var.namespace
   stage            = "corp"
-  zone_id          = "${aws_route53_zone.parent_dns_zone.zone_id}"
+  zone_id          = aws_route53_zone.parent_dns_zone.zone_id
 }
 
 output "corp_name_servers" {
-  value = "${module.corp.name_servers}"
+  value = module.corp.name_servers
 }

--- a/deprecated/aws/root-dns/parent-data-ns.tf
+++ b/deprecated/aws/root-dns/parent-data-ns.tf
@@ -1,11 +1,11 @@
 module "data" {
   source           = "ns"
-  accounts_enabled = "${var.accounts_enabled}"
-  namespace        = "${var.namespace}"
+  accounts_enabled = var.accounts_enabled
+  namespace        = var.namespace
   stage            = "data"
-  zone_id          = "${aws_route53_zone.parent_dns_zone.zone_id}"
+  zone_id          = aws_route53_zone.parent_dns_zone.zone_id
 }
 
 output "data_name_servers" {
-  value = "${module.data.name_servers}"
+  value = module.data.name_servers
 }

--- a/deprecated/aws/root-dns/parent-dev-ns.tf
+++ b/deprecated/aws/root-dns/parent-dev-ns.tf
@@ -1,11 +1,11 @@
 module "dev" {
   source           = "ns"
-  accounts_enabled = "${var.accounts_enabled}"
-  namespace        = "${var.namespace}"
+  accounts_enabled = var.accounts_enabled
+  namespace        = var.namespace
   stage            = "dev"
-  zone_id          = "${aws_route53_zone.parent_dns_zone.zone_id}"
+  zone_id          = aws_route53_zone.parent_dns_zone.zone_id
 }
 
 output "dev_name_servers" {
-  value = "${module.dev.name_servers}"
+  value = module.dev.name_servers
 }

--- a/deprecated/aws/root-dns/parent-identity-ns.tf
+++ b/deprecated/aws/root-dns/parent-identity-ns.tf
@@ -1,11 +1,11 @@
 module "identity" {
   source           = "ns"
-  accounts_enabled = "${var.accounts_enabled}"
-  namespace        = "${var.namespace}"
+  accounts_enabled = var.accounts_enabled
+  namespace        = var.namespace
   stage            = "identity"
-  zone_id          = "${aws_route53_zone.parent_dns_zone.zone_id}"
+  zone_id          = aws_route53_zone.parent_dns_zone.zone_id
 }
 
 output "identity_name_servers" {
-  value = "${module.identity.name_servers}"
+  value = module.identity.name_servers
 }

--- a/deprecated/aws/root-dns/parent-local-ns.tf
+++ b/deprecated/aws/root-dns/parent-local-ns.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "local_dns_name" {
-  zone_id = "${aws_route53_zone.parent_dns_zone.zone_id}"
+  zone_id = aws_route53_zone.parent_dns_zone.zone_id
   name    = "local"
   type    = "A"
   ttl     = "30"
@@ -7,7 +7,7 @@ resource "aws_route53_record" "local_dns_name" {
 }
 
 resource "aws_route53_record" "local_dns_wildcard" {
-  zone_id = "${aws_route53_zone.parent_dns_zone.zone_id}"
+  zone_id = aws_route53_zone.parent_dns_zone.zone_id
   name    = "*.local"
   type    = "A"
   ttl     = "30"

--- a/deprecated/aws/root-dns/parent-prod-ns.tf
+++ b/deprecated/aws/root-dns/parent-prod-ns.tf
@@ -1,11 +1,11 @@
 module "prod" {
   source           = "ns"
-  accounts_enabled = "${var.accounts_enabled}"
-  namespace        = "${var.namespace}"
+  accounts_enabled = var.accounts_enabled
+  namespace        = var.namespace
   stage            = "prod"
-  zone_id          = "${aws_route53_zone.parent_dns_zone.zone_id}"
+  zone_id          = aws_route53_zone.parent_dns_zone.zone_id
 }
 
 output "prod_name_servers" {
-  value = "${module.prod.name_servers}"
+  value = module.prod.name_servers
 }

--- a/deprecated/aws/root-dns/parent-qa-ns.tf
+++ b/deprecated/aws/root-dns/parent-qa-ns.tf
@@ -1,13 +1,13 @@
 module "qa" {
   source           = "ns"
-  accounts_enabled = "${var.accounts_enabled}"
-  namespace        = "${var.namespace}"
+  accounts_enabled = var.accounts_enabled
+  namespace        = var.namespace
   stage            = "qa"
-  zone_id          = "${aws_route53_zone.parent_dns_zone.zone_id}"
+  zone_id          = aws_route53_zone.parent_dns_zone.zone_id
   account          = "staging"
   key              = "qa-dns/terraform.tfstate"
 }
 
 output "qa_name_servers" {
-  value = "${module.qa.name_servers}"
+  value = module.qa.name_servers
 }

--- a/deprecated/aws/root-dns/parent-security-ns.tf
+++ b/deprecated/aws/root-dns/parent-security-ns.tf
@@ -1,11 +1,11 @@
 module "security" {
   source           = "ns"
-  accounts_enabled = "${var.accounts_enabled}"
-  namespace        = "${var.namespace}"
+  accounts_enabled = var.accounts_enabled
+  namespace        = var.namespace
   stage            = "security"
-  zone_id          = "${aws_route53_zone.parent_dns_zone.zone_id}"
+  zone_id          = aws_route53_zone.parent_dns_zone.zone_id
 }
 
 output "security_name_servers" {
-  value = "${module.security.name_servers}"
+  value = module.security.name_servers
 }

--- a/deprecated/aws/root-dns/parent-staging-ns.tf
+++ b/deprecated/aws/root-dns/parent-staging-ns.tf
@@ -1,11 +1,11 @@
 module "staging" {
   source           = "ns"
-  accounts_enabled = "${var.accounts_enabled}"
-  namespace        = "${var.namespace}"
+  accounts_enabled = var.accounts_enabled
+  namespace        = var.namespace
   stage            = "staging"
-  zone_id          = "${aws_route53_zone.parent_dns_zone.zone_id}"
+  zone_id          = aws_route53_zone.parent_dns_zone.zone_id
 }
 
 output "staging_name_servers" {
-  value = "${module.staging.name_servers}"
+  value = module.staging.name_servers
 }

--- a/deprecated/aws/root-dns/parent-testing-ns.tf
+++ b/deprecated/aws/root-dns/parent-testing-ns.tf
@@ -1,11 +1,11 @@
 module "testing" {
   source           = "ns"
-  accounts_enabled = "${var.accounts_enabled}"
-  namespace        = "${var.namespace}"
+  accounts_enabled = var.accounts_enabled
+  namespace        = var.namespace
   stage            = "testing"
-  zone_id          = "${aws_route53_zone.parent_dns_zone.zone_id}"
+  zone_id          = aws_route53_zone.parent_dns_zone.zone_id
 }
 
 output "testing_name_servers" {
-  value = "${module.testing.name_servers}"
+  value = module.testing.name_servers
 }

--- a/deprecated/aws/root-dns/parent.tf
+++ b/deprecated/aws/root-dns/parent.tf
@@ -1,17 +1,17 @@
 variable "parent_domain_name" {
-  type        = "string"
+  type        = string
   description = "Parent domain name"
 }
 
 resource "aws_route53_zone" "parent_dns_zone" {
-  name    = "${var.parent_domain_name}"
+  name    = var.parent_domain_name
   comment = "Parent domain name"
 }
 
 resource "aws_route53_record" "parent_dns_zone_soa" {
   allow_overwrite = true
-  zone_id         = "${aws_route53_zone.parent_dns_zone.id}"
-  name            = "${aws_route53_zone.parent_dns_zone.name}"
+  zone_id         = aws_route53_zone.parent_dns_zone.id
+  name            = aws_route53_zone.parent_dns_zone.name
   type            = "SOA"
   ttl             = "60"
 
@@ -21,9 +21,9 @@ resource "aws_route53_record" "parent_dns_zone_soa" {
 }
 
 output "parent_zone_id" {
-  value = "${aws_route53_zone.parent_dns_zone.zone_id}"
+  value = aws_route53_zone.parent_dns_zone.zone_id
 }
 
 output "parent_name_servers" {
-  value = "${aws_route53_zone.parent_dns_zone.name_servers}"
+  value = aws_route53_zone.parent_dns_zone.name_servers
 }

--- a/deprecated/aws/root-dns/root.tf
+++ b/deprecated/aws/root-dns/root.tf
@@ -1,17 +1,17 @@
 variable "root_domain_name" {
-  type        = "string"
+  type        = string
   description = "Root domain name"
 }
 
 resource "aws_route53_zone" "root_dns_zone" {
-  name    = "${var.root_domain_name}"
+  name    = var.root_domain_name
   comment = "DNS Zone for Root Account"
 }
 
 resource "aws_route53_record" "root_dns_zone_soa" {
   allow_overwrite = true
-  zone_id         = "${aws_route53_zone.root_dns_zone.id}"
-  name            = "${aws_route53_zone.root_dns_zone.name}"
+  zone_id         = aws_route53_zone.root_dns_zone.id
+  name            = aws_route53_zone.root_dns_zone.name
   type            = "SOA"
   ttl             = "60"
 
@@ -21,7 +21,7 @@ resource "aws_route53_record" "root_dns_zone_soa" {
 }
 
 resource "aws_route53_record" "root_dns_zone_ns" {
-  zone_id = "${aws_route53_zone.parent_dns_zone.zone_id}"
+  zone_id = aws_route53_zone.parent_dns_zone.zone_id
   name    = "root"
   type    = "NS"
   ttl     = "30"
@@ -29,9 +29,9 @@ resource "aws_route53_record" "root_dns_zone_ns" {
 }
 
 output "root_zone_id" {
-  value = "${aws_route53_zone.root_dns_zone.zone_id}"
+  value = aws_route53_zone.root_dns_zone.zone_id
 }
 
 output "root_name_servers" {
-  value = "${aws_route53_zone.root_dns_zone.name_servers}"
+  value = aws_route53_zone.root_dns_zone.name_servers
 }

--- a/deprecated/aws/root-iam/main.tf
+++ b/deprecated/aws/root-iam/main.tf
@@ -6,6 +6,6 @@ terraform {
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }

--- a/deprecated/aws/root-iam/root.tf
+++ b/deprecated/aws/root-iam/root.tf
@@ -1,11 +1,11 @@
 variable "root_account_admin_user_names" {
-  type        = "list"
+  type        = list(string)
   description = "IAM user names to grant admin access to Root account"
   default     = []
 }
 
 variable "root_account_readonly_user_names" {
-  type        = "list"
+  type        = list(string)
   description = "IAM user names to grant readonly access to Root account"
   default     = []
 }
@@ -13,7 +13,7 @@ variable "root_account_readonly_user_names" {
 # Provision group access to root account with MFA
 module "organization_access_group_root" {
   source              = "git::https://github.com/cloudposse/terraform-aws-iam-assumed-roles.git?ref=tags/0.6.0"
-  namespace           = "${var.namespace}"
+  namespace           = var.namespace
   stage               = "root"
   admin_name          = "admin"
   readonly_name       = "readonly"
@@ -43,19 +43,19 @@ module "organization_access_group_ssm_root" {
 }
 
 output "admin_group" {
-  value = "${module.organization_access_group_root.group_admin_name}"
+  value = module.organization_access_group_root.group_admin_name
 }
 
 output "admin_switchrole_url" {
   description = "URL to the IAM console to switch to the admin role"
-  value       = "${module.organization_access_group_root.switchrole_admin_url}"
+  value       = module.organization_access_group_root.switchrole_admin_url
 }
 
 output "readonly_group" {
-  value = "${module.organization_access_group_root.group_readonly_name}"
+  value = module.organization_access_group_root.group_readonly_name
 }
 
 output "readonly_switchrole_url" {
   description = "URL to the IAM console to switch to the readonly role"
-  value       = "${module.organization_access_group_root.switchrole_readonly_url}"
+  value       = module.organization_access_group_root.switchrole_readonly_url
 }

--- a/deprecated/aws/root-iam/variables.tf
+++ b/deprecated/aws/root-iam/variables.tf
@@ -1,13 +1,13 @@
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }

--- a/deprecated/aws/security-baseline/main.tf
+++ b/deprecated/aws/security-baseline/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
@@ -19,7 +19,7 @@ data "aws_vpc" "default" {
 }
 
 resource "aws_default_security_group" "default" {
-  vpc_id = "${data.aws_vpc.default.id}"
+  vpc_id = data.aws_vpc.default.id
 
   tags = {
     Name = "Default Security Group"
@@ -30,15 +30,15 @@ module "flow_logs" {
   source = "git::https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket.git?ref=tags/0.1.0"
 
   name       = "vpc"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  tags       = "${var.tags}"
-  attributes = "${concat(list("default"), var.attributes, list("flow-logs"))}"
-  delimiter  = "${var.delimiter}"
+  namespace  = var.namespace
+  stage      = var.stage
+  tags       = var.tags
+  attributes = concat(list("default"), var.attributes, list("flow-logs"))
+  delimiter  = var.delimiter
 
-  region = "${var.region}"
+  region = var.region
 
-  enabled = "${var.flow_logs_enabled}"
+  enabled = var.flow_logs_enabled
 
-  vpc_id = "${data.aws_vpc.default.id}"
+  vpc_id = data.aws_vpc.default.id
 }

--- a/deprecated/aws/security-baseline/output.tf
+++ b/deprecated/aws/security-baseline/output.tf
@@ -1,44 +1,44 @@
 output "flow_logs_kms_key_arn" {
-  value       = "${module.flow_logs.kms_key_arn}"
+  value       = module.flow_logs.kms_key_arn
   description = "Flow logs KMS Key ARN"
 }
 
 output "flow_logs_kms_key_id" {
-  value       = "${module.flow_logs.kms_key_id}"
+  value       = module.flow_logs.kms_key_id
   description = "Flow logs KMS Key ID"
 }
 
 output "flow_logs_kms_alias_arn" {
-  value       = "${module.flow_logs.kms_alias_arn}"
+  value       = module.flow_logs.kms_alias_arn
   description = "Flow logs KMS Alias ARN"
 }
 
 output "flow_logs_kms_alias_name" {
-  value       = "${module.flow_logs.kms_alias_name}"
+  value       = module.flow_logs.kms_alias_name
   description = "Flow logs KMS Alias name"
 }
 
 output "flow_logs_bucket_domain_name" {
-  value       = "${module.flow_logs.bucket_domain_name}"
+  value       = module.flow_logs.bucket_domain_name
   description = "Flow logs FQDN of bucket"
 }
 
 output "flow_logs_bucket_id" {
-  value       = "${module.flow_logs.bucket_id}"
+  value       = module.flow_logs.bucket_id
   description = "Flow logs bucket Name (aka ID)"
 }
 
 output "flow_logs_bucket_arn" {
-  value       = "${module.flow_logs.bucket_arn}"
+  value       = module.flow_logs.bucket_arn
   description = "Flow logs bucket ARN"
 }
 
 output "flow_logs_bucket_prefix" {
-  value       = "${module.flow_logs.bucket_prefix}"
+  value       = module.flow_logs.bucket_prefix
   description = "Flow logs bucket prefix configured for lifecycle rules"
 }
 
 output "flow_logs_id" {
-  value       = "${module.flow_logs.id}"
+  value       = module.flow_logs.id
   description = "Flow logs ID"
 }

--- a/deprecated/aws/security-baseline/variables.tf
+++ b/deprecated/aws/security-baseline/variables.tf
@@ -1,5 +1,5 @@
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "enabled" {
@@ -8,29 +8,29 @@ variable "enabled" {
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter between `name`, `namespace`, `stage` and `attributes`"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   description = "Additional attributes (_e.g._ \"1\")"
   default     = []
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   description = "Additional tags (_e.g._ map(\"BusinessUnit\",\"ABC\")"
   default     = {}
 }

--- a/deprecated/aws/ses/emails.tf
+++ b/deprecated/aws/ses/emails.tf
@@ -3,7 +3,7 @@ variable "relay_email" {
 }
 
 variable "forward_emails" {
-  type = "map"
+  type = map(string)
 
   default = {
     "ops@example.com" = ["example@gmail.com"]

--- a/deprecated/aws/ses/main.tf
+++ b/deprecated/aws/ses/main.tf
@@ -6,54 +6,54 @@ terraform {
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 
-  region = "${var.ses_region}"
+  region = var.ses_region
 }
 
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "ses_region" {
-  type        = "string"
+  type        = string
   description = "AWS Region the SES should reside in"
   default     = "us-west-2"
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "ses_name" {
-  type        = "string"
+  type        = string
   description = "Application or solution name (e.g. `app`)"
   default     = "ses"
 }
 
 variable "parent_domain_name" {
-  type        = "string"
+  type        = string
   description = "Root domain name"
 }
 
 module "ses" {
   source = "git::https://github.com/cloudposse/terraform-aws-ses-lambda-forwarder.git?ref=tags/0.2.0"
 
-  namespace = "${var.namespace}"
-  name      = "${var.ses_name}"
-  stage     = "${var.stage}"
+  namespace = var.namespace
+  name      = var.ses_name
+  stage     = var.stage
 
-  region = "${var.ses_region}"
+  region = var.ses_region
 
-  relay_email = "${var.relay_email}"
-  domain      = "${var.parent_domain_name}"
+  relay_email = var.relay_email
+  domain      = var.parent_domain_name
 
-  forward_emails = "${var.forward_emails}"
+  forward_emails = var.forward_emails
 }

--- a/deprecated/aws/slack-archive/main.tf
+++ b/deprecated/aws/slack-archive/main.tf
@@ -5,38 +5,38 @@ terraform {
 }
 
 variable "aws_assume_role_arn" {
-  type        = "string"
+  type        = string
   description = "The Amazon Resource Name (ARN) of the role to assume."
 }
 
 variable "domain_name" {
-  type        = "string"
+  type        = string
   description = "Domain name for Slack Archive"
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `eg` or `cp`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "region" {
-  type        = "string"
+  type        = string
   description = "AWS region"
 }
 
 variable "account_id" {
-  type        = "string"
+  type        = string
   description = "AWS account ID"
 }
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
@@ -45,14 +45,14 @@ provider "aws" {
   region = "us-east-1"
 
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
 # https://www.terraform.io/docs/providers/aws/d/acm_certificate.html
 data "aws_acm_certificate" "acm_cloudfront_certificate" {
   provider = "aws.virginia"
-  domain   = "${var.domain_name}"
+  domain   = var.domain_name
   statuses = ["ISSUED"]
   types    = ["AMAZON_ISSUED"]
 }
@@ -65,19 +65,19 @@ locals {
 
 module "slack_archive_user" {
   source    = "git::https://github.com/cloudposse/terraform-aws-iam-system-user.git?ref=tags/0.2.2"
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
-  name      = "${local.name}"
+  namespace = var.namespace
+  stage     = var.stage
+  name      = local.name
 }
 
 module "origin" {
   source               = "git::https://github.com/cloudposse/terraform-aws-s3-website.git?ref=tags/0.5.2"
-  namespace            = "${var.namespace}"
-  stage                = "${var.stage}"
-  name                 = "${local.name}"
-  hostname             = "${local.cdn_domain}"
-  parent_zone_name     = "${var.domain_name}"
-  region               = "${var.region}"
+  namespace            = var.namespace
+  stage                = var.stage
+  name                 = local.name
+  hostname             = local.cdn_domain
+  parent_zone_name     = var.domain_name
+  region               = var.region
   cors_allowed_headers = ["*"]
   cors_allowed_methods = ["GET"]
   cors_allowed_origins = ["*"]
@@ -102,14 +102,14 @@ module "origin" {
 # CloudFront CDN fronting origin
 module "cdn" {
   source                 = "git::https://github.com/cloudposse/terraform-aws-cloudfront-cdn.git?ref=tags/0.4.0"
-  namespace              = "${var.namespace}"
-  stage                  = "${var.stage}"
-  name                   = "${local.name}"
+  namespace              = var.namespace
+  stage                  = var.stage
+  name                   = local.name
   aliases                = ["${local.cdn_domain}", "archive.sweetops.com"]
-  origin_domain_name     = "${module.origin.s3_bucket_website_endpoint}"
+  origin_domain_name     = module.origin.s3_bucket_website_endpoint
   origin_protocol_policy = "http-only"
   viewer_protocol_policy = "redirect-to-https"
-  parent_zone_name       = "${var.domain_name}"
+  parent_zone_name       = var.domain_name
   forward_cookies        = "none"
   forward_headers        = ["Origin", "Access-Control-Request-Headers", "Access-Control-Request-Method"]
   default_ttl            = 60
@@ -120,5 +120,5 @@ module "cdn" {
   allowed_methods        = ["GET", "HEAD", "OPTIONS"]
   price_class            = "PriceClass_All"
   default_root_object    = "index.html"
-  acm_certificate_arn    = "${data.aws_acm_certificate.acm_cloudfront_certificate.arn}"
+  acm_certificate_arn    = data.aws_acm_certificate.acm_cloudfront_certificate.arn
 }

--- a/deprecated/aws/slack-archive/outputs.tf
+++ b/deprecated/aws/slack-archive/outputs.tf
@@ -1,82 +1,82 @@
 output "slack_archive_user_name" {
-  value       = "${module.slack_archive_user.user_name}"
+  value       = module.slack_archive_user.user_name
   description = "Normalized IAM user name"
 }
 
 output "slack_archive_user_arn" {
-  value       = "${module.slack_archive_user.user_arn}"
+  value       = module.slack_archive_user.user_arn
   description = "The ARN assigned by AWS for the user"
 }
 
 output "slack_archive_user_unique_id" {
-  value       = "${module.slack_archive_user.user_unique_id}"
+  value       = module.slack_archive_user.user_unique_id
   description = "The user unique ID assigned by AWS"
 }
 
 output "slack_archive_user_access_key_id" {
-  value       = "${module.slack_archive_user.access_key_id}"
+  value       = module.slack_archive_user.access_key_id
   description = "The access key ID"
   sensitive   = true
 }
 
 output "slack_archive_user_secret_access_key" {
-  value       = "${module.slack_archive_user.secret_access_key}"
+  value       = module.slack_archive_user.secret_access_key
   description = "The secret access key. This will be written to the state file in plain-text"
   sensitive   = true
 }
 
 output "slack_archive_s3_bucket_name" {
-  value = "${module.origin.s3_bucket_name}"
+  value = module.origin.s3_bucket_name
 }
 
 output "slack_archive_s3_bucket_domain_name" {
-  value = "${module.origin.s3_bucket_domain_name}"
+  value = module.origin.s3_bucket_domain_name
 }
 
 output "slack_archive_s3_bucket_arn" {
-  value = "${module.origin.s3_bucket_arn}"
+  value = module.origin.s3_bucket_arn
 }
 
 output "slack_archive_s3_bucket_website_endpoint" {
-  value = "${module.origin.s3_bucket_website_endpoint}"
+  value = module.origin.s3_bucket_website_endpoint
 }
 
 output "slack_archive_s3_bucket_website_domain" {
-  value = "${module.origin.s3_bucket_website_domain}"
+  value = module.origin.s3_bucket_website_domain
 }
 
 output "slack_archive_s3_bucket_hosted_zone_id" {
-  value = "${module.origin.s3_bucket_hosted_zone_id}"
+  value = module.origin.s3_bucket_hosted_zone_id
 }
 
 output "slack_archive_cloudfront_id" {
-  value = "${module.cdn.cf_id}"
+  value = module.cdn.cf_id
 }
 
 output "slack_archive_cloudfront_arn" {
-  value = "${module.cdn.cf_arn}"
+  value = module.cdn.cf_arn
 }
 
 output "slack_archive_cloudfront_aliases" {
-  value = "${module.cdn.cf_aliases}"
+  value = module.cdn.cf_aliases
 }
 
 output "slack_archive_cloudfront_status" {
-  value = "${module.cdn.cf_status}"
+  value = module.cdn.cf_status
 }
 
 output "slack_archive_cloudfront_domain_name" {
-  value = "${module.cdn.cf_domain_name}"
+  value = module.cdn.cf_domain_name
 }
 
 output "slack_archive_cloudfront_etag" {
-  value = "${module.cdn.cf_etag}"
+  value = module.cdn.cf_etag
 }
 
 output "slack_archive_cloudfront_hosted_zone_id" {
-  value = "${module.cdn.cf_hosted_zone_id}"
+  value = module.cdn.cf_hosted_zone_id
 }
 
 output "slack_archive_cloudfront_origin_access_identity_path" {
-  value = "${module.cdn.cf_origin_access_identity}"
+  value = module.cdn.cf_origin_access_identity
 }

--- a/deprecated/aws/teleport/main.tf
+++ b/deprecated/aws/teleport/main.tf
@@ -6,52 +6,52 @@ terraform {
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
 module "teleport_backend" {
   source                   = "git::https://github.com/cloudposse/terraform-aws-teleport-storage.git?ref=tags/0.4.0"
-  namespace                = "${var.namespace}"
-  stage                    = "${var.stage}"
-  name                     = "${var.name}"
+  namespace                = var.namespace
+  stage                    = var.stage
+  name                     = var.name
   attributes               = []
-  tags                     = "${var.tags}"
-  prefix                   = "${var.s3_prefix}"
-  standard_transition_days = "${var.s3_standard_transition_days}"
-  glacier_transition_days  = "${var.s3_glacier_transition_days}"
-  expiration_days          = "${var.s3_expiration_days}"
+  tags                     = var.tags
+  prefix                   = var.s3_prefix
+  standard_transition_days = var.s3_standard_transition_days
+  glacier_transition_days  = var.s3_glacier_transition_days
+  expiration_days          = var.s3_expiration_days
 
-  iam_role_max_session_duration = "${var.iam_role_max_session_duration}"
+  iam_role_max_session_duration = var.iam_role_max_session_duration
 
   # Autoscale min_read and min_write capacity will set the provisioned capacity for both cluster state and audit events
-  autoscale_min_read_capacity  = "${var.autoscale_min_read_capacity}"
-  autoscale_min_write_capacity = "${var.autoscale_min_write_capacity}"
+  autoscale_min_read_capacity  = var.autoscale_min_read_capacity
+  autoscale_min_write_capacity = var.autoscale_min_write_capacity
 
   # Currently the autoscalers for the cluster state and the audit events share the same settings
-  autoscale_read_target        = "${var.autoscale_read_target}"
-  autoscale_write_target       = "${var.autoscale_write_target}"
-  autoscale_max_read_capacity  = "${var.autoscale_max_read_capacity}"
-  autoscale_max_write_capacity = "${var.autoscale_max_write_capacity}"
+  autoscale_read_target        = var.autoscale_read_target
+  autoscale_write_target       = var.autoscale_write_target
+  autoscale_max_read_capacity  = var.autoscale_max_read_capacity
+  autoscale_max_write_capacity = var.autoscale_max_write_capacity
 }
 
 module "teleport_role_name" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
-  delimiter  = "${var.delimiter}"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  delimiter  = var.delimiter
   attributes = ["auth"]
-  tags       = "${var.tags}"
+  tags       = var.tags
 }
 
 module "kops_metadata" {
   source       = "git::https://github.com/cloudposse/terraform-aws-kops-data-iam.git?ref=tags/0.1.0"
-  cluster_name = "${var.cluster_name}"
+  cluster_name = var.cluster_name
 }
 
 locals {
-  chamber_service = "${var.chamber_service == "" ? basename(pathexpand(path.module)) : var.chamber_service}"
+  chamber_service = var.chamber_service == "" ? basename(pathexpand(path.module)) : var.chamber_service
 
   kops_arns = {
     masters = ["${module.kops_metadata.masters_role_arn}"]
@@ -82,9 +82,9 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "teleport" {
-  name                 = "${module.teleport_role_name.id}"
-  assume_role_policy   = "${data.aws_iam_policy_document.assume_role.json}"
-  max_session_duration = "${var.iam_role_max_session_duration}"
+  name                 = module.teleport_role_name.id
+  assume_role_policy   = data.aws_iam_policy_document.assume_role.json
+  max_session_duration = var.iam_role_max_session_duration
   description          = "The Teleport role to access teleport backend"
 }
 
@@ -131,18 +131,18 @@ data "aws_iam_policy_document" "teleport" {
 }
 
 resource "aws_iam_policy" "teleport" {
-  name        = "${module.teleport_role_name.id}"
+  name        = module.teleport_role_name.id
   description = "Grant permissions for teleport"
-  policy      = "${data.aws_iam_policy_document.teleport.json}"
+  policy      = data.aws_iam_policy_document.teleport.json
 }
 
 resource "aws_iam_role_policy_attachment" "teleport" {
-  role       = "${aws_iam_role.teleport.name}"
-  policy_arn = "${aws_iam_policy.teleport.arn}"
+  role       = aws_iam_role.teleport.name
+  policy_arn = aws_iam_policy.teleport.arn
 }
 
 resource "aws_ssm_parameter" "teleport_audit_sessions_uri" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "teleport_audit_sessions_uri")}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, "teleport_audit_sessions_uri")
   value       = "s3://${module.teleport_backend.s3_bucket_id}"
   description = "Teleport session logs storage URI"
   type        = "String"
@@ -150,7 +150,7 @@ resource "aws_ssm_parameter" "teleport_audit_sessions_uri" {
 }
 
 resource "aws_ssm_parameter" "teleport_audit_events_uri" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "teleport_audit_events_uri")}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, "teleport_audit_events_uri")
   value       = "dynamodb://${module.teleport_backend.dynamodb_audit_table_id}"
   description = "Teleport audite events storage URI"
   type        = "String"
@@ -158,24 +158,24 @@ resource "aws_ssm_parameter" "teleport_audit_events_uri" {
 }
 
 resource "aws_ssm_parameter" "teleport_cluster_state_dynamodb_table" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "teleport_cluster_state_dynamodb_table")}"
-  value       = "${module.teleport_backend.dynamodb_state_table_id}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, "teleport_cluster_state_dynamodb_table")
+  value       = module.teleport_backend.dynamodb_state_table_id
   description = "Teleport cluster state storage dynamodb table"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "teleport_auth_iam_role" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "teleport_auth_iam_role")}"
-  value       = "${aws_iam_role.teleport.name}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, "teleport_auth_iam_role")
+  value       = aws_iam_role.teleport.name
   description = "Teleport auth IAM role"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "teleport_kubernetes_namespace" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "teleport_kubernetes_namespace")}"
-  value       = "${var.kubernetes_namespace}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, "teleport_kubernetes_namespace")
+  value       = var.kubernetes_namespace
   description = "Teleport auth IAM role"
   type        = "String"
   overwrite   = "true"
@@ -186,35 +186,35 @@ locals {
 }
 
 resource "random_string" "tokens" {
-  count   = "${length(local.token_names)}"
+  count   = length(local.token_names)
   length  = 32
   special = false
 
   keepers {
-    cluster_name = "${var.cluster_name}"
+    cluster_name = var.cluster_name
   }
 }
 
 resource "aws_ssm_parameter" "teleport_tokens" {
-  count       = "${length(local.token_names)}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "${element(local.token_names, count.index)}")}"
-  value       = "${element(random_string.tokens.*.result, count.index)}"
+  count       = length(local.token_names)
+  name        = format(var.chamber_parameter_name, local.chamber_service, "${element(local.token_names, count.index)}")
+  value       = element(random_string.tokens.*.result, count.index)
   description = "Teleport join token: ${element(local.token_names, count.index)}"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "teleport_proxy_domain_name" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "teleport_proxy_domain_name")}"
-  value       = "${var.teleport_proxy_domain_name}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, "teleport_proxy_domain_name")
+  value       = var.teleport_proxy_domain_name
   description = "Teleport Proxy domain name"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "teleport_version" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, "teleport_version")}"
-  value       = "${var.teleport_version}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, "teleport_version")
+  value       = var.teleport_version
   description = "Teleport version to install"
   type        = "String"
   overwrite   = "true"
@@ -230,6 +230,6 @@ resource "kubernetes_namespace" "default" {
       name = "${var.kubernetes_namespace}"
     }
 
-    name = "${var.kubernetes_namespace}"
+    name = var.kubernetes_namespace
   }
 }

--- a/deprecated/aws/teleport/outputs.tf
+++ b/deprecated/aws/teleport/outputs.tf
@@ -1,25 +1,25 @@
 output "teleport_version" {
-  value = "${var.teleport_version}"
+  value = var.teleport_version
 }
 
 output "teleport_proxy_domain_name" {
-  value = "${var.teleport_proxy_domain_name}"
+  value = var.teleport_proxy_domain_name
 }
 
 output "parameter_store_prefix" {
-  value = "${format(var.chamber_parameter_name, local.chamber_service, "")}"
+  value = format(var.chamber_parameter_name, local.chamber_service, "")
 }
 
 output "teleport_kubernetes_namespace" {
-  value = "${var.kubernetes_namespace}"
+  value = var.kubernetes_namespace
 }
 
 output "teleport_auth_iam_role" {
-  value = "${aws_iam_role.teleport.name}"
+  value = aws_iam_role.teleport.name
 }
 
 output "teleport_cluster_state_dynamodb_table" {
-  value = "${module.teleport_backend.dynamodb_state_table_id}"
+  value = module.teleport_backend.dynamodb_state_table_id
 }
 
 output "teleport_audit_sessions_uri" {

--- a/deprecated/aws/teleport/variables.tf
+++ b/deprecated/aws/teleport/variables.tf
@@ -1,5 +1,5 @@
 variable "permitted_nodes" {
-  type = "string"
+  type = string
 
   # Set to 'masters' if using kiam to control roles
   default     = "both"
@@ -7,67 +7,67 @@ variable "permitted_nodes" {
 }
 
 variable "cluster_name" {
-  type        = "string"
+  type        = string
   description = "Kops cluster name (e.g. `us-east-1.prod.cloudposse.co` or `cluster-1.cloudposse.co`)"
 }
 
 variable "aws_assume_role_arn" {
-  type        = "string"
+  type        = string
   description = "AWS IAM Role for Terraform to assume during operation"
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "kubernetes_namespace" {
-  type        = "string"
+  type        = string
   description = "Kubernetes namespace in which to place Teleport resources"
   default     = "teleport"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage, e.g. 'prod', 'staging', 'dev', or 'test'"
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   description = "The name of the app"
   default     = "teleport"
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Additional tags (e.g. map('BusinessUnit`,`XYZ`)"
 }
 
 variable "teleport_version" {
-  type        = "string"
+  type        = string
   description = "Version number of Teleport to install (e.g. \"4.0.9\")"
 }
 
 variable "teleport_proxy_domain_name" {
-  type        = "string"
+  type        = string
   description = "Domain name to use for Teleport Proxy"
 }
 
 variable "masters_name" {
-  type        = "string"
+  type        = string
   default     = "masters"
   description = "Kops masters subdomain name in the cluster DNS zone"
 }
 
 variable "nodes_name" {
-  type        = "string"
+  type        = string
   default     = "nodes"
   description = "Kops nodes subdomain name in the cluster DNS zone"
 }
@@ -82,25 +82,25 @@ variable "chamber_parameter_name" {
 }
 
 variable "s3_prefix" {
-  type        = "string"
+  type        = string
   description = "S3 bucket prefix"
   default     = ""
 }
 
 variable "s3_standard_transition_days" {
-  type        = "string"
+  type        = string
   description = "Number of days to persist in the standard storage tier before moving to the glacier tier"
   default     = "30"
 }
 
 variable "s3_glacier_transition_days" {
-  type        = "string"
+  type        = string
   description = "Number of days after which to move the data to the glacier storage tier"
   default     = "60"
 }
 
 variable "s3_expiration_days" {
-  type        = "string"
+  type        = string
   description = "Number of days after which to expunge the objects"
   default     = "90"
 }

--- a/deprecated/aws/tfstate-backend/main.tf
+++ b/deprecated/aws/tfstate-backend/main.tf
@@ -8,63 +8,63 @@ variable "aws_assume_role_arn" {}
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   description = "Application or solution name (e.g. `app`)"
   default     = "terraform"
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   default     = ["state"]
   description = "Additional attributes (e.g. `1`)"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
 }
 
 variable "region" {
-  type        = "string"
+  type        = string
   description = "AWS Region the S3 bucket should reside in"
   default     = "us-west-2"
 }
 
 variable "force_destroy" {
-  type        = "string"
+  type        = string
   description = "A boolean that indicates the S3 bucket can be destroyed even if it contains objects. These objects are not recoverable."
   default     = "false"
 }
 
 module "tfstate_backend" {
   source        = "git::https://github.com/cloudposse/terraform-aws-tfstate-backend.git?ref=tags/0.7.0"
-  namespace     = "${var.namespace}"
-  name          = "${var.name}"
-  stage         = "${var.stage}"
-  attributes    = "${var.attributes}"
-  tags          = "${var.tags}"
-  region        = "${var.region}"
-  force_destroy = "${var.force_destroy}"
+  namespace     = var.namespace
+  name          = var.name
+  stage         = var.stage
+  attributes    = var.attributes
+  tags          = var.tags
+  region        = var.region
+  force_destroy = var.force_destroy
 }

--- a/deprecated/aws/tfstate-backend/outputs.tf
+++ b/deprecated/aws/tfstate-backend/outputs.tf
@@ -1,23 +1,23 @@
 output "tfstate_backend_s3_bucket_domain_name" {
-  value = "${module.tfstate_backend.s3_bucket_domain_name}"
+  value = module.tfstate_backend.s3_bucket_domain_name
 }
 
 output "tfstate_backend_s3_bucket_id" {
-  value = "${module.tfstate_backend.s3_bucket_id}"
+  value = module.tfstate_backend.s3_bucket_id
 }
 
 output "tfstate_backend_s3_bucket_arn" {
-  value = "${module.tfstate_backend.s3_bucket_arn}"
+  value = module.tfstate_backend.s3_bucket_arn
 }
 
 output "tfstate_backend_dynamodb_table_name" {
-  value = "${module.tfstate_backend.dynamodb_table_name}"
+  value = module.tfstate_backend.dynamodb_table_name
 }
 
 output "tfstate_backend_dynamodb_table_id" {
-  value = "${module.tfstate_backend.dynamodb_table_id}"
+  value = module.tfstate_backend.dynamodb_table_id
 }
 
 output "tfstate_backend_dynamodb_table_arn" {
-  value = "${module.tfstate_backend.dynamodb_table_arn}"
+  value = module.tfstate_backend.dynamodb_table_arn
 }

--- a/deprecated/aws/users/main.tf
+++ b/deprecated/aws/users/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
@@ -29,29 +29,29 @@ data "terraform_remote_state" "root_iam" {
 }
 
 locals {
-  accounts_enabled = "${concat(list("root"), var.accounts_enabled)}"
+  accounts_enabled = concat(list("root"), var.accounts_enabled)
 }
 
 # Fetch the OrganizationAccountAccessRole ARNs from SSM
 module "admin_groups" {
   source         = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
-  parameter_read = "${formatlist("/${var.namespace}/%s/admin_group", local.accounts_enabled)}"
+  parameter_read = formatlist("/${var.namespace}/%s/admin_group", local.accounts_enabled)
 }
 
 locals {
-  account_alias           = "${data.terraform_remote_state.account_settings.account_alias}"
-  signin_url              = "${data.terraform_remote_state.account_settings.signin_url}"
+  account_alias           = data.terraform_remote_state.account_settings.account_alias
+  signin_url              = data.terraform_remote_state.account_settings.signin_url
   admin_groups            = ["${module.admin_groups.values}"]
   readonly_groups         = ["${data.terraform_remote_state.root_iam.readonly_group}"]
-  minimum_password_length = "${data.terraform_remote_state.account_settings.minimum_password_length}"
+  minimum_password_length = data.terraform_remote_state.account_settings.minimum_password_length
 }
 
 output "account_alias" {
   description = "AWS IAM Account Alias"
-  value       = "${local.account_alias}"
+  value       = local.account_alias
 }
 
 output "signin_url" {
   description = "AWS Signin URL"
-  value       = "${local.signin_url}"
+  value       = local.signin_url
 }

--- a/deprecated/aws/users/variables.tf
+++ b/deprecated/aws/users/variables.tf
@@ -1,30 +1,30 @@
 variable "aws_assume_role_arn" {}
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   description = "Application or solution name (e.g. `app`)"
   default     = "terraform"
 }
 
 variable "smtp_username" {
   description = "Username to authenticate with the SMTP server"
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "smtp_password" {
   description = "Password to authenticate with the SMTP server"
-  type        = "string"
+  type        = string
   default     = ""
 }
 
@@ -39,7 +39,7 @@ variable "smtp_port" {
 }
 
 variable "accounts_enabled" {
-  type        = "list"
+  type        = list(string)
   description = "Accounts to enable"
   default     = ["dev", "staging", "prod", "testing", "audit"]
 }

--- a/deprecated/aws/vpc-peering-intra-account/main.tf
+++ b/deprecated/aws/vpc-peering-intra-account/main.tf
@@ -6,28 +6,28 @@ terraform {
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
 module "vpc_peering" {
   source = "git::https://github.com/cloudposse/terraform-aws-vpc-peering.git?ref=tags/0.2.0"
 
-  enabled = "${var.enabled}"
+  enabled = var.enabled
 
-  stage      = "${var.stage}"
-  namespace  = "${var.namespace}"
-  name       = "${var.name}"
-  delimiter  = "${var.delimiter}"
-  attributes = "${var.attributes}"
-  tags       = "${var.tags}"
+  stage      = var.stage
+  namespace  = var.namespace
+  name       = var.name
+  delimiter  = var.delimiter
+  attributes = var.attributes
+  tags       = var.tags
 
-  requestor_vpc_id   = "${var.requestor_vpc_id}"
-  requestor_vpc_tags = "${var.requestor_vpc_tags}"
-  acceptor_vpc_id    = "${var.acceptor_vpc_id}"
-  acceptor_vpc_tags  = "${var.acceptor_vpc_tags}"
-  auto_accept        = "${var.auto_accept}"
+  requestor_vpc_id   = var.requestor_vpc_id
+  requestor_vpc_tags = var.requestor_vpc_tags
+  acceptor_vpc_id    = var.acceptor_vpc_id
+  acceptor_vpc_tags  = var.acceptor_vpc_tags
+  auto_accept        = var.auto_accept
 
-  acceptor_allow_remote_vpc_dns_resolution  = "${var.acceptor_allow_remote_vpc_dns_resolution}"
-  requestor_allow_remote_vpc_dns_resolution = "${var.requestor_allow_remote_vpc_dns_resolution}"
+  acceptor_allow_remote_vpc_dns_resolution  = var.acceptor_allow_remote_vpc_dns_resolution
+  requestor_allow_remote_vpc_dns_resolution = var.requestor_allow_remote_vpc_dns_resolution
 }

--- a/deprecated/aws/vpc-peering-intra-account/outputs.tf
+++ b/deprecated/aws/vpc-peering-intra-account/outputs.tf
@@ -1,9 +1,9 @@
 output "connection_id" {
-  value       = "${module.vpc_peering.connection_id}"
+  value       = module.vpc_peering.connection_id
   description = "VPC peering connection ID"
 }
 
 output "accept_status" {
-  value       = "${module.vpc_peering.accept_status}"
+  value       = module.vpc_peering.accept_status
   description = "The status of the VPC peering connection request"
 }

--- a/deprecated/aws/vpc-peering-intra-account/variables.tf
+++ b/deprecated/aws/vpc-peering-intra-account/variables.tf
@@ -4,29 +4,29 @@ variable "enabled" {
 }
 
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "requestor_vpc_id" {
-  type        = "string"
+  type        = string
   description = "Requestor VPC ID"
   default     = ""
 }
 
 variable "requestor_vpc_tags" {
-  type        = "map"
+  type        = map(string)
   description = "Requestor VPC tags"
   default     = {}
 }
 
 variable "acceptor_vpc_id" {
-  type        = "string"
+  type        = string
   description = "Acceptor VPC ID"
   default     = ""
 }
 
 variable "acceptor_vpc_tags" {
-  type        = "map"
+  type        = map(string)
   description = "Acceptor VPC tags"
   default     = {}
 }
@@ -48,33 +48,33 @@ variable "requestor_allow_remote_vpc_dns_resolution" {
 
 variable "namespace" {
   description = "Namespace (e.g. `cp` or `cloudposse`)"
-  type        = "string"
+  type        = string
 }
 
 variable "stage" {
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
-  type        = "string"
+  type        = string
 }
 
 variable "name" {
   description = "Name  (e.g. `app` or `cluster`)"
-  type        = "string"
+  type        = string
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Additional attributes (e.g. `policy` or `role`)"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Additional tags (e.g. map('BusinessUnit`,`XYZ`)"
 }

--- a/deprecated/aws/vpc-peering/main.tf
+++ b/deprecated/aws/vpc-peering/main.tf
@@ -6,75 +6,75 @@ terraform {
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
 # Fetch the OrganizationAccountAccessRole ARNs from SSM
 module "requester_role_arns" {
-  enabled        = "${var.enabled}"
+  enabled        = var.enabled
   source         = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
   parameter_read = ["/${var.namespace}/${var.requester_account}/organization_account_access_role"]
 }
 
 locals {
-  requester_vpc_tags = "${var.requester_vpc_tags}"
-  requester_region   = "${var.requester_region}"
-  requester_role_arn = "${join("", module.requester_role_arns.values)}"
+  requester_vpc_tags = var.requester_vpc_tags
+  requester_region   = var.requester_region
+  requester_role_arn = join("", module.requester_role_arns.values)
 }
 
 # Fetch the OrganizationAccountAccessRole ARNs from SSM
 module "accepter_role_arns" {
-  enabled        = "${var.enabled}"
+  enabled        = var.enabled
   source         = "git::https://github.com/cloudposse/terraform-aws-ssm-parameter-store?ref=tags/0.1.5"
   parameter_read = ["/${var.namespace}/${var.accepter_account}/organization_account_access_role"]
 }
 
 locals {
-  accepter_vpc_tags = "${var.accepter_vpc_tags}"
-  accepter_region   = "${var.accepter_region}"
-  accepter_role_arn = "${join("", module.accepter_role_arns.values)}"
+  accepter_vpc_tags = var.accepter_vpc_tags
+  accepter_region   = var.accepter_region
+  accepter_role_arn = join("", module.accepter_role_arns.values)
 }
 
 module "vpc_peering" {
   source = "git::https://github.com/cloudposse/terraform-aws-vpc-peering-multi-account.git?ref=tags/0.1.0"
 
-  enabled = "${var.enabled}"
+  enabled = var.enabled
 
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
   attributes = ["${var.requester_account}", "${var.accepter_account}"]
 
   auto_accept = true
 
   # Requester
-  requester_vpc_tags            = "${local.requester_vpc_tags}"
-  requester_region              = "${local.requester_region}"
-  requester_aws_assume_role_arn = "${local.requester_role_arn}"
+  requester_vpc_tags            = local.requester_vpc_tags
+  requester_region              = local.requester_region
+  requester_aws_assume_role_arn = local.requester_role_arn
 
   # Accepter
-  accepter_vpc_tags            = "${local.accepter_vpc_tags}"
-  accepter_region              = "${local.accepter_region}"
-  accepter_aws_assume_role_arn = "${local.accepter_role_arn}"
+  accepter_vpc_tags            = local.accepter_vpc_tags
+  accepter_region              = local.accepter_region
+  accepter_aws_assume_role_arn = local.accepter_role_arn
 }
 
 output "accepter_accept_status" {
   description = "Accepter VPC peering connection request status"
-  value       = "${module.vpc_peering.accepter_accept_status}"
+  value       = module.vpc_peering.accepter_accept_status
 }
 
 output "accepter_connection_id" {
   description = "Accepter VPC peering connection ID"
-  value       = "${module.vpc_peering.accepter_connection_id}"
+  value       = module.vpc_peering.accepter_connection_id
 }
 
 output "requester_accept_status" {
   description = "Requester VPC peering connection request status"
-  value       = "${module.vpc_peering.requester_accept_status}"
+  value       = module.vpc_peering.requester_accept_status
 }
 
 output "requester_connection_id" {
   description = "Requester VPC peering connection ID"
-  value       = "${module.vpc_peering.requester_connection_id}"
+  value       = module.vpc_peering.requester_connection_id
 }

--- a/deprecated/aws/vpc-peering/variables.tf
+++ b/deprecated/aws/vpc-peering/variables.tf
@@ -1,23 +1,23 @@
 variable "aws_assume_role_arn" {}
 
 variable "enabled" {
-  type        = "string"
+  type        = string
   description = "Whether to create the resources. Set to `false` to prevent the module from creating any resources"
   default     = "true"
 }
 
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `eg` or `cp`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   description = "Application or solution name (e.g. `app`)"
   default     = "vpc-peering"
 }
@@ -31,7 +31,7 @@ variable "requester_region" {
 }
 
 variable "requester_vpc_tags" {
-  type        = "map"
+  type        = map(string)
   description = "Tags to filter for the requester's VPC"
   default     = {}
 }
@@ -45,7 +45,7 @@ variable "accepter_account" {
 }
 
 variable "accepter_vpc_tags" {
-  type        = "map"
+  type        = map(string)
   description = "Tags to filter for the accepter's VPC"
   default     = {}
 }

--- a/deprecated/aws/vpc/main.tf
+++ b/deprecated/aws/vpc/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 provider "aws" {
   assume_role {
-    role_arn = "${var.aws_assume_role_arn}"
+    role_arn = var.aws_assume_role_arn
   }
 }
 
@@ -15,18 +15,18 @@ provider "null" {
 }
 
 locals {
-  chamber_service = "${var.chamber_service == "" ? basename(pathexpand(path.module)) : var.chamber_service}"
+  chamber_service = var.chamber_service == "" ? basename(pathexpand(path.module)) : var.chamber_service
 
   # Work around limitation that conditional operator cannot be used with lists. https://github.com/hashicorp/terraform/issues/18259
-  availability_zones = "${split("|", length(var.availability_zones) == 0 ? join("|", data.aws_availability_zones.available.names) : join("|", var.availability_zones))}"
+  availability_zones = split("|", length(var.availability_zones) == 0 ? join("|", data.aws_availability_zones.available.names) : join("|", var.availability_zones))
 }
 
 module "parameter_prefix" {
   source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
   namespace  = ""
   stage      = ""
-  name       = "${var.name}"
-  attributes = "${var.attributes}"
+  name       = var.name
+  attributes = var.attributes
   delimiter  = "_"
 }
 
@@ -34,108 +34,108 @@ data "aws_availability_zones" "available" {}
 
 module "vpc" {
   source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.3.3"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
-  cidr_block = "${var.vpc_cidr_block}"
-  attributes = "${var.attributes}"
-  tags       = "${var.tags}"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  cidr_block = var.vpc_cidr_block
+  attributes = var.attributes
+  tags       = var.tags
 }
 
 module "subnets" {
   source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.12.3"
-  availability_zones   = "${local.availability_zones}"
-  max_subnet_count     = "${var.max_subnet_count}"
-  namespace            = "${var.namespace}"
-  stage                = "${var.stage}"
-  name                 = "${var.name}"
-  vpc_id               = "${module.vpc.vpc_id}"
-  igw_id               = "${module.vpc.igw_id}"
-  cidr_block           = "${module.vpc.vpc_cidr_block}"
-  nat_gateway_enabled  = "${var.vpc_nat_gateway_enabled}"
-  nat_instance_enabled = "${var.vpc_nat_instance_enabled}"
-  nat_instance_type    = "${var.vpc_nat_instance_type}"
-  attributes           = "${var.attributes}"
-  tags                 = "${var.tags}"
+  availability_zones   = local.availability_zones
+  max_subnet_count     = var.max_subnet_count
+  namespace            = var.namespace
+  stage                = var.stage
+  name                 = var.name
+  vpc_id               = module.vpc.vpc_id
+  igw_id               = module.vpc.igw_id
+  cidr_block           = module.vpc.vpc_cidr_block
+  nat_gateway_enabled  = var.vpc_nat_gateway_enabled
+  nat_instance_enabled = var.vpc_nat_instance_enabled
+  nat_instance_type    = var.vpc_nat_instance_type
+  attributes           = var.attributes
+  tags                 = var.tags
 }
 
 resource "aws_ssm_parameter" "vpc_id" {
   description = "VPC ID of backing services"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "vpc_id")}"
-  value       = "${module.vpc.vpc_id}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "vpc_id")
+  value       = module.vpc.vpc_id
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "igw_id" {
   description = "VPC ID of backing services"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "igw_id")}"
-  value       = "${module.vpc.igw_id}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "igw_id")
+  value       = module.vpc.igw_id
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "cidr_block" {
   description = "VPC ID of backing services"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "cidr_block")}"
-  value       = "${module.vpc.vpc_cidr_block}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "cidr_block")
+  value       = module.vpc.vpc_cidr_block
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "availability_zones" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "availability_zones")}"
-  value       = "${join(",", local.availability_zones)}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "availability_zones")
+  value       = join(",", local.availability_zones)
   description = "VPC subnet availability zones"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "nat_gateways" {
-  count       = "${var.vpc_nat_gateway_enabled == "true" ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "nat_gateways")}"
-  value       = "${join(",", module.subnets.nat_gateway_ids)}"
+  count       = var.vpc_nat_gateway_enabled == "true" ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "nat_gateways")
+  value       = join(",", module.subnets.nat_gateway_ids)
   description = "VPC private NAT gateways"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "nat_instances" {
-  count       = "${var.vpc_nat_instance_enabled == "true" ? 1 : 0}"
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "nat_instances")}"
-  value       = "${join(",", module.subnets.nat_instance_ids)}"
+  count       = var.vpc_nat_instance_enabled == "true" ? 1 : 0
+  name        = format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "nat_instances")
+  value       = join(",", module.subnets.nat_instance_ids)
   description = "VPC private NAT instances"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "private_subnet_cidrs" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "private_subnet_cidrs")}"
-  value       = "${join(",", module.subnets.private_subnet_cidrs)}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "private_subnet_cidrs")
+  value       = join(",", module.subnets.private_subnet_cidrs)
   description = "VPC private subnet CIDRs"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "private_subnet_ids" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "private_subnet_ids")}"
-  value       = "${join(",", module.subnets.private_subnet_ids)}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "private_subnet_ids")
+  value       = join(",", module.subnets.private_subnet_ids)
   description = "VPC private subnet AWS IDs"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "public_subnet_cidrs" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "public_subnet_cidrs")}"
-  value       = "${join(",", module.subnets.public_subnet_cidrs)}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "public_subnet_cidrs")
+  value       = join(",", module.subnets.public_subnet_cidrs)
   description = "VPC public subnet CIDRs"
   type        = "String"
   overwrite   = "true"
 }
 
 resource "aws_ssm_parameter" "public_subnet_ids" {
-  name        = "${format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "public_subnet_ids")}"
-  value       = "${join(",", module.subnets.public_subnet_ids)}"
+  name        = format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "public_subnet_ids")
+  value       = join(",", module.subnets.public_subnet_ids)
   description = "VPC public subnet AWS IDs"
   type        = "String"
   overwrite   = "true"

--- a/deprecated/aws/vpc/outputs.tf
+++ b/deprecated/aws/vpc/outputs.tf
@@ -1,48 +1,48 @@
 output "parameter_store_prefix" {
-  value = "${format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "")}"
+  value = format(var.chamber_parameter_name, local.chamber_service, module.parameter_prefix.id, "")
 }
 
 output "vpc_id" {
   description = "AWS ID of the VPC created"
-  value       = "${aws_ssm_parameter.vpc_id.value}"
+  value       = aws_ssm_parameter.vpc_id.value
 }
 
 output "igw_id" {
   description = "AWS ID of Internet Gateway for the VPC"
-  value       = "${aws_ssm_parameter.igw_id.value}"
+  value       = aws_ssm_parameter.igw_id.value
 }
 
 output "nat_gateways" {
   description = "Comma-separated string list of AWS IDs of NAT Gateways for the VPC"
-  value       = "${join("", aws_ssm_parameter.nat_gateways.*.value)}"
+  value       = join("", aws_ssm_parameter.nat_gateways.*.value)
 }
 
 output "cidr_block" {
   description = "CIDR block of the VPC"
-  value       = "${aws_ssm_parameter.cidr_block.value}"
+  value       = aws_ssm_parameter.cidr_block.value
 }
 
 output "availability_zones" {
   description = "Comma-separated string list of avaialbility zones where subnets have been created"
-  value       = "${aws_ssm_parameter.availability_zones.value}"
+  value       = aws_ssm_parameter.availability_zones.value
 }
 
 output "public_subnet_cidrs" {
   description = "Comma-separated string list of CIDR blocks of public VPC subnets"
-  value       = "${aws_ssm_parameter.public_subnet_cidrs.value}"
+  value       = aws_ssm_parameter.public_subnet_cidrs.value
 }
 
 output "public_subnet_ids" {
   description = "Comma-separated string list of AWS IDs of public VPC subnets"
-  value       = "${aws_ssm_parameter.public_subnet_ids.value}"
+  value       = aws_ssm_parameter.public_subnet_ids.value
 }
 
 output "private_subnet_cidrs" {
   description = "Comma-separated string list of CIDR blocks of private VPC subnets"
-  value       = "${aws_ssm_parameter.private_subnet_cidrs.value}"
+  value       = aws_ssm_parameter.private_subnet_cidrs.value
 }
 
 output "private_subnet_ids" {
   description = "Comma-separated string list of AWS IDs of private VPC subnets"
-  value       = "${aws_ssm_parameter.private_subnet_ids.value}"
+  value       = aws_ssm_parameter.private_subnet_ids.value
 }

--- a/deprecated/aws/vpc/variables.tf
+++ b/deprecated/aws/vpc/variables.tf
@@ -1,31 +1,31 @@
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   description = "Name to distinguish this VPC from others in this account"
   default     = "vpc"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   description = "Additional attributes to distinguish this VPC from others in this account"
   default     = ["common"]
 }
 
 variable "aws_assume_role_arn" {
-  type = "string"
+  type = string
 }
 
 variable "region" {
-  type = "string"
+  type = string
 }
 
 variable "max_subnet_count" {
@@ -34,7 +34,7 @@ variable "max_subnet_count" {
 }
 
 variable "availability_zones" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "List of Availability Zones where subnets will be created. If empty, all zones will be used"
 }
@@ -55,7 +55,7 @@ variable "vpc_nat_instance_type" {
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Additional tags, for example map(`KubernetesCluster`,`us-west-2.prod.example.com`)"
 }

--- a/modules/aws-waf-acl/README.md
+++ b/modules/aws-waf-acl/README.md
@@ -57,7 +57,7 @@ components:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_aws_waf"></a> [aws\_waf](#module\_aws\_waf) | cloudposse/waf/aws | 0.0.1 |
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
 
 ## Resources

--- a/modules/efs/README.md
+++ b/modules/efs/README.md
@@ -33,16 +33,18 @@ components:
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
-| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 0.17.0 |
 | <a name="module_efs"></a> [efs](#module\_efs) | git::https://github.com/cloudposse/terraform-aws-efs.git | tags/0.21.0 |
+| <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 0.17.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_kms_key_efs"></a> [kms\_key\_efs](#module\_kms\_key\_efs) | git::https://github.com/cloudposse/terraform-aws-kms-key.git | tags/0.7.0 |
-| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 0.17.0 |
 
 ## Resources
 
@@ -50,9 +52,6 @@ components:
 |------|------|
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.kms_key_efs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [terraform_remote_state.dns_delegated](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
-| [terraform_remote_state.eks](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
-| [terraform_remote_state.vpc](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
 ## Inputs
 
@@ -60,14 +59,16 @@ components:
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_order": [],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_dns_name"></a> [dns\_name](#input\_dns\_name) | Name of the CNAME record to create | `string` | n/a | yes |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_import_role_arn"></a> [import\_role\_arn](#input\_import\_role\_arn) | IAM Role ARN to use when importing a resource | `string` | `null` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | <a name="input_performance_mode"></a> [performance\_mode](#input\_performance\_mode) | The file system performance mode. Can be either `generalPurpose` or `maxIO` | `string` | `"generalPurpose"` | no |
@@ -86,6 +87,7 @@ components:
 | <a name="input_tfstate_role_name"></a> [tfstate\_role\_name](#input\_tfstate\_role\_name) | IAM Role name for accessing the Terraform remote state | `string` | `"terraform"` | no |
 | <a name="input_tfstate_role_stage_name"></a> [tfstate\_role\_stage\_name](#input\_tfstate\_role\_stage\_name) | The name of the stage for Terraform state IAM role | `string` | `"root"` | no |
 | <a name="input_throughput_mode"></a> [throughput\_mode](#input\_throughput\_mode) | Throughput mode for the file system. Defaults to bursting. Valid values: `bursting`, `provisioned`. When using `provisioned`, also set `provisioned_throughput_in_mibps` | `string` | `"bursting"` | no |
+| <a name="input_use_eks_security_group"></a> [use\_eks\_security\_group](#input\_use\_eks\_security\_group) | Use the eks default security group | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/elasticsearch/README.md
+++ b/modules/elasticsearch/README.md
@@ -33,14 +33,13 @@ components:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.8 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.8 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 
@@ -60,6 +59,7 @@ components:
 | [aws_ssm_parameter.admin_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.elasticsearch_domain_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.elasticsearch_kibana_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [random_password.elasticsearch_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 
 ## Inputs
 
@@ -68,13 +68,14 @@ components:
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
-| <a name="input_create_iam_service_linked_role"></a> [create\_iam\_service\_linked\_role](#input\_create\_iam\_service\_linked\_role) | Whether to create `AWSServiceRoleForAmazonElasticsearchService` service-linked role. Set it to `false` if you already have an ElasticSearch cluster created in the AWS account and AWSServiceRoleForAmazonElasticsearchService already exists. See https://github.com/terraform-providers/terraform-provider-aws/issues/5218 for more info | `bool` | n/a | yes |
+| <a name="input_create_iam_service_linked_role"></a> [create\_iam\_service\_linked\_role](#input\_create\_iam\_service\_linked\_role) | Whether to create `AWSServiceRoleForAmazonElasticsearchService` service-linked role.<br>Set this to `false` if you already have an ElasticSearch cluster created in the AWS account and `AWSServiceRoleForAmazonElasticsearchService` already exists.<br>See https://github.com/terraform-providers/terraform-provider-aws/issues/5218 for more information. | `bool` | n/a | yes |
 | <a name="input_dedicated_master_enabled"></a> [dedicated\_master\_enabled](#input\_dedicated\_master\_enabled) | Indicates whether dedicated master nodes are enabled for the cluster | `bool` | n/a | yes |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_domain_hostname_enabled"></a> [domain\_hostname\_enabled](#input\_domain\_hostname\_enabled) | Explicit flag to enable creating a DNS hostname for ES. If `true`, then `var.dns_zone_id` is required. | `bool` | n/a | yes |
 | <a name="input_ebs_volume_size"></a> [ebs\_volume\_size](#input\_ebs\_volume\_size) | EBS volumes for data storage in GB | `number` | n/a | yes |
 | <a name="input_elasticsearch_iam_actions"></a> [elasticsearch\_iam\_actions](#input\_elasticsearch\_iam\_actions) | List of actions to allow for the IAM roles, _e.g._ `es:ESHttpGet`, `es:ESHttpPut`, `es:ESHttpPost` | `list(string)` | <pre>[<br>  "es:ESHttpGet",<br>  "es:ESHttpPut",<br>  "es:ESHttpPost",<br>  "es:ESHttpHead",<br>  "es:Describe*",<br>  "es:List*"<br>]</pre> | no |
 | <a name="input_elasticsearch_iam_role_arns"></a> [elasticsearch\_iam\_role\_arns](#input\_elasticsearch\_iam\_role\_arns) | List of additional IAM role ARNs to permit access to the Elasticsearch domain | `list(string)` | `[]` | no |
+| <a name="input_elasticsearch_password"></a> [elasticsearch\_password](#input\_elasticsearch\_password) | Password for the elasticsearch user | `string` | `""` | no |
 | <a name="input_elasticsearch_subdomain_name"></a> [elasticsearch\_subdomain\_name](#input\_elasticsearch\_subdomain\_name) | The name of the subdomain for Elasticsearch in the DNS zone (\_e.g.\_ `elasticsearch`, `ui`, `ui-es`, `search-ui`) | `string` | n/a | yes |
 | <a name="input_elasticsearch_version"></a> [elasticsearch\_version](#input\_elasticsearch\_version) | Version of Elasticsearch to deploy (\_e.g.\_ `7.1`, `6.8`, `6.7`, `6.5`, `6.4`, `6.3`, `6.2`, `6.0`, `5.6`, `5.5`, `5.3`, `5.1`, `2.3`, `1.5` | `string` | n/a | yes |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |

--- a/modules/iam-delegated-roles/main.tf
+++ b/modules/iam-delegated-roles/main.tf
@@ -1,6 +1,6 @@
 locals {
   merged_role_policy_arns = merge(var.default_account_role_policy_arns, var.account_role_policy_arns)
-  roles_config            = { for key, value in data.terraform_remote_state.primary_roles.outputs.delegated_roles_config : key => value if ! contains(var.exclude_roles, key) }
+  roles_config            = { for key, value in data.terraform_remote_state.primary_roles.outputs.delegated_roles_config : key => value if !contains(var.exclude_roles, key) }
   roles_policy_arns       = { for key, value in local.roles_config : key => lookup(local.merged_role_policy_arns, key, value["role_policy_arns"]) }
   role_name_map           = { for role_name, config in data.terraform_remote_state.primary_roles.outputs.delegated_roles_config : role_name => format("%s-%s", module.label.id, role_name) }
 
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "assume_role" {
         ],
         var.allow_same_account_assume_role ? [
           for role in local.trusted_primary_roles[each.key] :
-          format("arn:aws:iam::%s:role/%s", var.account_number, local.role_name_map[role]) if ! contains(var.exclude_roles, role)
+          format("arn:aws:iam::%s:role/%s", var.account_number, local.role_name_map[role]) if !contains(var.exclude_roles, role)
       ] : [])
     }
   }

--- a/modules/iam-primary-roles/main.tf
+++ b/modules/iam-primary-roles/main.tf
@@ -28,7 +28,7 @@ locals {
   allowed_assume_role_principals_map = {
     for target_role, config in local.roles_config : target_role => [
       for source_role in config.trusted_primary_roles : # aws_iam_role.default[role].arn
-      format("arn:aws:iam::%s:role/%s", var.primary_account_id, local.role_name_map[source_role]) if ! contains([target_role, "cicd"], source_role)
+      format("arn:aws:iam::%s:role/%s", var.primary_account_id, local.role_name_map[source_role]) if !contains([target_role, "cicd"], source_role)
     ]
   }
 }
@@ -63,7 +63,7 @@ data "aws_iam_policy_document" "primary_roles_assume" {
   for_each = local.roles_config
 
   dynamic "statement" {
-    for_each = ! local.assume_role_restricted || length(local.allowed_assume_role_principals_map[each.key]) > 0 ? ["has_principals"] : []
+    for_each = !local.assume_role_restricted || length(local.allowed_assume_role_principals_map[each.key]) > 0 ? ["has_principals"] : []
     content {
       sid = "IdentityAccountAssume"
       actions = [

--- a/modules/spacelift-worker-pool/README.md
+++ b/modules/spacelift-worker-pool/README.md
@@ -77,7 +77,6 @@ _HINT_: The API key ID is displayed as an upper-case, 16-character alphanumeric 
 |------|------|
 | [aws_iam_role_policy.spacelift_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_security_group.spacelift](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-
 | spacelift_worker_pool.primary | resource |
 | [aws_iam_policy_document.spacelift_role_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_ssm_parameter.spacelift_key_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |


### PR DESCRIPTION
## what
* All existing components will now pass the `pre-commit` formatting check used in this repo.

## why
* This means that, when we add future components, if we run pre-commit checks locally to ensure that the new components will pass the pre-commit format check for this repo, we won't end up modifying ~150 files.

## references
* https://github.com/cloudposse/terraform-aws-components/pull/297

## blocked by
https://github.com/cloudposse/terraform-aws-components/pull/360