### PR TITLE
Update `module "datadog_configuration"` modules

### DIFF
--- a/modules/datadog-configuration/README.md
+++ b/modules/datadog-configuration/README.md
@@ -45,6 +45,7 @@ Here is a snippet of using the `datadog_keys` submodule:
 ```terraform
 module "datadog_configuration" {
   source  = "../datadog-configuration/modules/datadog_keys"
+  enabled = true
   context = module.this.context
 }
 

--- a/modules/datadog-configuration/modules/datadog_keys/README.md
+++ b/modules/datadog-configuration/modules/datadog_keys/README.md
@@ -7,8 +7,8 @@ Useful submodule for other modules to quickly configure the datadog provider
 ```hcl
 module "datadog_configuration" {
   source  = "../datadog-configuration/modules/datadog_keys"
-  context = module.this.context
   enabled = true
+  context = module.this.context
 }
 
 provider "datadog" {

--- a/modules/datadog-integration/provider-datadog.tf
+++ b/modules/datadog-integration/provider-datadog.tf
@@ -1,7 +1,7 @@
 module "datadog_configuration" {
   source  = "../datadog-configuration/modules/datadog_keys"
-  context = module.this.context
   enabled = true
+  context = module.this.context
 }
 
 provider "datadog" {

--- a/modules/datadog-lambda-forwarder/provider-datadog.tf
+++ b/modules/datadog-lambda-forwarder/provider-datadog.tf
@@ -1,7 +1,7 @@
 module "datadog_configuration" {
   source  = "../datadog-configuration/modules/datadog_keys"
-  context = module.this.context
   enabled = true
+  context = module.this.context
 }
 
 provider "datadog" {

--- a/modules/datadog-logs-archive/provider-datadog.tf
+++ b/modules/datadog-logs-archive/provider-datadog.tf
@@ -1,7 +1,7 @@
 module "datadog_configuration" {
   source  = "../datadog-configuration/modules/datadog_keys"
-  context = module.this.context
   enabled = true
+  context = module.this.context
 }
 
 locals {

--- a/modules/datadog-monitor/provider-datadog.tf
+++ b/modules/datadog-monitor/provider-datadog.tf
@@ -1,7 +1,7 @@
 module "datadog_configuration" {
   source  = "../datadog-configuration/modules/datadog_keys"
-  context = module.this.context
   enabled = true
+  context = module.this.context
 }
 
 provider "datadog" {

--- a/modules/datadog-private-location-ecs/provider-datadog.tf
+++ b/modules/datadog-private-location-ecs/provider-datadog.tf
@@ -1,7 +1,7 @@
 module "datadog_configuration" {
   source  = "../datadog-configuration/modules/datadog_keys"
-  context = module.this.context
   enabled = true
+  context = module.this.context
 }
 
 provider "datadog" {

--- a/modules/datadog-synthetics-private-location/provider-datadog.tf
+++ b/modules/datadog-synthetics-private-location/provider-datadog.tf
@@ -1,7 +1,7 @@
 module "datadog_configuration" {
   source  = "../datadog-configuration/modules/datadog_keys"
-  context = module.this.context
   enabled = true
+  context = module.this.context
 }
 
 provider "datadog" {

--- a/modules/datadog-synthetics/provider-datadog.tf
+++ b/modules/datadog-synthetics/provider-datadog.tf
@@ -1,7 +1,7 @@
 module "datadog_configuration" {
   source  = "../datadog-configuration/modules/datadog_keys"
-  context = module.this.context
   enabled = true
+  context = module.this.context
 }
 
 provider "datadog" {

--- a/modules/ecs-service/datadog-agent.tf
+++ b/modules/ecs-service/datadog-agent.tf
@@ -158,6 +158,6 @@ module "datadog_fluent_bit_container_definition" {
 module "datadog_configuration" {
   count   = var.datadog_agent_sidecar_enabled ? 1 : 0
   source  = "../datadog-configuration/modules/datadog_keys"
-  region  = var.region
+  enabled = true
   context = module.this.context
 }

--- a/modules/opsgenie-team/provider-datadog.tf
+++ b/modules/opsgenie-team/provider-datadog.tf
@@ -2,7 +2,6 @@
 
 module "datadog_configuration" {
   source  = "../datadog-configuration/modules/datadog_keys"
-  region  = var.region
   enabled = true
   context = module.this.context
 }


### PR DESCRIPTION
## what
* Update `module "datadog_configuration"` modules

## why
* The module does not accept the `region` variable
* The module must be always enabled to be able to read the Datadog API keys even if the component is disabled

