### PR TITLE
Update `datadog-lambda-forwarder` component and README

### DIFF
--- a/modules/datadog-lambda-forwarder/README.md
+++ b/modules/datadog-lambda-forwarder/README.md
@@ -19,9 +19,28 @@ components:
           workspace_enabled: true
       vars:
         enabled: true
-        forwarder_log_enabled: true
+        name: datadog-lambda-forwarder
+        # Set `forwarder_rds_enabled`  to `true` and configure `rds-enhanced-monitoring` Log Group when:
+        # 1. The account has RDS instances provisioned
+        # 2. RDS Enhanced Monitoring is enabled
+        # 3. CloudWatch Log Group `RDSOSMetrics` exists (it will be created by AWS automatically when RDS Enhanced Monitoring is enabled)
         forwarder_rds_enabled: true
+        forwarder_log_enabled: true
         forwarder_vpc_enabled: true
+        cloudwatch_forwarder_log_groups:
+          rds-enhanced-monitoring:
+            name: "RDSOSMetrics"
+            filter_pattern: ""
+          eks-cluster:
+            # Use either `name` or `name_prefix` with `name_suffix`
+            # If `name_prefix` with `name_suffix` are used, the final `name` will be constructed using `name_prefix` + context + `name_suffix`, 
+            # e.g. "/aws/eks/eg-ue2-prod-eks-cluster/cluster"
+            name_prefix: "/aws/eks/"
+            name_suffix: "eks-cluster/cluster"
+            filter_pattern: ""
+          transfer-sftp:
+            name: "/aws/transfer/s-xxxxxxxxxxxx"
+            filter_pattern: ""
         dd_api_key_source:
           resource: "ssm"
           identifier: "datadog/datadog_api_key"
@@ -33,7 +52,7 @@ components:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers
 
@@ -43,7 +62,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_datadog_lambda_forwarder"></a> [datadog\_lambda\_forwarder](#module\_datadog\_lambda\_forwarder) | cloudposse/datadog-lambda-forwarder/aws | 0.8.0 |
+| <a name="module_datadog_lambda_forwarder"></a> [datadog\_lambda\_forwarder](#module\_datadog\_lambda\_forwarder) | cloudposse/datadog-lambda-forwarder/aws | 0.12.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_log_group_prefix"></a> [log\_group\_prefix](#module\_log\_group\_prefix) | cloudposse/label/null | 0.25.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |

--- a/modules/datadog-lambda-forwarder/default.auto.tfvars
+++ b/modules/datadog-lambda-forwarder/default.auto.tfvars
@@ -1,3 +1,0 @@
-# This file is included by default in terraform plans
-
-enabled = false

--- a/modules/datadog-lambda-forwarder/main.tf
+++ b/modules/datadog-lambda-forwarder/main.tf
@@ -4,14 +4,14 @@ locals {
   cloudwatch_forwarder_log_groups = {
     for k, v in var.cloudwatch_forwarder_log_groups :
     k => {
-      "name" : lookup(v, "name_suffix", null) != null ? format(
+      name : lookup(v, "name_suffix", null) != null ? format(
         "%s%s%s%s",
         lookup(v, "name_prefix", "/aws/"),
         module.log_group_prefix.id,
         module.log_group_prefix.delimiter,
         lookup(v, "name_suffix")
       ) : lookup(v, "name")
-      "filter_pattern" : lookup(v, "filter_pattern", "")
+      filter_pattern : lookup(v, "filter_pattern", "")
     }
   }
 
@@ -38,7 +38,7 @@ module "log_group_prefix" {
 
 module "datadog_lambda_forwarder" {
   source  = "cloudposse/datadog-lambda-forwarder/aws"
-  version = "0.8.0"
+  version = "0.12.0"
 
   cloudwatch_forwarder_log_groups       = local.cloudwatch_forwarder_log_groups
   dd_api_key_kms_ciphertext_blob        = var.dd_api_key_kms_ciphertext_blob

--- a/modules/datadog-lambda-forwarder/versions.tf
+++ b/modules/datadog-lambda-forwarder/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = ">= 3.0"
     }
   }
 }


### PR DESCRIPTION
## what
* Update `datadog-lambda-forwarder` component and README

## why
* Add example on how to configure `cloudwatch_forwarder_log_groups` 
* Describe use cases when `forwarder_rds_enabled` could be enabled and configured

