### PR TITLE
Update `eks/external-dns` component to support Istio `istio-gateway` resources

### DIFF
--- a/modules/eks/external-dns/main.tf
+++ b/modules/eks/external-dns/main.tf
@@ -98,7 +98,7 @@ module "external_dns" {
       publishInternalServices = var.publish_internal_services
       txtOwnerId              = local.txt_owner
       txtPrefix               = local.txt_prefix
-      source                  = local.sources
+      sources                 = local.sources
     }),
     # hardcoded values
     file("${path.module}/resources/values.yaml"),


### PR DESCRIPTION
## what

* Update `eks/external-dns` component to support Istio `istio-gateway` resources

## why

* The `external-dns` Helm Chart supports the `sources` variable (not `source`) to specify the resources types to be observed for new DNS entries by ExternalDNS

```console
## @param sources [array] K8s resources type to be observed for new DNS entries by ExternalDNS
##
sources:
  # - crd
  - service
  - ingress
```

The code used the `source` variable instead of `sources`. It was working for the `service` and `ingress` types because they are in the Chart values by default. 

The `istio-gateway` resource was never added, preventing `external-dns` from managing Istio Gateways and creating DNS records for the Gateway's hosts.

## references

* https://artifacthub.io/packages/helm/bitnami/external-dns?modal=values

