### PR TITLE
Update `account-map` component

### DIFF
--- a/modules/account-map/README.md
+++ b/modules/account-map/README.md
@@ -13,11 +13,15 @@ components:
   terraform:
     account-map:
       vars:
+        enabled: true
+        # If this is true, profile must be provided instead of role_arn in each backend.tf.json
+        # If this is false, role_arn must be provided instead of profile in each backend.tf.json
+        profiles_enabled: false
         root_account_aws_name: "aws-root"
-        root_account_stage_name: root
-        identity_account_stage_name: identity
-        dns_account_stage_name: dns
-        audit_account_stage_name: audit
+        root_account_account_name: root
+        identity_account_account_name: identity
+        dns_account_account_name: dns
+        audit_account_account_name: audit
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -25,26 +29,21 @@ components:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 0.14.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.32 |
-| <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.1 |
-| <a name="requirement_http"></a> [http](#requirement\_http) | ~> 2.0 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | ~> 2.2 |
-| <a name="requirement_utils"></a> [utils](#requirement\_utils) | ~> 0.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_accounts"></a> [accounts](#module\_accounts) | cloudposse/stack-config/yaml//modules/remote-state | 0.13.0 |
-| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
+| <a name="module_accounts"></a> [accounts](#module\_accounts) | cloudposse/stack-config/yaml//modules/remote-state | 0.19.0 |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
 
@@ -56,49 +55,57 @@ components:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
-| <a name="input_artifacts_account_stage_name"></a> [artifacts\_account\_stage\_name](#input\_artifacts\_account\_stage\_name) | The stage name for the artifacts account | `string` | `"artifacts"` | no |
-| <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| <a name="input_audit_account_stage_name"></a> [audit\_account\_stage\_name](#input\_audit\_account\_stage\_name) | The stage name for the audit account | `string` | `"audit"` | no |
-| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_order": [],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
-| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
-| <a name="input_dns_account_stage_name"></a> [dns\_account\_stage\_name](#input\_dns\_account\_stage\_name) | The stage name for the primary DNS account | `string` | `"dns"` | no |
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_artifacts_account_account_name"></a> [artifacts\_account\_account\_name](#input\_artifacts\_account\_account\_name) | The stage name for the artifacts account | `string` | `"artifacts"` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
+| <a name="input_audit_account_account_name"></a> [audit\_account\_account\_name](#input\_audit\_account\_account\_name) | The stage name for the audit account | `string` | `"audit"` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
+| <a name="input_dns_account_account_name"></a> [dns\_account\_account\_name](#input\_dns\_account\_account\_name) | The stage name for the primary DNS account | `string` | `"dns"` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
-| <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_global_environment_name"></a> [global\_environment\_name](#input\_global\_environment\_name) | Global environment name | `string` | `"gbl"` | no |
-| <a name="input_iam_role_arn_template"></a> [iam\_role\_arn\_template](#input\_iam\_role\_arn\_template) | IAM Role ARN template | `string` | `"arn:aws:iam::%s:role/%s-%s-%s-%s"` | no |
-| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
-| <a name="input_identity_account_stage_name"></a> [identity\_account\_stage\_name](#input\_identity\_account\_stage\_name) | The stage name for the account holding primary IAM roles | `string` | `"identity"` | no |
-| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
-| <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
-| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
-| <a name="input_profile_template"></a> [profile\_template](#input\_profile\_template) | AWS Profile name template | `string` | `"%s-%s-%s-%s"` | no |
-| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_iam_role_arn_template"></a> [iam\_role\_arn\_template](#input\_iam\_role\_arn\_template) | The template used to render Role ARNs.<br><br>Note that if the `null-label` variable `label_order` is truncated or extended with additional labels, this template will<br>need to be updated to reflect the new number of labels. | `string` | `"arn:aws:iam::%s:role/%s-%s-%s-%s"` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_identity_account_account_name"></a> [identity\_account\_account\_name](#input\_identity\_account\_account\_name) | The stage name for the account holding primary IAM roles | `string` | `"identity"` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br>set as tag values, and output by this module individually.<br>Does not affect values of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br>Default is to include all labels.<br>Tags with empty values will not be included in the `tags` output.<br>Set to `[]` to suppress all generated tags.<br>**Notes:**<br>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
+| <a name="input_profile_template"></a> [profile\_template](#input\_profile\_template) | The template used to render AWS Profile names.<br><br>Note that if the `null-label` variable `label_order` is truncated or extended with additional labels, this template will<br>need to be updated to reflect the new number of labels. | `string` | `"%s-%s-%s-%s"` | no |
+| <a name="input_profiles_enabled"></a> [profiles\_enabled](#input\_profiles\_enabled) | Whether or not to enable profiles instead of roles for the backend. If true, profile must be set. If false, role\_arn must be set. | `bool` | `false` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
+| <a name="input_root_account_account_name"></a> [root\_account\_account\_name](#input\_root\_account\_account\_name) | The stage name for the root account | `string` | `"root"` | no |
 | <a name="input_root_account_aws_name"></a> [root\_account\_aws\_name](#input\_root\_account\_aws\_name) | The name of the root account as reported by AWS | `string` | n/a | yes |
-| <a name="input_root_account_stage_name"></a> [root\_account\_stage\_name](#input\_root\_account\_stage\_name) | The stage name for the root account | `string` | `"root"` | no |
-| <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
+| <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| <a name="output_account_info_map"></a> [account\_info\_map](#output\_account\_info\_map) | A map from account name to various information about the account.<br>See the `account_info_map` output of `account` for more detail. |
 | <a name="output_all_accounts"></a> [all\_accounts](#output\_all\_accounts) | A list of all accounts in the AWS Organization |
-| <a name="output_artifacts_account_stage_name"></a> [artifacts\_account\_stage\_name](#output\_artifacts\_account\_stage\_name) | The stage name for the artifacts account |
-| <a name="output_audit_account_stage_name"></a> [audit\_account\_stage\_name](#output\_audit\_account\_stage\_name) | The stage name for the audit account |
+| <a name="output_artifacts_account_account_name"></a> [artifacts\_account\_account\_name](#output\_artifacts\_account\_account\_name) | The short name for the artifacts account |
+| <a name="output_audit_account_account_name"></a> [audit\_account\_account\_name](#output\_audit\_account\_account\_name) | The short name for the audit account |
 | <a name="output_cicd_profiles"></a> [cicd\_profiles](#output\_cicd\_profiles) | A list of all SSO profiles used by cicd platforms |
 | <a name="output_cicd_roles"></a> [cicd\_roles](#output\_cicd\_roles) | A list of all IAM roles used by cicd platforms |
-| <a name="output_dns_account_stage_name"></a> [dns\_account\_stage\_name](#output\_dns\_account\_stage\_name) | The stage name for the primary DNS account |
+| <a name="output_dns_account_account_name"></a> [dns\_account\_account\_name](#output\_dns\_account\_account\_name) | The short name for the primary DNS account |
 | <a name="output_eks_accounts"></a> [eks\_accounts](#output\_eks\_accounts) | A list of all accounts in the AWS Organization that contain EKS clusters |
-| <a name="output_full_account_map"></a> [full\_account\_map](#output\_full\_account\_map) | The map describing attributes of accounts in the AWS Organization. |
+| <a name="output_full_account_map"></a> [full\_account\_map](#output\_full\_account\_map) | The map of account name to account ID (number). |
 | <a name="output_helm_profiles"></a> [helm\_profiles](#output\_helm\_profiles) | A list of all SSO profiles used to run helm updates |
 | <a name="output_helm_roles"></a> [helm\_roles](#output\_helm\_roles) | A list of all IAM roles used to run helm updates |
-| <a name="output_identity_account_stage_name"></a> [identity\_account\_stage\_name](#output\_identity\_account\_stage\_name) | The stage name for the account holding primary IAM roles |
+| <a name="output_identity_account_account_name"></a> [identity\_account\_account\_name](#output\_identity\_account\_account\_name) | The short name for the account holding primary IAM roles |
 | <a name="output_non_eks_accounts"></a> [non\_eks\_accounts](#output\_non\_eks\_accounts) | A list of all accounts in the AWS Organization that do not contain EKS clusters |
 | <a name="output_org"></a> [org](#output\_org) | The name of the AWS Organization |
+| <a name="output_profiles_enabled"></a> [profiles\_enabled](#output\_profiles\_enabled) | Whether or not to enable profiles instead of roles for the backend |
+| <a name="output_root_account_account_name"></a> [root\_account\_account\_name](#output\_root\_account\_account\_name) | The short name for the root account |
 | <a name="output_root_account_aws_name"></a> [root\_account\_aws\_name](#output\_root\_account\_aws\_name) | The name of the root account as reported by AWS |
-| <a name="output_root_account_stage_name"></a> [root\_account\_stage\_name](#output\_root\_account\_stage\_name) | The stage name for the root account |
 | <a name="output_terraform_profiles"></a> [terraform\_profiles](#output\_terraform\_profiles) | A list of all SSO profiles used to run terraform updates |
 | <a name="output_terraform_roles"></a> [terraform\_roles](#output\_terraform\_roles) | A list of all IAM roles used to run terraform updates |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/account-map/context.tf
+++ b/modules/account-map/context.tf
@@ -8,6 +8,8 @@
 # Cloud Posse's standard configuration inputs suitable for passing
 # to Cloud Posse modules.
 #
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
 # Modules should access the whole context as `module.this.context`
 # to get the input variables with nulls for defaults,
 # for example `context = module.this.context`,
@@ -20,10 +22,11 @@
 
 module "this" {
   source  = "cloudposse/label/null"
-  version = "0.24.1" # requires Terraform >= 0.13.0
+  version = "0.25.0" # requires Terraform >= 0.13.0
 
   enabled             = var.enabled
   namespace           = var.namespace
+  tenant              = var.tenant
   environment         = var.environment
   stage               = var.stage
   name                = var.name
@@ -34,6 +37,10 @@ module "this" {
   label_order         = var.label_order
   regex_replace_chars = var.regex_replace_chars
   id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
 
   context = var.context
 }
@@ -41,23 +48,11 @@ module "this" {
 # Copy contents of cloudposse/terraform-null-label/variables.tf here
 
 variable "context" {
-  type = object({
-    enabled             = bool
-    namespace           = string
-    environment         = string
-    stage               = string
-    name                = string
-    delimiter           = string
-    attributes          = list(string)
-    tags                = map(string)
-    additional_tag_map  = map(string)
-    regex_replace_chars = string
-    label_order         = list(string)
-    id_length_limit     = number
-  })
+  type = any
   default = {
     enabled             = true
     namespace           = null
+    tenant              = null
     environment         = null
     stage               = null
     name                = null
@@ -68,6 +63,17 @@ variable "context" {
     regex_replace_chars = null
     label_order         = []
     id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
   }
   description = <<-EOT
     Single object for setting entire context at once.
@@ -76,6 +82,16 @@ variable "context" {
     Individual variable settings (non-null) override settings in context object,
     except for attributes, tags, and additional_tag_map, which are merged.
   EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
 }
 
 variable "enabled" {
@@ -87,32 +103,42 @@ variable "enabled" {
 variable "namespace" {
   type        = string
   default     = null
-  description = "Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp'"
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
 }
 
 variable "environment" {
   type        = string
   default     = null
-  description = "Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT'"
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
 }
 
 variable "stage" {
   type        = string
   default     = null
-  description = "Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release'"
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
 }
 
 variable "name" {
   type        = string
   default     = null
-  description = "Solution name, e.g. 'app' or 'jenkins'"
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
 }
 
 variable "delimiter" {
   type        = string
   default     = null
   description = <<-EOT
-    Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
+    Delimiter to be used between ID elements.
     Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
   EOT
 }
@@ -120,36 +146,64 @@ variable "delimiter" {
 variable "attributes" {
   type        = list(string)
   default     = []
-  description = "Additional attributes (e.g. `1`)"
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
 }
 
 variable "tags" {
   type        = map(string)
   default     = {}
-  description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`"
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
 }
 
 variable "additional_tag_map" {
   type        = map(string)
   default     = {}
-  description = "Additional tags for appending to tags_as_list_of_maps. Not added to `tags`."
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
 }
 
 variable "label_order" {
   type        = list(string)
   default     = null
   description = <<-EOT
-    The naming order of the id output and Name tag.
+    The order in which the labels (ID elements) appear in the `id`.
     Defaults to ["namespace", "environment", "stage", "name", "attributes"].
-    You can omit any of the 5 elements, but at least one must be present.
-  EOT
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
 }
 
 variable "regex_replace_chars" {
   type        = string
   default     = null
   description = <<-EOT
-    Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
     If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
   EOT
 }
@@ -158,11 +212,68 @@ variable "id_length_limit" {
   type        = number
   default     = null
   description = <<-EOT
-    Limit `id` to this many characters.
+    Limit `id` to this many characters (minimum 6).
     Set to `0` for unlimited length.
-    Set to `null` for default, which is `0`.
+    Set to `null` for keep the existing setting, which defaults to `0`.
     Does not affect `id_full`.
   EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
 }
 
 #### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/account-map/main.tf
+++ b/modules/account-map/main.tf
@@ -3,83 +3,102 @@ data "aws_organizations_organization" "organization" {}
 locals {
   full_account_map = {
     for acct in data.aws_organizations_organization.organization.accounts
-    : acct.name == var.root_account_aws_name ? var.root_account_stage_name : acct.name => acct.id
+    : acct.name == var.root_account_aws_name ? var.root_account_account_name : acct.name => acct.id
   }
 
   eks_accounts     = module.accounts.outputs.eks_accounts
   non_eks_accounts = module.accounts.outputs.non_eks_accounts
   all_accounts     = concat(local.eks_accounts, local.non_eks_accounts)
+  account_info_map = module.accounts.outputs.account_info_map
 
   terraform_roles = {
-    for name, id in local.full_account_map : name => format(var.iam_role_arn_template,
-      id,
-      module.this.namespace,
-      module.this.environment,
-      name,
-      (contains([
-        var.root_account_stage_name,
-        var.identity_account_stage_name
-      ], name) ? "admin" : "terraform")
-    )
+    for name, info in local.account_info_map : name => format(var.iam_role_arn_template, compact(
+      [
+        info.id,
+        module.this.namespace,
+        lookup(info, "tenant", ""),
+        module.this.environment,
+        info.stage,
+        (contains([
+          var.root_account_account_name,
+          var.identity_account_account_name
+        ], name) ? "admin" : "terraform")
+      ]
+    )...)
   }
 
   terraform_profiles = {
-    for name, id in local.full_account_map : name => format(var.profile_template,
-      module.this.namespace,
-      module.this.environment,
-      name,
-      (contains([
-        var.root_account_stage_name,
-        var.identity_account_stage_name
-      ], name) ? "admin" : "terraform")
-    )
+    for name, info in local.account_info_map : name => format(var.profile_template, compact(
+      [
+        module.this.namespace,
+        lookup(info, "tenant", ""),
+        module.this.environment,
+        info.stage,
+        (contains([
+          var.root_account_account_name,
+          var.identity_account_account_name
+        ], name) ? "admin" : "terraform")
+      ]
+    )...)
   }
 
   helm_roles = {
-    for name, id in local.full_account_map : name => format(var.iam_role_arn_template,
-      id,
-      module.this.namespace,
-      module.this.environment,
-      name,
-      (contains([
-        var.root_account_stage_name,
-        var.identity_account_stage_name
-      ], name) ? "admin" : "helm")
-    )
+    for name, info in local.account_info_map : name => format(var.iam_role_arn_template, compact(
+      [
+        info.id,
+        module.this.namespace,
+        lookup(info, "tenant", ""),
+        module.this.environment,
+        info.stage,
+        (contains([
+          var.root_account_account_name,
+          var.identity_account_account_name
+        ], name) ? "admin" : "helm")
+      ]
+    )...)
   }
 
   helm_profiles = {
-    for name, id in local.full_account_map : name => format(var.profile_template,
-      module.this.namespace,
-      module.this.environment,
-      name,
-      (contains([
-        var.root_account_stage_name,
-        var.identity_account_stage_name
-      ], name) ? "admin" : "helm")
-    )
+    for name, info in local.account_info_map : name => format(var.profile_template, compact(
+      [
+        module.this.namespace,
+        lookup(info, "tenant", ""),
+        module.this.environment,
+        info.stage,
+        (contains([
+          var.root_account_account_name,
+          var.identity_account_account_name
+        ], name) ? "admin" : "helm")
+      ]
+    )...)
   }
 
   cicd_roles = {
-    for name, id in local.full_account_map : name => format(var.iam_role_arn_template,
-      id,
-      module.this.namespace,
-      var.global_environment_name,
-      name,
-      (contains([
-        var.root_account_stage_name
-      ], name) ? "admin" : "cicd")
-    )
+    for name, info in local.account_info_map : name => format(var.iam_role_arn_template, compact(
+      [
+        info.id,
+        module.this.namespace,
+        lookup(info, "tenant", ""),
+        var.global_environment_name,
+        info.stage,
+        (contains([
+          var.root_account_account_name
+        ], name) ? "admin" : "cicd")
+      ]
+    )...)
   }
 
   cicd_profiles = {
-    for name, id in local.full_account_map : name => format(var.profile_template,
-      module.this.namespace,
-      var.global_environment_name,
-      name,
-      (contains([
-        var.root_account_stage_name
-      ], name) ? "admin" : "cicd")
-    )
+    for name, info in local.account_info_map : name => format(var.profile_template, compact(
+      [
+        module.this.namespace,
+        lookup(info, "tenant", ""),
+        var.global_environment_name,
+        info.stage,
+        (contains([
+          var.root_account_account_name
+        ], name) ? "admin" : "cicd")
+      ]
+    )...)
   }
 }

--- a/modules/account-map/modules/iam-roles/context.tf
+++ b/modules/account-map/modules/iam-roles/context.tf
@@ -8,6 +8,8 @@
 # Cloud Posse's standard configuration inputs suitable for passing
 # to Cloud Posse modules.
 #
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
 # Modules should access the whole context as `module.this.context`
 # to get the input variables with nulls for defaults,
 # for example `context = module.this.context`,
@@ -20,10 +22,11 @@
 
 module "this" {
   source  = "cloudposse/label/null"
-  version = "0.24.1" # requires Terraform >= 0.13.0
+  version = "0.25.0" # requires Terraform >= 0.13.0
 
   enabled             = var.enabled
   namespace           = var.namespace
+  tenant              = var.tenant
   environment         = var.environment
   stage               = var.stage
   name                = var.name
@@ -34,6 +37,10 @@ module "this" {
   label_order         = var.label_order
   regex_replace_chars = var.regex_replace_chars
   id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
 
   context = var.context
 }
@@ -41,23 +48,11 @@ module "this" {
 # Copy contents of cloudposse/terraform-null-label/variables.tf here
 
 variable "context" {
-  type = object({
-    enabled             = bool
-    namespace           = string
-    environment         = string
-    stage               = string
-    name                = string
-    delimiter           = string
-    attributes          = list(string)
-    tags                = map(string)
-    additional_tag_map  = map(string)
-    regex_replace_chars = string
-    label_order         = list(string)
-    id_length_limit     = number
-  })
+  type = any
   default = {
     enabled             = true
     namespace           = null
+    tenant              = null
     environment         = null
     stage               = null
     name                = null
@@ -68,6 +63,17 @@ variable "context" {
     regex_replace_chars = null
     label_order         = []
     id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
   }
   description = <<-EOT
     Single object for setting entire context at once.
@@ -76,6 +82,16 @@ variable "context" {
     Individual variable settings (non-null) override settings in context object,
     except for attributes, tags, and additional_tag_map, which are merged.
   EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
 }
 
 variable "enabled" {
@@ -87,32 +103,42 @@ variable "enabled" {
 variable "namespace" {
   type        = string
   default     = null
-  description = "Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp'"
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
 }
 
 variable "environment" {
   type        = string
   default     = null
-  description = "Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT'"
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
 }
 
 variable "stage" {
   type        = string
   default     = null
-  description = "Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release'"
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
 }
 
 variable "name" {
   type        = string
   default     = null
-  description = "Solution name, e.g. 'app' or 'jenkins'"
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
 }
 
 variable "delimiter" {
   type        = string
   default     = null
   description = <<-EOT
-    Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
+    Delimiter to be used between ID elements.
     Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
   EOT
 }
@@ -120,36 +146,64 @@ variable "delimiter" {
 variable "attributes" {
   type        = list(string)
   default     = []
-  description = "Additional attributes (e.g. `1`)"
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
 }
 
 variable "tags" {
   type        = map(string)
   default     = {}
-  description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`"
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
 }
 
 variable "additional_tag_map" {
   type        = map(string)
   default     = {}
-  description = "Additional tags for appending to tags_as_list_of_maps. Not added to `tags`."
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
 }
 
 variable "label_order" {
   type        = list(string)
   default     = null
   description = <<-EOT
-    The naming order of the id output and Name tag.
+    The order in which the labels (ID elements) appear in the `id`.
     Defaults to ["namespace", "environment", "stage", "name", "attributes"].
-    You can omit any of the 5 elements, but at least one must be present.
-  EOT
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
 }
 
 variable "regex_replace_chars" {
   type        = string
   default     = null
   description = <<-EOT
-    Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
     If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
   EOT
 }
@@ -158,11 +212,68 @@ variable "id_length_limit" {
   type        = number
   default     = null
   description = <<-EOT
-    Limit `id` to this many characters.
+    Limit `id` to this many characters (minimum 6).
     Set to `0` for unlimited length.
-    Set to `null` for default, which is `0`.
+    Set to `null` for keep the existing setting, which defaults to `0`.
     Does not affect `id_full`.
   EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
 }
 
 #### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/account-map/modules/iam-roles/default.auto.tfvars
+++ b/modules/account-map/modules/iam-roles/default.auto.tfvars
@@ -1,3 +1,0 @@
-# This file is included by default in terraform plans
-
-enabled = true

--- a/modules/account-map/modules/iam-roles/main.tf
+++ b/modules/account-map/modules/iam-roles/main.tf
@@ -1,6 +1,6 @@
-module "forced" {
+module "always" {
   source  = "cloudposse/label/null"
-  version = "0.24.1"
+  version = "0.25.0"
 
   # account_map must always be enabled, even for components that are disabled
   enabled = true
@@ -10,13 +10,18 @@ module "forced" {
 
 module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.14.0"
+  version = "0.19.0"
 
   component               = "account-map"
   privileged              = var.privileged
+  tenant                  = var.global_tenant_name
   environment             = var.global_environment_name
   stack_config_local_path = "../../../stacks"
   stage                   = var.root_account_stage_name
 
-  context = module.forced.context
+  context = module.always.context
+}
+
+locals {
+  account_name = lookup(module.always.descriptors, "account_name", module.always.stage)
 }

--- a/modules/account-map/modules/iam-roles/outputs.tf
+++ b/modules/account-map/modules/iam-roles/outputs.tf
@@ -1,46 +1,50 @@
 output "terraform_role_arn" {
-  value = module.account_map.outputs.terraform_roles[module.forced.stage]
+  value = module.account_map.outputs.terraform_roles[local.account_name]
 }
 
 output "terraform_profile_name" {
-  value = module.account_map.outputs.terraform_profiles[module.forced.stage]
+  value = module.account_map.outputs.terraform_profiles[local.account_name]
 }
 
 output "org_role_arn" {
-  value = module.forced.stage == module.account_map.outputs.root_account_stage_name ? null : format(
+  value = local.account_name == module.account_map.outputs.root_account_account_name ? null : format(
     "arn:aws:iam::%s:role/OrganizationAccountAccessRole",
-    module.account_map.outputs.full_account_map[module.forced.stage]
+    module.account_map.outputs.full_account_map[local.account_name]
   )
 }
 
 output "dns_terraform_role_arn" {
-  value = module.account_map.outputs.terraform_roles[module.account_map.outputs.dns_account_stage_name]
+  value = module.account_map.outputs.terraform_roles[module.account_map.outputs.dns_account_account_name]
 }
 
 output "dns_terraform_profile_name" {
-  value = module.account_map.outputs.terraform_profiles[module.account_map.outputs.dns_account_stage_name]
+  value = module.account_map.outputs.terraform_profiles[module.account_map.outputs.dns_account_account_name]
 }
 
 output "audit_terraform_role_arn" {
-  value = module.account_map.outputs.terraform_roles[module.account_map.outputs.audit_account_stage_name]
+  value = module.account_map.outputs.terraform_roles[module.account_map.outputs.audit_account_account_name]
 }
 
 output "audit_terraform_profile_name" {
-  value = module.account_map.outputs.terraform_profiles[module.account_map.outputs.audit_account_stage_name]
+  value = module.account_map.outputs.terraform_profiles[module.account_map.outputs.audit_account_account_name]
 }
 
 output "identity_terraform_role_arn" {
-  value = module.account_map.outputs.terraform_roles[module.account_map.outputs.identity_account_stage_name]
+  value = module.account_map.outputs.terraform_roles[module.account_map.outputs.identity_account_account_name]
 }
 
 output "identity_terraform_profile_name" {
-  value = module.account_map.outputs.terraform_profiles[module.account_map.outputs.identity_account_stage_name]
+  value = module.account_map.outputs.terraform_profiles[module.account_map.outputs.identity_account_account_name]
 }
 
 output "identity_cicd_role_arn" {
-  value = module.account_map.outputs.cicd_roles[module.account_map.outputs.identity_account_stage_name]
+  value = module.account_map.outputs.cicd_roles[module.account_map.outputs.identity_account_account_name]
 }
 
 output "identity_cicd_profile_name" {
-  value = module.account_map.outputs.cicd_profiles[module.account_map.outputs.identity_account_stage_name]
+  value = module.account_map.outputs.cicd_profiles[module.account_map.outputs.identity_account_account_name]
+}
+
+output "profiles_enabled" {
+  value = module.account_map.outputs.profiles_enabled
 }

--- a/modules/account-map/modules/iam-roles/variables.tf
+++ b/modules/account-map/modules/iam-roles/variables.tf
@@ -4,6 +4,12 @@ variable "privileged" {
   default     = false
 }
 
+variable "global_tenant_name" {
+  type        = string
+  description = "Global tenant name"
+  default     = null
+}
+
 variable "global_environment_name" {
   type        = string
   description = "Global environment name"

--- a/modules/account-map/modules/roles-to-principals/context.tf
+++ b/modules/account-map/modules/roles-to-principals/context.tf
@@ -8,6 +8,8 @@
 # Cloud Posse's standard configuration inputs suitable for passing
 # to Cloud Posse modules.
 #
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
 # Modules should access the whole context as `module.this.context`
 # to get the input variables with nulls for defaults,
 # for example `context = module.this.context`,
@@ -20,10 +22,11 @@
 
 module "this" {
   source  = "cloudposse/label/null"
-  version = "0.24.1" # requires Terraform >= 0.13.0
+  version = "0.25.0" # requires Terraform >= 0.13.0
 
   enabled             = var.enabled
   namespace           = var.namespace
+  tenant              = var.tenant
   environment         = var.environment
   stage               = var.stage
   name                = var.name
@@ -34,6 +37,10 @@ module "this" {
   label_order         = var.label_order
   regex_replace_chars = var.regex_replace_chars
   id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
 
   context = var.context
 }
@@ -41,23 +48,11 @@ module "this" {
 # Copy contents of cloudposse/terraform-null-label/variables.tf here
 
 variable "context" {
-  type = object({
-    enabled             = bool
-    namespace           = string
-    environment         = string
-    stage               = string
-    name                = string
-    delimiter           = string
-    attributes          = list(string)
-    tags                = map(string)
-    additional_tag_map  = map(string)
-    regex_replace_chars = string
-    label_order         = list(string)
-    id_length_limit     = number
-  })
+  type = any
   default = {
     enabled             = true
     namespace           = null
+    tenant              = null
     environment         = null
     stage               = null
     name                = null
@@ -68,6 +63,17 @@ variable "context" {
     regex_replace_chars = null
     label_order         = []
     id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
   }
   description = <<-EOT
     Single object for setting entire context at once.
@@ -76,6 +82,16 @@ variable "context" {
     Individual variable settings (non-null) override settings in context object,
     except for attributes, tags, and additional_tag_map, which are merged.
   EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
 }
 
 variable "enabled" {
@@ -87,32 +103,42 @@ variable "enabled" {
 variable "namespace" {
   type        = string
   default     = null
-  description = "Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp'"
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
 }
 
 variable "environment" {
   type        = string
   default     = null
-  description = "Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT'"
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
 }
 
 variable "stage" {
   type        = string
   default     = null
-  description = "Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release'"
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
 }
 
 variable "name" {
   type        = string
   default     = null
-  description = "Solution name, e.g. 'app' or 'jenkins'"
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
 }
 
 variable "delimiter" {
   type        = string
   default     = null
   description = <<-EOT
-    Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
+    Delimiter to be used between ID elements.
     Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
   EOT
 }
@@ -120,36 +146,64 @@ variable "delimiter" {
 variable "attributes" {
   type        = list(string)
   default     = []
-  description = "Additional attributes (e.g. `1`)"
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
 }
 
 variable "tags" {
   type        = map(string)
   default     = {}
-  description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`"
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
 }
 
 variable "additional_tag_map" {
   type        = map(string)
   default     = {}
-  description = "Additional tags for appending to tags_as_list_of_maps. Not added to `tags`."
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
 }
 
 variable "label_order" {
   type        = list(string)
   default     = null
   description = <<-EOT
-    The naming order of the id output and Name tag.
+    The order in which the labels (ID elements) appear in the `id`.
     Defaults to ["namespace", "environment", "stage", "name", "attributes"].
-    You can omit any of the 5 elements, but at least one must be present.
-  EOT
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
 }
 
 variable "regex_replace_chars" {
   type        = string
   default     = null
   description = <<-EOT
-    Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
     If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
   EOT
 }
@@ -158,11 +212,68 @@ variable "id_length_limit" {
   type        = number
   default     = null
   description = <<-EOT
-    Limit `id` to this many characters.
+    Limit `id` to this many characters (minimum 6).
     Set to `0` for unlimited length.
-    Set to `null` for default, which is `0`.
+    Set to `null` for keep the existing setting, which defaults to `0`.
     Does not affect `id_full`.
   EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
 }
 
 #### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/account-map/modules/roles-to-principals/default.auto.tfvars
+++ b/modules/account-map/modules/roles-to-principals/default.auto.tfvars
@@ -1,3 +1,0 @@
-# This file is included by default in terraform plans
-
-enabled = true

--- a/modules/account-map/modules/roles-to-principals/main.tf
+++ b/modules/account-map/modules/roles-to-principals/main.tf
@@ -1,6 +1,6 @@
-module "forced" {
+module "always" {
   source  = "cloudposse/label/null"
-  version = "0.24.1"
+  version = "0.25.0"
 
   # account_map must always be enabled, even for components that are disabled
   enabled = true
@@ -10,15 +10,16 @@ module "forced" {
 
 module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.14.0"
+  version = "0.19.0"
 
   component               = "account-map"
   privileged              = var.privileged
+  tenant                  = var.global_tenant_name
   environment             = var.global_environment_name
   stack_config_local_path = "../../../stacks"
   stage                   = var.root_account_stage_name
 
-  context = module.forced.context
+  context = module.always.context
 }
 
 locals {
@@ -27,7 +28,7 @@ locals {
     [
       for role in v : format(var.iam_role_arn_template,
         module.account_map.outputs.full_account_map[acct],
-        module.forced.namespace,
+        module.always.namespace,
         var.global_environment_name,
         acct,
         role

--- a/modules/account-map/modules/roles-to-principals/variables.tf
+++ b/modules/account-map/modules/roles-to-principals/variables.tf
@@ -5,7 +5,7 @@ variable "role_map" {
 
 variable "iam_role_arn_template" {
   type        = string
-  default     = "arn:aws:iam::%s:role/%s-%s-%s-%s"
+  default     = "arn:aws:iam::%s:role/%s-%s-%s-%s-%s"
   description = "IAM Role ARN template"
 }
 
@@ -13,6 +13,12 @@ variable "privileged" {
   type        = bool
   description = "True if the default provider already has access to the backend"
   default     = false
+}
+
+variable "global_tenant_name" {
+  type        = string
+  description = "Global tenant name"
+  default     = null
 }
 
 variable "global_environment_name" {

--- a/modules/account-map/outputs.tf
+++ b/modules/account-map/outputs.tf
@@ -3,29 +3,29 @@ output "root_account_aws_name" {
   description = "The name of the root account as reported by AWS"
 }
 
-output "root_account_stage_name" {
-  value       = var.root_account_stage_name
-  description = "The stage name for the root account"
+output "root_account_account_name" {
+  value       = var.root_account_account_name
+  description = "The short name for the root account"
 }
 
-output "identity_account_stage_name" {
-  value       = var.identity_account_stage_name
-  description = "The stage name for the account holding primary IAM roles"
+output "identity_account_account_name" {
+  value       = var.identity_account_account_name
+  description = "The short name for the account holding primary IAM roles"
 }
 
-output "dns_account_stage_name" {
-  value       = var.dns_account_stage_name
-  description = "The stage name for the primary DNS account"
+output "dns_account_account_name" {
+  value       = var.dns_account_account_name
+  description = "The short name for the primary DNS account"
 }
 
-output "artifacts_account_stage_name" {
-  value       = var.artifacts_account_stage_name
-  description = "The stage name for the artifacts account"
+output "artifacts_account_account_name" {
+  value       = var.artifacts_account_account_name
+  description = "The short name for the artifacts account"
 }
 
-output "audit_account_stage_name" {
-  value       = var.audit_account_stage_name
-  description = "The stage name for the audit account"
+output "audit_account_account_name" {
+  value       = var.audit_account_account_name
+  description = "The short name for the audit account"
 }
 
 output "org" {
@@ -34,9 +34,17 @@ output "org" {
 
 }
 
+output "account_info_map" {
+  value       = local.account_info_map
+  description = <<-EOT
+    A map from account name to various information about the account.
+    See the `account_info_map` output of `account` for more detail.
+    EOT
+}
+
 output "full_account_map" {
   value       = local.full_account_map
-  description = "The map describing attributes of accounts in the AWS Organization."
+  description = "The map of account name to account ID (number)."
 }
 
 output "eks_accounts" {
@@ -82,4 +90,9 @@ output "cicd_roles" {
 output "cicd_profiles" {
   value       = local.cicd_profiles
   description = "A list of all SSO profiles used by cicd platforms"
+}
+
+output "profiles_enabled" {
+  value       = var.profiles_enabled
+  description = "Whether or not to enable profiles instead of roles for the backend"
 }

--- a/modules/account-map/remote-state.tf
+++ b/modules/account-map/remote-state.tf
@@ -1,6 +1,6 @@
 module "accounts" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.13.0"
+  version = "0.19.0"
 
   component               = "account"
   privileged              = true

--- a/modules/account-map/variables.tf
+++ b/modules/account-map/variables.tf
@@ -8,31 +8,31 @@ variable "root_account_aws_name" {
   description = "The name of the root account as reported by AWS"
 }
 
-variable "root_account_stage_name" {
+variable "root_account_account_name" {
   type        = string
   default     = "root"
   description = "The stage name for the root account"
 }
 
-variable "identity_account_stage_name" {
+variable "identity_account_account_name" {
   type        = string
   default     = "identity"
   description = "The stage name for the account holding primary IAM roles"
 }
 
-variable "dns_account_stage_name" {
+variable "dns_account_account_name" {
   type        = string
   default     = "dns"
   description = "The stage name for the primary DNS account"
 }
 
-variable "artifacts_account_stage_name" {
+variable "artifacts_account_account_name" {
   type        = string
   default     = "artifacts"
   description = "The stage name for the artifacts account"
 }
 
-variable "audit_account_stage_name" {
+variable "audit_account_account_name" {
   type        = string
   default     = "audit"
   description = "The stage name for the audit account"
@@ -41,17 +41,33 @@ variable "audit_account_stage_name" {
 variable "iam_role_arn_template" {
   type        = string
   default     = "arn:aws:iam::%s:role/%s-%s-%s-%s"
-  description = "IAM Role ARN template"
+  description = <<-EOT
+  The template used to render Role ARNs.
+
+  Note that if the `null-label` variable `label_order` is truncated or extended with additional labels, this template will
+  need to be updated to reflect the new number of labels.
+  EOT
 }
 
 variable "profile_template" {
   type        = string
   default     = "%s-%s-%s-%s"
-  description = "AWS Profile name template"
+  description = <<-EOT
+  The template used to render AWS Profile names.
+
+  Note that if the `null-label` variable `label_order` is truncated or extended with additional labels, this template will
+  need to be updated to reflect the new number of labels.
+  EOT
 }
 
 variable "global_environment_name" {
   type        = string
   default     = "gbl"
   description = "Global environment name"
+}
+
+variable "profiles_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether or not to enable profiles instead of roles for the backend. If true, profile must be set. If false, role_arn must be set."
 }

--- a/modules/account-map/versions.tf
+++ b/modules/account-map/versions.tf
@@ -1,30 +1,10 @@
 terraform {
-  required_version = "~> 0.14.0"
+  required_version = ">= 1.0.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.32"
-    }
-    external = {
-      source  = "hashicorp/external"
-      version = "~> 2.1"
-    }
-    http = {
-      source  = "hashicorp/http"
-      version = "~> 2.0"
-    }
-    local = {
-      source  = "hashicorp/local"
-      version = "~> 2.0"
-    }
-    template = {
-      source  = "hashicorp/template"
-      version = "~> 2.2"
-    }
-    utils = {
-      source  = "cloudposse/utils"
-      version = "~> 0.3.0"
+      version = ">= 3.0"
     }
   }
 }


### PR DESCRIPTION
## what

Latest account-map

* tenant changes
* Added `profiles_enabled`

## why
* Allowing tenants using the latest context.tf
* Allow switching between profiles and roles depending on what is set in the `account-map` catalog

<details><summary>example providers.tf</summary>

```hcl
provider "aws" {
  region = var.region

  profile = module.iam_roles.profiles_enabled ? coalesce(var.import_profile_name, module.iam_roles.terraform_profile_name) : null
  dynamic "assume_role" {
    for_each = module.iam_roles.profiles_enabled ? [] : ["role"]
    content {
      role_arn = coalesce(var.import_role_arn, module.iam_roles.terraform_role_arn)
    }
  }
}

module "iam_roles" {
  source  = "../account-map/modules/iam-roles"
  context = module.this.context
}

variable "import_profile_name" {
  type        = string
  default     = null
  description = "AWS Profile name to use when importing a resource"
}

variable "import_role_arn" {
  type        = string
  default     = null
  description = "IAM Role ARN to use when importing a resource"
}
```
</details>


## references
* N/A
